### PR TITLE
make is_nonoverlapping private and remove num-traits dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3432,7 +3432,6 @@ dependencies = [
 name = "solana-program-memory"
 version = "2.2.0"
 dependencies = [
- "num-traits",
  "solana-define-syscall",
 ]
 

--- a/program-memory/Cargo.toml
+++ b/program-memory/Cargo.toml
@@ -9,9 +9,6 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[dependencies]
-num-traits = { workspace = true }
-
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 

--- a/program-memory/src/lib.rs
+++ b/program-memory/src/lib.rs
@@ -11,19 +11,14 @@ pub mod syscalls {
 }
 
 /// Check that two regions do not overlap.
-///
-/// Hidden to share with bpf_loader without being part of the API surface.
-#[doc(hidden)]
-pub fn is_nonoverlapping<N>(src: N, src_len: N, dst: N, dst_len: N) -> bool
-where
-    N: Ord + num_traits::SaturatingSub,
+fn is_nonoverlapping(src: usize, src_len: usize, dst: usize, dst_len: usize) -> bool
 {
     // If the absolute distance between the ptrs is at least as big as the size of the other,
     // they do not overlap.
     if src > dst {
-        src.saturating_sub(&dst) >= dst_len
+        src.saturating_sub(dst) >= dst_len
     } else {
-        dst.saturating_sub(&src) >= src_len
+        dst.saturating_sub(src) >= src_len
     }
 }
 


### PR DESCRIPTION
This function is only used here and in solana-bpf-loader program. When used here, it doesn't need num-traits. I have opened a PR in the Agave repo to copy the num-traits version into solana-bpf-loader program https://github.com/anza-xyz/agave/pull/4888

Since the function is hidden this is not a breaking change.