### PR TITLE
CI: Disable downstream job temporarily

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,6 +102,7 @@ jobs:
         run: ./scripts/check-nightly.sh
 
   check-downstream-agave:
+    if: false # re-enable after agave uses loader-v3-interface v3
     name: Cargo check Agave master
     runs-on: ubuntu-latest
     needs: [sanity]


### PR DESCRIPTION
#### Problem

#9 introduced a breaking change to the loader-v3-interface crate, but the downstream job is still running.

#### Summary of changes

Until agave is updated to use the newest version of loader-v3-interface, disable the downstream job.