### PR TITLE
increased quic connection timeout

### DIFF
--- a/quic-definitions/src/lib.rs
+++ b/quic-definitions/src/lib.rs
@@ -22,7 +22,9 @@ pub const QUIC_MAX_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// To avoid idle timeout, the QUIC endpoint sends a ping every
 /// QUIC_KEEP_ALIVE. This shouldn't be too low to avoid unnecessary ping traffic.
-pub const QUIC_KEEP_ALIVE: Duration = Duration::from_secs(45);
+/// For upgrade purpose, we keep the original one. Once the network is upgraded
+/// to the one having higher QUIC_MAX_TIMEOUT, this value can be increased.
+pub const QUIC_KEEP_ALIVE: Duration = Duration::from_secs(1);
 
 // Disable Quic send fairness.
 // When set to false, streams are still scheduled based on priority,

--- a/quic-definitions/src/lib.rs
+++ b/quic-definitions/src/lib.rs
@@ -16,8 +16,13 @@ pub const QUIC_TOTAL_STAKED_CONCURRENT_STREAMS: usize = 100_000;
 // forwarded packets from staked nodes.
 pub const QUIC_MAX_STAKED_CONCURRENT_STREAMS: usize = 512;
 
-pub const QUIC_MAX_TIMEOUT: Duration = Duration::from_secs(2);
-pub const QUIC_KEEP_ALIVE: Duration = Duration::from_secs(1);
+/// QUIC connection idle timeout. The connection will be closed if
+/// there are no activities on it within the timeout window.
+pub const QUIC_MAX_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// To avoid idle timeout, the QUIC endpoint sends a ping every
+/// QUIC_KEEP_ALIVE. This shouldn't be too low to avoid unnecessary ping traffic.
+pub const QUIC_KEEP_ALIVE: Duration = Duration::from_secs(45);
 
 // Disable Quic send fairness.
 // When set to false, streams are still scheduled based on priority,


### PR DESCRIPTION
This is to resurrect the PR https://github.com/anza-xyz/agave/pull/4585 which was reverted due to CI failure.
The CI failure has been root caused due to defunct connections being used for longtime before the increased idle timeout value: https://github.com/anza-xyz/agave/pull/4841. 

For backward compatibility the QUIC_KEEP_ALIVE is kept as the old one -- to be increased once the network is upgraded to having the higher IDLE_TIMEOUT