### PR TITLE
Version crates independently

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,6 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.2.0"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/agave"
 homepage = "https://anza.xyz/"

--- a/account-info/Cargo.toml
+++ b/account-info/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-account-info"
 description = "Solana AccountInfo and related definitions."
 documentation = "https://docs.rs/solana-account-info"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/account/Cargo.toml
+++ b/account/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-account"
 description = "Solana Account type"
 documentation = "https://docs.rs/solana-account"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/address-lookup-table-interface/Cargo.toml
+++ b/address-lookup-table-interface/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-address-lookup-table-interface"
 description = "Solana address lookup table interface."
 documentation = "https://docs.rs/solana-address-lookup-table-interface"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/atomic-u64/Cargo.toml
+++ b/atomic-u64/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-atomic-u64"
 description = "Solana atomic u64 implementation. For internal use only."
 documentation = "https://docs.rs/solana-atomic-u64"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/big-mod-exp/Cargo.toml
+++ b/big-mod-exp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-big-mod-exp"
 description = "Solana big integer modular exponentiation"
 documentation = "https://docs.rs/solana-big-mod-exp"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/bincode/Cargo.toml
+++ b/bincode/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-bincode"
 description = "Solana bincode utilities"
 documentation = "https://docs.rs/solana-bincode"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/blake3-hasher/Cargo.toml
+++ b/blake3-hasher/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-blake3-hasher"
 description = "Solana BLAKE3 hashing"
 documentation = "https://docs.rs/solana-blake3-hasher"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/bn254/Cargo.toml
+++ b/bn254/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-bn254"
 description = "Solana BN254"
 documentation = "https://docs.rs/solana-bn254"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-borsh"
 description = "Solana Borsh utilities"
 documentation = "https://docs.rs/solana-borsh"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/client-traits/Cargo.toml
+++ b/client-traits/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-client-traits"
 description = "Traits for Solana clients"
 documentation = "https://docs.rs/solana-client-traits"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/clock/Cargo.toml
+++ b/clock/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-clock"
 description = "Solana Clock and Time Definitions"
 documentation = "https://docs.rs/solana-clock"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/cluster-type/Cargo.toml
+++ b/cluster-type/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-cluster-type"
 description = "Solana ClusterType enum"
 documentation = "https://docs.rs/solana-cluster-type"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/commitment-config/Cargo.toml
+++ b/commitment-config/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-commitment-config"
 description = "Solana commitment config."
 documentation = "https://docs.rs/solana-commitment-config"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/compute-budget-interface/Cargo.toml
+++ b/compute-budget-interface/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-compute-budget-interface"
 description = "Solana compute budget interface."
 documentation = "https://docs.rs/solana-compute-budget-interface"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/cpi/Cargo.toml
+++ b/cpi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-cpi"
 description = "Solana Cross-program Invocation"
 documentation = "https://docs.rs/solana-cpi"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/decode-error/Cargo.toml
+++ b/decode-error/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-decode-error"
 description = "Solana DecodeError Trait"
 documentation = "https://docs.rs/solana-decode-error"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/define-syscall/Cargo.toml
+++ b/define-syscall/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-define-syscall"
 description = "Solana define_syscall macro and core syscall definitions."
 documentation = "https://docs.rs/solana-define-syscall"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/derivation-path/Cargo.toml
+++ b/derivation-path/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-derivation-path"
 description = "Solana BIP44 derivation paths."
 documentation = "https://docs.rs/solana-derivation-path"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/ed25519-program/Cargo.toml
+++ b/ed25519-program/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-ed25519-program"
 description = "Instructions for the Solana ed25519 native program"
 documentation = "https://docs.rs/solana-ed25519-program"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/epoch-info/Cargo.toml
+++ b/epoch-info/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-epoch-info"
 description = "Information about a Solana epoch."
 documentation = "https://docs.rs/solana-epoch-info"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/epoch-rewards-hasher/Cargo.toml
+++ b/epoch-rewards-hasher/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-epoch-rewards-hasher"
 description = "Solana epoch rewards hasher."
 documentation = "https://docs.rs/solana-epoch-rewards-hasher"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/epoch-rewards/Cargo.toml
+++ b/epoch-rewards/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-epoch-rewards"
 description = "Solana epoch rewards sysvar."
 documentation = "https://docs.rs/solana-epoch-rewards"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/epoch-schedule/Cargo.toml
+++ b/epoch-schedule/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-epoch-schedule"
 description = "Configuration for Solana epochs and slots."
 documentation = "https://docs.rs/solana-epoch-schedule"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/example-mocks/Cargo.toml
+++ b/example-mocks/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-example-mocks"
 description = "Solana mock types for use in examples"
 documentation = "https://docs.rs/solana-example-mocks"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/feature-gate-interface/Cargo.toml
+++ b/feature-gate-interface/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-feature-gate-interface"
 description = "Solana feature gate program interface."
 documentation = "https://docs.rs/solana-feature-gate-interface"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/feature-set/Cargo.toml
+++ b/feature-set/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-feature-set"
 description = "Solana runtime features."
 documentation = "https://docs.rs/solana-feature-set"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/fee-calculator/Cargo.toml
+++ b/fee-calculator/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-fee-calculator"
 description = "Solana transaction fee calculation"
 documentation = "https://docs.rs/solana-fee-calculator"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/fee-structure/Cargo.toml
+++ b/fee-structure/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-fee-structure"
 description = "Solana fee structures."
 documentation = "https://docs.rs/solana-fee-structure"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/file-download/Cargo.toml
+++ b/file-download/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-file-download"
 description = "Solana File Download Utility"
 documentation = "https://docs.rs/solana-file-download"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/frozen-abi-macro/Cargo.toml
+++ b/frozen-abi-macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-frozen-abi-macro"
 description = "Solana Frozen ABI Macro"
 documentation = "https://docs.rs/solana-frozen-abi-macro"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/frozen-abi/Cargo.toml
+++ b/frozen-abi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-frozen-abi"
 description = "Solana Frozen ABI"
 documentation = "https://docs.rs/solana-frozen-abi"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/genesis-config/Cargo.toml
+++ b/genesis-config/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-genesis-config"
 description = "A Solana network's genesis config."
 documentation = "https://docs.rs/solana-genesis-config"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/hard-forks/Cargo.toml
+++ b/hard-forks/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-hard-forks"
 description = "The list of slot boundaries at which a hard fork should occur."
 documentation = "https://docs.rs/solana-hard-forks"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/hash/Cargo.toml
+++ b/hash/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-hash"
 description = "Solana wrapper for the 32-byte output of a hashing algorithm."
 documentation = "https://docs.rs/solana-hash"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/inflation/Cargo.toml
+++ b/inflation/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-inflation"
 description = "Configuration for Solana network inflation"
 documentation = "https://docs.rs/solana-inflation"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/instruction/Cargo.toml
+++ b/instruction/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-instruction"
 description = "Types for directing the execution of Solana programs."
 documentation = "https://docs.rs/solana-instruction"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/instructions-sysvar/Cargo.toml
+++ b/instructions-sysvar/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-instructions-sysvar"
 description = "Type for instruction introspection during execution of Solana programs."
 documentation = "https://docs.rs/solana-instructions-sysvar"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/keccak-hasher/Cargo.toml
+++ b/keccak-hasher/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-keccak-hasher"
 description = "Solana Keccak hashing"
 documentation = "https://docs.rs/solana-keccak-hasher"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/keypair/Cargo.toml
+++ b/keypair/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-keypair"
 description = "Concrete implementation of a Solana `Signer`."
 documentation = "https://docs.rs/solana-keypair"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/last-restart-slot/Cargo.toml
+++ b/last-restart-slot/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-last-restart-slot"
 description = "Types and utilities for the Solana LastRestartSlot sysvar."
 documentation = "https://docs.rs/solana-last-restart-slot"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/loader-v2-interface/Cargo.toml
+++ b/loader-v2-interface/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-loader-v2-interface"
 description = "Solana non-upgradable BPF loader v2 instructions."
 documentation = "https://docs.rs/solana-loader-v2-interface"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/loader-v3-interface/Cargo.toml
+++ b/loader-v3-interface/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-loader-v3-interface"
 description = "Solana loader V3 interface."
 documentation = "https://docs.rs/solana-loader-v3-interface"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/loader-v4-interface/Cargo.toml
+++ b/loader-v4-interface/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-loader-v4-interface"
 description = "Solana loader V4 interface."
 documentation = "https://docs.rs/solana-loader-v4-interface"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-logger"
 description = "Solana Logger"
 documentation = "https://docs.rs/solana-logger"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/message/Cargo.toml
+++ b/message/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-message"
 description = "Solana transaction message types."
 documentation = "https://docs.rs/solana-message"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/msg/Cargo.toml
+++ b/msg/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-msg"
 description = "Solana msg macro."
 documentation = "https://docs.rs/solana-msg"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/native-token/Cargo.toml
+++ b/native-token/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-native-token"
 description = "Definitions for the native SOL token and its fractional lamports."
 documentation = "https://docs.rs/solana-native-token"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/nonce-account/Cargo.toml
+++ b/nonce-account/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-nonce-account"
 description = "Solana nonce account utils."
 documentation = "https://docs.rs/solana-nonce-account"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/nonce/Cargo.toml
+++ b/nonce/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-nonce"
 description = "Solana durable transaction nonces."
 documentation = "https://docs.rs/solana-nonce"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/offchain-message/Cargo.toml
+++ b/offchain-message/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-offchain-message"
 description = "Solana offchain message signing"
 documentation = "https://docs.rs/solana-offchain-message"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/package-metadata-macro/Cargo.toml
+++ b/package-metadata-macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-package-metadata-macro"
 description = "Solana Package Metadata Macro"
 documentation = "https://docs.rs/solana-package-metadata-macro"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/package-metadata/Cargo.toml
+++ b/package-metadata/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-package-metadata"
 description = "Solana Package Metadata"
 documentation = "https://docs.rs/solana-package-metadata"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/packet/Cargo.toml
+++ b/packet/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-packet"
 description = "The definition of a Solana network packet."
 documentation = "https://docs.rs/solana-packet"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/poh-config/Cargo.toml
+++ b/poh-config/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-poh-config"
 description = "Definitions of Solana's proof of history."
 documentation = "https://docs.rs/solana-poh-config"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/precompile-error/Cargo.toml
+++ b/precompile-error/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-precompile-error"
 description = "Solana PrecompileError type"
 documentation = "https://docs.rs/solana-precompile-error"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/precompiles/Cargo.toml
+++ b/precompiles/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-precompiles"
 description = "Solana precompiled programs."
 documentation = "https://docs.rs/solana-precompiles"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/presigner/Cargo.toml
+++ b/presigner/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-presigner"
 description = "A Solana `Signer` implementation representing an externally-constructed `Signature`."
 documentation = "https://docs.rs/solana-presigner"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/program-entrypoint/Cargo.toml
+++ b/program-entrypoint/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-program-entrypoint"
 description = "The Solana BPF program entrypoint supported by the latest BPF loader."
 documentation = "https://docs.rs/solana-program-entrypoint"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/program-error/Cargo.toml
+++ b/program-error/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-program-error"
 description = "Solana ProgramError type and related definitions."
 documentation = "https://docs.rs/solana-program-error"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/program-memory/Cargo.toml
+++ b/program-memory/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-program-memory"
 description = "Basic low-level memory operations for Solana."
 documentation = "https://docs.rs/solana-program-memory"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/program-option/Cargo.toml
+++ b/program-option/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-program-option"
 description = "A C representation of Rust's Option, used in Solana programs."
 documentation = "https://docs.rs/solana-program-option"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/program-pack/Cargo.toml
+++ b/program-pack/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-program-pack"
 description = "Solana Pack serialization trait."
 documentation = "https://docs.rs/solana-program-pack"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -3,7 +3,7 @@ name = "solana-program"
 description = "Solana Program"
 documentation = "https://docs.rs/solana-program"
 readme = "README.md"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/pubkey/Cargo.toml
+++ b/pubkey/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-pubkey"
 description = "Solana account addresses"
 documentation = "https://docs.rs/solana-pubkey"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/quic-definitions/Cargo.toml
+++ b/quic-definitions/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-quic-definitions"
 description = "Definitions related to Solana over QUIC."
 documentation = "https://docs.rs/solana-quic-definitions"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/rent-collector/Cargo.toml
+++ b/rent-collector/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-rent-collector"
 description = "Calculate and collect rent from accounts."
 documentation = "https://docs.rs/solana-rent-collector"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/rent-debits/Cargo.toml
+++ b/rent-debits/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-rent-debits"
 description = "Solana rent debit types."
 documentation = "https://docs.rs/solana-rent-debits"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/rent/Cargo.toml
+++ b/rent/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-rent"
 description = "Configuration for Solana network rent."
 documentation = "https://docs.rs/solana-rent"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/reserved-account-keys/Cargo.toml
+++ b/reserved-account-keys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-reserved-account-keys"
 description = "Reserved Solana account keys"
 documentation = "https://docs.rs/solana-reserved-account-keys"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/reward-info/Cargo.toml
+++ b/reward-info/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-reward-info"
 description = "Solana vote reward info types"
 documentation = "https://docs.rs/solana-reward-info"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/sanitize/Cargo.toml
+++ b/sanitize/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-sanitize"
 description = "Solana Message Sanitization"
 documentation = "https://docs.rs/solana-sanitize"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/sdk-ids/Cargo.toml
+++ b/sdk-ids/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-sdk-ids"
 description = "Solana SDK IDs"
 documentation = "https://docs.rs/solana-sdk-ids"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/sdk-macro/Cargo.toml
+++ b/sdk-macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-sdk-macro"
 description = "Solana SDK Macro"
 documentation = "https://docs.rs/solana-sdk-macro"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -3,7 +3,7 @@ name = "solana-sdk"
 description = "Solana SDK"
 documentation = "https://docs.rs/solana-sdk"
 readme = "README.md"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/secp256k1-program/Cargo.toml
+++ b/secp256k1-program/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-secp256k1-program"
 description = "Instructions for the Solana Secp256k1 native program."
 documentation = "https://docs.rs/solana-secp256k1-program"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/secp256k1-recover/Cargo.toml
+++ b/secp256k1-recover/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-secp256k1-recover"
 description = "Solana SECP256K1 Recover"
 documentation = "https://docs.rs/solana-secp256k1-recover"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/secp256r1-program/Cargo.toml
+++ b/secp256r1-program/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-secp256r1-program"
 description = "Precompile implementation for the secp256r1 elliptic curve."
 documentation = "https://docs.rs/solana-secp256r1"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/seed-derivable/Cargo.toml
+++ b/seed-derivable/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-seed-derivable"
 description = "Solana trait defining the interface by which keys are derived."
 documentation = "https://docs.rs/solana-seed-derivable"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/seed-phrase/Cargo.toml
+++ b/seed-phrase/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-seed-phrase"
 description = "Solana functions for generating keypairs from seed phrases."
 documentation = "https://docs.rs/solana-seed-phrase"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/serde-varint/Cargo.toml
+++ b/serde-varint/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-serde-varint"
 description = "Solana definitions for integers that serialize to variable size"
 documentation = "https://docs.rs/solana-serde-varint"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-serde"
 description = "Solana serde helpers"
 documentation = "https://docs.rs/solana-serde"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/serialize-utils/Cargo.toml
+++ b/serialize-utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-serialize-utils"
 description = "Solana helpers for reading and writing bytes."
 documentation = "https://docs.rs/solana-serialize-utils"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/sha256-hasher/Cargo.toml
+++ b/sha256-hasher/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-sha256-hasher"
 description = "Solana SHA256 hashing"
 documentation = "https://docs.rs/solana-sha256-hasher"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/short-vec/Cargo.toml
+++ b/short-vec/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-short-vec"
 description = "Solana compact serde-encoding of vectors with small length."
 documentation = "https://docs.rs/solana-short-vec"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/shred-version/Cargo.toml
+++ b/shred-version/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-shred-version"
 description = "Calculation of shred versions."
 documentation = "https://docs.rs/solana-shred-version"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-signature"
 description = "Solana 64-byte signature type"
 documentation = "https://docs.rs/solana-signature"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-signer"
 description = "Abstractions for Solana transaction signers. See `solana-keypair` for a concrete implementation."
 documentation = "https://docs.rs/solana-signer"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/slot-hashes/Cargo.toml
+++ b/slot-hashes/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-slot-hashes"
 description = "Types and utilities for the Solana SlotHashes sysvar."
 documentation = "https://docs.rs/solana-slot-hashes"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/slot-history/Cargo.toml
+++ b/slot-history/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-slot-history"
 description = "Types and utilities for the Solana SlotHistory sysvar."
 documentation = "https://docs.rs/solana-slot-history"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/stable-layout/Cargo.toml
+++ b/stable-layout/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-stable-layout"
 description = "Solana types with stable memory layouts. Internal use only."
 documentation = "https://docs.rs/solana-stable-layout"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/system-transaction/Cargo.toml
+++ b/system-transaction/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-system-transaction"
 description = "Functionality for creating system transactions."
 documentation = "https://docs.rs/solana-system-transaction"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/sysvar-id/Cargo.toml
+++ b/sysvar-id/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-sysvar-id"
 description = "Definition for the sysvar id trait and associated macros."
 documentation = "https://docs.rs/solana-sysvar-id"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/sysvar/Cargo.toml
+++ b/sysvar/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-sysvar"
 description = "Solana sysvar account types"
 documentation = "https://docs.rs/solana-sysvar"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/time-utils/Cargo.toml
+++ b/time-utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-time-utils"
 description = "`std::time` utilities for Solana"
 documentation = "https://docs.rs/solana-time-utils"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/transaction-context/Cargo.toml
+++ b/transaction-context/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-transaction-context"
 description = "Solana data shared between program runtime and built-in programs as well as SBF programs."
 documentation = "https://docs.rs/solana-transaction-context"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/transaction-error/Cargo.toml
+++ b/transaction-error/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-transaction-error"
 description = "Solana TransactionError type"
 documentation = "https://docs.rs/solana-transaction-error"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/transaction/Cargo.toml
+++ b/transaction/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-transaction"
 description = "Solana transaction-types"
 documentation = "https://docs.rs/solana-transaction"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/validator-exit/Cargo.toml
+++ b/validator-exit/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-validator-exit"
 description = "Solana validator exit handling."
 documentation = "https://docs.rs/solana-validator-exit"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/vote-interface/Cargo.toml
+++ b/vote-interface/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-vote-interface"
 description = "Solana vote interface."
 documentation = "https://docs.rs/solana-vote-interface"
-version = { workspace = true }
+version = "2.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }


### PR DESCRIPTION
#### Problem

The sdk repo currently defines the version for all crates at the workspace level, which makes sense when all crates are supposed to be on the same version.

However, we intend to version crates independently in the future.

#### Summary of changes

Remove the version defined in the workspace Cargo.toml, and set all crates to 2.2.0. To do all crates, I ran the following command:

```
git grep -l "version.*workspace" | xargs sed -i 's/^version = { workspace = true }/version = "2.2.0"/'
```