### PR TITLE
loader-v3: Add `UpgradeableLoaderInstruction::Migrate`

### DIFF
--- a/loader-v3-interface/src/instruction.rs
+++ b/loader-v3-interface/src/instruction.rs
@@ -5,7 +5,7 @@ use {
     crate::{get_program_data_address, state::UpgradeableLoaderState},
     solana_instruction::{error::InstructionError, AccountMeta, Instruction},
     solana_pubkey::Pubkey,
-    solana_sdk_ids::{bpf_loader_upgradeable::id, sysvar},
+    solana_sdk_ids::{bpf_loader_upgradeable::id, loader_v4, sysvar},
     solana_system_interface::instruction as system_instruction,
 };
 
@@ -171,6 +171,14 @@ pub enum UpgradeableLoaderInstruction {
     ///   1. `[signer]` The current authority.
     ///   2. `[signer]` The new authority.
     SetAuthorityChecked,
+
+    /// Migrate the program to loader-v4.
+    ///
+    /// # Account references
+    ///   0. `[writable]` The ProgramData account.
+    ///   1. `[writable]` The Program account.
+    ///   2. `[signer]` The current authority.
+    Migrate,
 }
 
 #[cfg(feature = "bincode")]
@@ -297,6 +305,10 @@ pub fn is_close_instruction(instruction_data: &[u8]) -> bool {
 
 pub fn is_set_authority_checked_instruction(instruction_data: &[u8]) -> bool {
     !instruction_data.is_empty() && 7 == instruction_data[0]
+}
+
+pub fn is_migrate_instruction(instruction_data: &[u8]) -> bool {
+    !instruction_data.is_empty() && 8 == instruction_data[0]
 }
 
 #[cfg(feature = "bincode")]
@@ -440,6 +452,23 @@ pub fn extend_program(
     )
 }
 
+/// Returns the instructions required to migrate a program to loader-v4.
+#[cfg(feature = "bincode")]
+pub fn migrate_program(
+    programdata_address: &Pubkey,
+    program_address: &Pubkey,
+    authority: &Pubkey,
+) -> Instruction {
+    let accounts = vec![
+        AccountMeta::new(*programdata_address, false),
+        AccountMeta::new(*program_address, false),
+        AccountMeta::new_readonly(*authority, true),
+        AccountMeta::new_readonly(loader_v4::id(), false),
+    ];
+
+    Instruction::new_with_bincode(id(), &UpgradeableLoaderInstruction::Migrate, accounts)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -531,6 +560,15 @@ mod tests {
         assert_is_instruction(
             is_upgrade_instruction,
             UpgradeableLoaderInstruction::Upgrade {},
+        );
+    }
+
+    #[test]
+    fn test_is_migrate_instruction() {
+        assert!(!is_migrate_instruction(&[]));
+        assert_is_instruction(
+            is_migrate_instruction,
+            UpgradeableLoaderInstruction::Migrate {},
         );
     }
 }

--- a/program/src/bpf_loader_upgradeable.rs
+++ b/program/src/bpf_loader_upgradeable.rs
@@ -5,8 +5,9 @@ pub use solana_loader_v3_interface::{
     instruction::{
         close, close_any, create_buffer, deploy_with_max_program_len, extend_program,
         is_close_instruction, is_set_authority_checked_instruction, is_set_authority_instruction,
-        is_upgrade_instruction, set_buffer_authority, set_buffer_authority_checked,
-        set_upgrade_authority, set_upgrade_authority_checked, upgrade, write,
+        is_upgrade_instruction, migrate_program, set_buffer_authority,
+        set_buffer_authority_checked, set_upgrade_authority, set_upgrade_authority_checked,
+        upgrade, write,
     },
     state::UpgradeableLoaderState,
 };

--- a/program/src/bpf_loader_upgradeable.rs
+++ b/program/src/bpf_loader_upgradeable.rs
@@ -5,9 +5,8 @@ pub use solana_loader_v3_interface::{
     instruction::{
         close, close_any, create_buffer, deploy_with_max_program_len, extend_program,
         is_close_instruction, is_set_authority_checked_instruction, is_set_authority_instruction,
-        is_upgrade_instruction, migrate_program, set_buffer_authority,
-        set_buffer_authority_checked, set_upgrade_authority, set_upgrade_authority_checked,
-        upgrade, write,
+        is_upgrade_instruction, set_buffer_authority, set_buffer_authority_checked,
+        set_upgrade_authority, set_upgrade_authority_checked, upgrade, write,
     },
     state::UpgradeableLoaderState,
 };


### PR DESCRIPTION
#### Problem

The SDK changes from https://github.com/anza-xyz/agave/pull/4661 need to be applied here.

See [SIMD-0167](https://github.com/solana-foundation/solana-improvement-documents/pull/167).

#### Summary of Changes

Feature Gate Issue: https://github.com/anza-xyz/feature-gate-tracker/issues/78

Once this lands, we can publish v3.0.0 of the crate to be used by Agave