### PR TITLE
CI: Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "08:00"
+    timezone: UTC
+  open-pull-requests-limit: 6


### PR DESCRIPTION
#### Problem

The solana-sdk exists in its own separate repo, but there's no dependabot checking for security vulnerabilities or updating dependencies, unlike the Agave repo.

#### Summary of changes

Add dependabot configuration, just like Agave.