### PR TITLE
CI: Add manual workflow to publish crates

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -1,0 +1,170 @@
+name: Publish Crate
+
+on:
+  workflow_dispatch:
+    inputs:
+      package_path:
+        description: Path to directory with package to release
+        required: true
+        type: string
+      level:
+        description: Level
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - version
+      version:
+        description: Version (used with level "version")
+        required: false
+        type: string
+      dry_run:
+        description: Dry run
+        required: true
+        default: true
+        type: boolean
+      create_release:
+        description: Create a GitHub release
+        required: true
+        type: boolean
+        default: true
+
+jobs:
+  sanity:
+    name: Sanity checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history to check for whitespace / conflict markers
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          stable-toolchain: true
+          cargo-cache-key: cargo-stable-sanity
+          cargo-cache-fallback-key: cargo-stable
+
+      - name: Check repo is in porcelain state
+        run: ./scripts/check-porcelain.sh
+
+      - name: Check code nits
+        run: ./scripts/check-nits.sh
+
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    needs: [sanity]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          rustfmt: true
+          cargo-cache-key: cargo-nightly-fmt
+          cargo-cache-fallback-key: cargo-nightly
+
+      - name: Check formatting
+        run: ./scripts/check-fmt.sh
+
+  clippy:
+    name: Clippy
+    needs: [sanity]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          clippy: true
+          cargo-cache-key: cargo-nightly-clippy
+          cargo-cache-fallback-key: cargo-nightly
+
+      - name: Run clippy
+        run: ./scripts/check-clippy.sh
+
+  publish-crate:
+    name: Publish crate
+    runs-on: ubuntu-latest
+    needs: [format, clippy]
+    permissions:
+      contents: write
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.ANZA_TEAM_PAT }}
+          fetch-depth: 0 # get the whole history for git-cliff
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          stable-toolchain: true
+          cargo-cache-key: cargo-stable-publish
+          cargo-cache-fallback-key: cargo-stable
+
+      - name: Install cargo-release
+        uses: taiki-e/cache-cargo-install-action@v2
+        with:
+          tool: cargo-release
+
+      - name: Ensure CARGO_REGISTRY_TOKEN variable is set
+        env:
+          token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        if: ${{ env.token == '' }}
+        run: |
+          echo "The CARGO_REGISTRY_TOKEN secret variable is not set"
+          echo "Go to \"Settings\" -> \"Secrets and variables\" -> \"Actions\" -> \"New repository secret\"."
+          exit 1
+
+      - name: Set Git Author
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+      - name: Publish Crate
+        id: publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          if [ "${{ inputs.level }}" == "version" ]; then
+            LEVEL=${{ inputs.version }}
+          else
+            LEVEL=${{ inputs.level }}
+          fi
+
+          if [ "${{ inputs.dry_run }}" == "true" ]; then
+            OPTIONS="--dry-run"
+          else
+            OPTIONS=""
+          fi
+
+          ./scripts/publish-rust.sh "${{ inputs.package_path }}" $LEVEL $OPTIONS
+
+      - name: Generate a changelog
+        if: github.event.inputs.create_release == 'true'
+        uses: orhun/git-cliff-action@v3
+        with:
+          config: "scripts/cliff.toml"
+          args: |
+            "${{ steps.publish.outputs.old_git_tag }}"..master
+            --include-path "${{ inputs.package_path }}/**"
+            --github-repo "${{ github.repository }}"
+        env:
+          OUTPUT: TEMP_CHANGELOG.md
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Create GitHub release
+        if: github.event.inputs.create_release == 'true' && github.event.inputs.dry_run != 'true'
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.publish.outputs.new_git_tag }}
+          bodyFile: TEMP_CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -15,3 +15,17 @@ To patch all of the crates in this repo for Agave, just run:
 ```console
 ./scripts/patch-crates-no-header.sh <AGAVE_PATH> <SOLANA_SDK_PATH>
 ```
+
+### Publishing a crate from this repository
+
+Unlike Agave, the solana-sdk crates are versioned independently, and published
+as needed.
+
+If you need to publish a crate, you can use the "Publish Crate" GitHub Action.
+Simply type in the path to the crate directory you want to release, ie.
+`program-entrypoint`, along with the kind of release, either `patch`, `minor`,
+`major`, or a specific version string.
+
+The publish job will run checks, bump the crate version, commit and tag the
+bump, publish the crate to crates.io, and finally create GitHub Release with
+a simple changelog of all commits to the crate since the previous release.

--- a/scripts/cliff.toml
+++ b/scripts/cliff.toml
@@ -1,0 +1,49 @@
+# git-cliff configuration file
+# https://git-cliff.org/docs/configuration
+[changelog]
+header = """
+## What's new
+"""
+body = """
+{% for group, commits in commits | group_by(attribute="group") %}\
+    {% for commit in commits %}
+        - {{ commit.message | upper_first | split(pat="\n") | first | trim }}\
+        {% if commit.remote.username %} by @{{ commit.remote.username }}{%- endif %}\
+    {% endfor %}\
+{% endfor %}
+"""
+# remove the leading and trailing whitespace from the template
+trim = true
+footer = """
+"""
+postprocessors = [ ]
+[git]
+# parse the commits based on https://www.conventionalcommits.org
+conventional_commits = true
+# filter out the commits that are not conventional
+filter_unconventional = false
+# process each line of a commit as an individual commit
+split_commits = false
+# regex for preprocessing the commit messages
+commit_preprocessors = []
+# regex for parsing and grouping commits
+commit_parsers = [
+    { message = "^build\\(deps\\)", skip = true },
+    { message = "^build\\(deps-dev\\)", skip = true },
+    { message = "^ci", skip = true },
+    { body = ".*", group = "Changes" },
+]
+# protect breaking changes from being skipped due to matching a skipping commit_parser
+protect_breaking_commits = false
+# filter out the commits that are not matched by commit parsers
+filter_commits = false
+# glob pattern for matching git tags
+tag_pattern = "v[0-9]*"
+# regex for skipping tags
+skip_tags = ""
+# regex for ignoring tags
+ignore_tags = ""
+# sort the tags topologically
+topo_order = false
+# sort the commits inside sections by oldest/newest order
+sort_commits = "newest"

--- a/scripts/publish-rust.sh
+++ b/scripts/publish-rust.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -e
+base="$(dirname "${BASH_SOURCE[0]}")"
+# pacify shellcheck: cannot follow dynamic path
+# shellcheck disable=SC1090,SC1091
+source "$base/read-cargo-variable.sh"
+cd "$base/.."
+
+if [[ -z $1 ]]; then
+  echo 'A package manifest path — e.g. "program" — must be provided.'
+  exit 1
+fi
+PACKAGE_PATH=$1
+if [[ -z $2 ]]; then
+  echo 'A version level — e.g. "patch" — must be provided.'
+  exit 1
+fi
+LEVEL=$2
+DRY_RUN=$3
+
+# Go to the directory
+cd "${PACKAGE_PATH}"
+
+# Get the old version, used with git-cliff
+old_version=$(readCargoVariable version "Cargo.toml")
+package_name=$(readCargoVariable name "Cargo.toml")
+tag_name="${package_name//solana-/}"
+
+# Publish the new version, commit the repo change, tag it, and push it all.
+if [[ -n ${DRY_RUN} ]]; then
+  cargo release "${LEVEL}"
+else
+  cargo release "${LEVEL}" --tag-name "${tag_name}@v{{version}}" --no-confirm --execute
+fi
+
+# Stop here if this is a dry run.
+if [[ -n $DRY_RUN ]]; then
+  exit 0
+fi
+
+# Get the new version.
+new_version=$(readCargoVariable version "Cargo.toml")
+new_git_tag="${tag_name}@v${new_version}"
+old_git_tag="${tag_name}@v${old_version}"
+
+# Expose the new version to CI if needed.
+if [[ -n $CI ]]; then
+  echo "new_git_tag=${new_git_tag}" >> "$GITHUB_OUTPUT"
+  echo "old_git_tag=${old_git_tag}" >> "$GITHUB_OUTPUT"
+fi


### PR DESCRIPTION
#### Problem

The solana-sdk repo has no way of publishing crates.

#### Summary of changes

Following the model used by SPL at
https://github.com/solana-labs/solana-program-library/pull/7184, add a manual workflow to publish crates.