### PR TITLE
README: Add information from the Agave readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,42 @@
+[![Solana crate](https://img.shields.io/crates/v/solana-sdk.svg)](https://crates.io/crates/solana-sdk)
+[![Solana documentation](https://docs.rs/solana-sdk/badge.svg)](https://docs.rs/solana-sdk)
+
 # solana-sdk
 
 Rust SDK for the Solana blockchain, used by on-chain programs and the Agave
 validator.
+
+## Building
+
+### **1. Install rustc, cargo and rustfmt.**
+
+```console
+curl https://sh.rustup.rs -sSf | sh
+source $HOME/.cargo/env
+rustup component add rustfmt
+```
+
+### **2. Download the source code.**
+
+```console
+git clone https://github.com/anza-xyz/solana-sdk.git
+cd solana-sdk
+```
+
+When building the master branch, please make sure you are using the version
+specified in the repo's `rust-toolchain.toml` by running:
+
+```console
+rustup show
+```
+
+This command will download the toolchain if it is missing in the system.
+
+### **3. Test.**
+
+```console
+cargo test
+```
 
 ## For Agave Developers
 
@@ -29,3 +64,74 @@ Simply type in the path to the crate directory you want to release, ie.
 The publish job will run checks, bump the crate version, commit and tag the
 bump, publish the crate to crates.io, and finally create GitHub Release with
 a simple changelog of all commits to the crate since the previous release.
+
+## Testing
+
+Certain tests, such as `rustfmt` and `clippy`, require the nightly rustc
+configured on the repository. To easily install it, use the `./cargo` helper
+script in the root of the repository:
+
+```console
+./cargo nightly tree
+```
+
+### Basic testing
+
+Run the test suite:
+
+```console
+cargo test
+```
+
+Alternatively, there is a helper script:
+
+```console
+./scripts/test-stable.sh
+```
+
+### Formatting
+
+Format code for rustfmt check:
+
+```console
+./cargo nightly fmt --all
+```
+
+The check can be run with a helper script:
+
+```console
+./scripts/check-fmt.sh
+```
+
+### Clippy / Linting
+
+To check the clippy lints:
+
+```console
+./scripts/check-clippy.sh
+```
+
+### Benchmarking
+
+Run the benchmarks:
+
+```console
+./scripts/test-bench.sh
+```
+
+### Code coverage
+
+To generate code coverage statistics:
+
+```console
+./scripts/test-coverage.sh
+$ open target/cov/lcov-local/index.html
+```
+
+Code coverage requires `llvm-tools-preview` for the configured nightly
+toolchain. To install the component, run the command output by the script if it
+fails to find the component:
+
+```console
+rustup component add llvm-tools-preview --toolchain=<NIGHTLY_TOOLCHAIN>
+```


### PR DESCRIPTION
#### Problem

The README for this repository is missing information about how to get started, which is included in the Agave README.

#### Summary of changes

Add information about setting up and running tests