### PR TITLE
solana-vote-interface: deprecate VoteState::commission_split

### DIFF
--- a/vote-interface/src/state/mod.rs
+++ b/vote-interface/src/state/mod.rs
@@ -654,6 +654,7 @@ impl VoteState {
     ///
     ///  if commission calculation is 100% one way or other,
     ///   indicate with false for was_split
+    #[deprecated(since = "2.2.0", note = "logic was moved into the agave runtime crate")]
     pub fn commission_split(&self, on: u64) -> (u64, u64, bool) {
         match self.commission.min(100) {
             0 => (0, on, false),
@@ -1353,6 +1354,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_vote_state_commission_split() {
         let vote_state = VoteState::default();
 


### PR DESCRIPTION
The commission split logic should live in the runtime rather than the sdk in my opinion. I need to use this logic on a new runtime vote state view type introduced in https://github.com/anza-xyz/agave/pull/4834 without creating an instance of a `VoteState`. The logic will be moved into the runtime here: https://github.com/anza-xyz/agave/pull/4876. Rather than keeping two copies of this logic, let's deprecate and remove the method here since I don't think it's that useful to clients.