### PR TITLE
solana-account: add AccountSharedData::data_clone method

### DIFF
--- a/account/src/lib.rs
+++ b/account/src/lib.rs
@@ -597,6 +597,10 @@ impl AccountSharedData {
         self.data.capacity()
     }
 
+    pub fn data_clone(&self) -> Arc<Vec<u8>> {
+        Arc::clone(&self.data)
+    }
+
     fn data_mut(&mut self) -> &mut Vec<u8> {
         Arc::make_mut(&mut self.data)
     }


### PR DESCRIPTION
In order to create a lightweight view struct (https://github.com/anza-xyz/agave/pull/4834) over vote account data without creating another copy of the data, I need to copy the internal `Arc` which is private.