### PR TITLE
sdk: Remove dummy-for-ci-check feature

### DIFF
--- a/scripts/check-clippy.sh
+++ b/scripts/check-clippy.sh
@@ -15,7 +15,7 @@ cd "${src_root}"
 # the bench itself isn't stabilized yet...
 #   ref: https://github.com/rust-lang/rust/issues/66287
 ./cargo nightly clippy \
-  --workspace --all-targets --features dummy-for-ci-check,frozen-abi -- \
+  --workspace --all-targets --features frozen-abi -- \
   --deny=warnings \
   --deny=clippy::default_trait_access \
   --deny=clippy::arithmetic_side_effects \

--- a/scripts/check-nightly.sh
+++ b/scripts/check-nightly.sh
@@ -5,4 +5,4 @@ here="$(dirname "$0")"
 src_root="$(readlink -f "${here}/..")"
 cd "${src_root}"
 
-./cargo nightly check --locked --workspace --all-targets --features dummy-for-ci-check,frozen-abi
+./cargo nightly check --locked --workspace --all-targets --features frozen-abi

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -11,9 +11,6 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [features]
-# Needed by the monorepo for checks in CI, can be removed when the SDK is
-# extracted
-dummy-for-ci-check = []
 # "program" feature is a legacy feature retained to support v1.3 and older
 # programs.  New development should not use this feature.  Instead use the
 # solana-program crate


### PR DESCRIPTION
#### Problem

The `dummy-for-ci-check` feature was added to avoid breaking Agave's CI when the sdk was put into its own workspace, but it isn't actually needed by `solana-sdk` now that it's out of the Agave repo.

#### Summary of changes

Remove the feature everywhere.