### PR TITLE
Add `farf/` directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+farf/
 
 **/*.rs.bk
 .cargo


### PR DESCRIPTION
#### Problem

Some of the tests in this repo create a `farf/` directory, but it isn't included in the `.gitignore`, so they show up in the git diff.

#### Summary of changes

Add `farf/` to .gitignore