### PR TITLE
workspace: Bump all crates for publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,7 +1548,7 @@ checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi 0.4.0",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2536,7 +2536,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "bincode",
  "qualifier_attr",
@@ -2557,7 +2557,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-info"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "bincode",
  "serde",
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-interface"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -2587,14 +2587,14 @@ dependencies = [
 
 [[package]]
 name = "solana-atomic-u64"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
 name = "solana-big-mod-exp"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "array-bytes",
  "num-bigint",
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bincode"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "bincode",
  "serde",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "solana-blake3-hasher"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "blake3",
  "borsh 1.5.5",
@@ -2634,7 +2634,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bn254"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2652,7 +2652,7 @@ dependencies = [
 
 [[package]]
 name = "solana-borsh"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "borsh 0.10.4",
  "borsh 1.5.5",
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client-traits"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "solana-account",
  "solana-commitment-config",
@@ -2679,7 +2679,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clock"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2692,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cluster-type"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2703,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "solana-commitment-config"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-interface"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "borsh 1.5.5",
  "serde",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cpi"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "solana-account-info",
  "solana-define-syscall",
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "solana-decode-error"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "num-derive",
  "num-traits",
@@ -2748,11 +2748,11 @@ dependencies = [
 
 [[package]]
 name = "solana-define-syscall"
-version = "2.2.0"
+version = "2.2.1"
 
 [[package]]
 name = "solana-derivation-path"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "assert_matches",
  "derivation-path",
@@ -2762,7 +2762,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ed25519-program"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "solana-epoch-info"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2790,7 +2790,7 @@ dependencies = [
 
 [[package]]
 name = "solana-epoch-rewards"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2805,7 +2805,7 @@ dependencies = [
 
 [[package]]
 name = "solana-epoch-rewards-hasher"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "siphasher",
  "solana-hash",
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "solana-epoch-schedule"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2830,7 +2830,7 @@ dependencies = [
 
 [[package]]
 name = "solana-example-mocks"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2849,7 +2849,7 @@ dependencies = [
 
 [[package]]
 name = "solana-feature-gate-interface"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "bincode",
  "serde",
@@ -2867,7 +2867,7 @@ dependencies = [
 
 [[package]]
 name = "solana-feature-set"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "ahash",
  "lazy_static",
@@ -2881,7 +2881,7 @@ dependencies = [
 
 [[package]]
 name = "solana-fee-calculator"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "log",
  "serde",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "solana-fee-structure"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2906,7 +2906,7 @@ dependencies = [
 
 [[package]]
 name = "solana-file-download"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "console",
  "indicatif",
@@ -2916,7 +2916,7 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "bitflags 2.8.0",
  "bs58",
@@ -2936,7 +2936,7 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2945,7 +2945,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-config"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "bincode",
  "chrono",
@@ -2977,7 +2977,7 @@ dependencies = [
 
 [[package]]
 name = "solana-hard-forks"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2987,7 +2987,7 @@ dependencies = [
 
 [[package]]
 name = "solana-hash"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "borsh 1.5.5",
  "bs58",
@@ -3006,7 +3006,7 @@ dependencies = [
 
 [[package]]
 name = "solana-inflation"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -3016,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "solana-instruction"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "bincode",
  "borsh 1.5.5",
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "solana-instructions-sysvar"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "bitflags 2.8.0",
  "qualifier_attr",
@@ -3051,7 +3051,7 @@ dependencies = [
 
 [[package]]
 name = "solana-keccak-hasher"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "borsh 1.5.5",
  "serde",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "solana-keypair"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -3086,7 +3086,7 @@ dependencies = [
 
 [[package]]
 name = "solana-last-restart-slot"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v2-interface"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v3-interface"
-version = "2.2.0"
+version = "3.0.0"
 dependencies = [
  "bincode",
  "serde",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-interface"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "memoffset",
  "serde",
@@ -3143,7 +3143,7 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -3152,7 +3152,7 @@ dependencies = [
 
 [[package]]
 name = "solana-message"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3187,18 +3187,18 @@ dependencies = [
 
 [[package]]
 name = "solana-msg"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "solana-define-syscall",
 ]
 
 [[package]]
 name = "solana-native-token"
-version = "2.2.0"
+version = "2.2.1"
 
 [[package]]
 name = "solana-nonce"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "bincode",
  "serde",
@@ -3212,7 +3212,7 @@ dependencies = [
 
 [[package]]
 name = "solana-nonce-account"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "solana-account",
  "solana-fee-calculator",
@@ -3224,7 +3224,7 @@ dependencies = [
 
 [[package]]
 name = "solana-offchain-message"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "num_enum",
  "solana-hash",
@@ -3241,7 +3241,7 @@ dependencies = [
 
 [[package]]
 name = "solana-package-metadata"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "solana-package-metadata-macro",
  "solana-pubkey",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "solana-package-metadata-macro"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "solana-packet"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "bincode",
  "bitflags 2.8.0",
@@ -3275,7 +3275,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh-config"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -3287,7 +3287,7 @@ dependencies = [
 
 [[package]]
 name = "solana-precompile-error"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "num-traits",
  "solana-decode-error",
@@ -3295,7 +3295,7 @@ dependencies = [
 
 [[package]]
 name = "solana-precompiles"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "lazy_static",
  "solana-ed25519-program",
@@ -3310,7 +3310,7 @@ dependencies = [
 
 [[package]]
 name = "solana-presigner"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "solana-keypair",
  "solana-pubkey",
@@ -3320,7 +3320,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "arbitrary",
  "array-bytes",
@@ -3406,7 +3406,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-entrypoint"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "solana-account-info",
  "solana-msg",
@@ -3416,7 +3416,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-error"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "borsh 1.5.5",
  "num-traits",
@@ -3430,7 +3430,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-memory"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "num-traits",
  "solana-define-syscall",
@@ -3438,18 +3438,18 @@ dependencies = [
 
 [[package]]
 name = "solana-program-option"
-version = "2.2.0"
+version = "2.2.1"
 
 [[package]]
 name = "solana-program-pack"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "solana-program-error",
 ]
 
 [[package]]
 name = "solana-pubkey"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -3482,14 +3482,14 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-definitions"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "solana-keypair",
 ]
 
 [[package]]
 name = "solana-rent"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rent-collector"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "assert_matches",
  "serde",
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rent-debits"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "solana-pubkey",
  "solana-reward-info",
@@ -3531,7 +3531,7 @@ dependencies = [
 
 [[package]]
 name = "solana-reserved-account-keys"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "lazy_static",
  "solana-feature-set",
@@ -3545,7 +3545,7 @@ dependencies = [
 
 [[package]]
 name = "solana-reward-info"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -3555,11 +3555,11 @@ dependencies = [
 
 [[package]]
 name = "solana-sanitize"
-version = "2.2.0"
+version = "2.2.1"
 
 [[package]]
 name = "solana-sdk"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "bincode",
  "bs58",
@@ -3637,14 +3637,14 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-ids"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "solana-pubkey",
 ]
 
 [[package]]
 name = "solana-sdk-macro"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -3654,7 +3654,7 @@ dependencies = [
 
 [[package]]
 name = "solana-secp256k1-program"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3684,7 +3684,7 @@ dependencies = [
 
 [[package]]
 name = "solana-secp256k1-recover"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "anyhow",
  "borsh 1.5.5",
@@ -3698,7 +3698,7 @@ dependencies = [
 
 [[package]]
 name = "solana-secp256r1-program"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "bytemuck",
  "openssl",
@@ -3712,14 +3712,14 @@ dependencies = [
 
 [[package]]
 name = "solana-seed-derivable"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "solana-derivation-path",
 ]
 
 [[package]]
 name = "solana-seed-phrase"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2 0.11.0",
@@ -3728,7 +3728,7 @@ dependencies = [
 
 [[package]]
 name = "solana-serde"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "bincode",
  "serde",
@@ -3737,7 +3737,7 @@ dependencies = [
 
 [[package]]
 name = "solana-serde-varint"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "bincode",
  "rand 0.8.5",
@@ -3748,7 +3748,7 @@ dependencies = [
 
 [[package]]
 name = "solana-serialize-utils"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "bincode",
  "borsh 1.5.5",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sha256-hasher"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "sha2 0.10.8",
  "solana-define-syscall",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "solana-short-vec"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -3782,7 +3782,7 @@ dependencies = [
 
 [[package]]
 name = "solana-shred-version"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "solana-hard-forks",
  "solana-hash",
@@ -3791,7 +3791,7 @@ dependencies = [
 
 [[package]]
 name = "solana-signature"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "bincode",
  "bs58",
@@ -3812,7 +3812,7 @@ dependencies = [
 
 [[package]]
 name = "solana-signer"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "solana-pubkey",
  "solana-signature",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "solana-slot-hashes"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -3833,7 +3833,7 @@ dependencies = [
 
 [[package]]
 name = "solana-slot-history"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "bv",
  "serde",
@@ -3844,7 +3844,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stable-layout"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "memoffset",
  "solana-instruction",
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "solana-system-transaction"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "solana-hash",
  "solana-keypair",
@@ -3905,7 +3905,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sysvar"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3950,7 +3950,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sysvar-id"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "solana-pubkey",
  "solana-sdk-ids",
@@ -3958,11 +3958,11 @@ dependencies = [
 
 [[package]]
 name = "solana-time-utils"
-version = "2.2.0"
+version = "2.2.1"
 
 [[package]]
 name = "solana-transaction"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4001,7 +4001,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "bincode",
  "serde",
@@ -4019,7 +4019,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-error"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -4031,11 +4031,11 @@ dependencies = [
 
 [[package]]
 name = "solana-validator-exit"
-version = "2.2.0"
+version = "2.2.1"
 
 [[package]]
 name = "solana-vote-interface"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "arbitrary",
  "bincode",
@@ -4648,7 +4648,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,7 +1548,7 @@ checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi 0.4.0",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4648,7 +4648,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,107 +193,107 @@ serial_test = "2.0.0"
 sha2 = "0.10.8"
 sha3 = "0.10.8"
 siphasher = "0.3.11"
-solana-account = { path = "account", version = "2.2.0" }
-solana-account-info = { path = "account-info", version = "2.2.0" }
-solana-address-lookup-table-interface = { path = "address-lookup-table-interface", version = "2.2.1" }
-solana-atomic-u64 = { path = "atomic-u64", version = "2.2.0" }
-solana-big-mod-exp = { path = "big-mod-exp", version = "2.2.0" }
-solana-bincode = { path = "bincode", version = "2.2.0" }
-solana-blake3-hasher = { path = "blake3-hasher", version = "2.2.0" }
-solana-bn254 = { path = "bn254", version = "2.2.0" }
-solana-borsh = { path = "borsh", version = "2.2.0" }
-solana-client-traits = { path = "client-traits", version = "2.2.0" }
-solana-clock = { path = "clock", version = "2.2.0" }
-solana-cluster-type = { path = "cluster-type", version = "2.2.0" }
-solana-commitment-config = { path = "commitment-config", version = "2.2.0" }
-solana-compute-budget-interface = { path = "compute-budget-interface", version = "2.2.0" }
-solana-cpi = { path = "cpi", version = "2.2.0" }
-solana-decode-error = { path = "decode-error", version = "2.2.0" }
-solana-define-syscall = { path = "define-syscall", version = "2.2.0" }
-solana-derivation-path = { path = "derivation-path", version = "2.2.0" }
-solana-ed25519-program = { path = "ed25519-program", version = "2.2.0" }
-solana-program-entrypoint = { path = "program-entrypoint", version = "2.2.0" }
-solana-epoch-info = { path = "epoch-info", version = "2.2.0" }
-solana-epoch-rewards = { path = "epoch-rewards", version = "2.2.0" }
-solana-epoch-rewards-hasher = { path = "epoch-rewards-hasher", version = "2.2.0" }
-solana-epoch-schedule = { path = "epoch-schedule", version = "2.2.0" }
-solana-example-mocks = { path = "example-mocks", version = "2.2.0" }
-solana-feature-gate-interface = { path = "feature-gate-interface", version = "2.2.0" }
-solana-feature-set = { path = "feature-set", version = "2.2.0" }
-solana-fee-calculator = { path = "fee-calculator", version = "2.2.0" }
-solana-fee-structure = { path = "fee-structure", version = "2.2.0" }
-solana-frozen-abi = { path = "frozen-abi", version = "2.2.0" }
-solana-frozen-abi-macro = { path = "frozen-abi-macro", version = "2.2.0" }
-solana-file-download = { path = "file-download", version = "2.2.0" }
-solana-genesis-config = { path = "genesis-config", version = "2.2.0" }
-solana-hard-forks = { path = "hard-forks", version = "2.2.0", default-features = false }
-solana-hash = { path = "hash", version = "2.2.0", default-features = false }
-solana-inflation = { path = "inflation", version = "2.2.0" }
-solana-instruction = { path = "instruction", version = "2.2.0", default-features = false }
-solana-instructions-sysvar = { path = "instructions-sysvar", version = "2.2.0" }
-solana-keccak-hasher = { path = "keccak-hasher", version = "2.2.0" }
-solana-keypair = { path = "keypair", version = "2.2.0" }
-solana-last-restart-slot = { path = "last-restart-slot", version = "2.2.0" }
-solana-loader-v2-interface = { path = "loader-v2-interface", version = "2.2.0" }
-solana-loader-v3-interface = { path = "loader-v3-interface", version = "2.2.0" }
-solana-loader-v4-interface = { path = "loader-v4-interface", version = "2.2.0" }
-solana-logger = { path = "logger", version = "2.2.0" }
-solana-message = { path = "message", version = "2.2.0" }
-solana-msg = { path = "msg", version = "2.2.0" }
-solana-native-token = { path = "native-token", version = "2.2.0" }
-solana-nonce = { path = "nonce", version = "2.2.0" }
-solana-nonce-account = { path = "nonce-account", version = "2.2.0" }
-solana-offchain-message = { path = "offchain-message", version = "2.2.0" }
-solana-package-metadata = { path = "package-metadata", version = "2.2.0" }
-solana-package-metadata-macro = { path = "package-metadata-macro", version = "2.2.0" }
-solana-packet = { path = "packet", version = "2.2.0" }
-solana-poh-config = { path = "poh-config", version = "2.2.0" }
-solana-precompile-error = { path = "precompile-error", version = "2.2.0" }
-solana-precompiles = { path = "precompiles", version = "2.2.0" }
-solana-presigner = { path = "presigner", version = "2.2.0" }
-solana-program = { path = "program", version = "2.2.0", default-features = false }
-solana-program-error = { path = "program-error", version = "2.2.0" }
-solana-program-memory = { path = "program-memory", version = "2.2.0" }
-solana-program-option = { path = "program-option", version = "2.2.0" }
-solana-program-pack = { path = "program-pack", version = "2.2.0" }
-solana-pubkey = { path = "pubkey", version = "2.2.0", default-features = false }
-solana-quic-definitions = { path = "quic-definitions", version = "2.2.0" }
-solana-rent = { path = "rent", version = "2.2.0", default-features = false }
-solana-rent-collector = { path = "rent-collector", version = "2.2.0" }
-solana-rent-debits = { path = "rent-debits", version = "2.2.0" }
-solana-reserved-account-keys = { path = "reserved-account-keys", version = "2.2.0", default-features = false }
-solana-reward-info = { path = "reward-info", version = "2.2.0" }
-solana-sanitize = { path = "sanitize", version = "2.2.0" }
-solana-secp256r1-program = { path = "secp256r1-program", version = "2.2.0", default-features = false }
-solana-seed-derivable = { path = "seed-derivable", version = "2.2.0" }
-solana-seed-phrase = { path = "seed-phrase", version = "2.2.0" }
-solana-serde = { path = "serde", version = "2.2.0" }
-solana-serde-varint = { path = "serde-varint", version = "2.2.0" }
-solana-serialize-utils = { path = "serialize-utils", version = "2.2.0" }
-solana-sha256-hasher = { path = "sha256-hasher", version = "2.2.0" }
-solana-signature = { path = "signature", version = "2.2.0", default-features = false }
-solana-signer = { path = "signer", version = "2.2.0" }
-solana-slot-hashes = { path = "slot-hashes", version = "2.2.0" }
-solana-slot-history = { path = "slot-history", version = "2.2.0" }
-solana-time-utils = { path = "time-utils", version = "2.2.0" }
-solana-sdk = { path = "sdk", version = "2.2.0" }
-solana-sdk-ids = { path = "sdk-ids", version = "2.2.0" }
-solana-sdk-macro = { path = "sdk-macro", version = "2.2.0" }
-solana-secp256k1-program = { path = "secp256k1-program", version = "2.2.0" }
-solana-secp256k1-recover = { path = "secp256k1-recover", version = "2.2.0" }
-solana-short-vec = { path = "short-vec", version = "2.2.0" }
-solana-shred-version = { path = "shred-version", version = "2.2.0" }
-solana-stable-layout = { path = "stable-layout", version = "2.2.0" }
+solana-account = { path = "account", version = "2.2.1" }
+solana-account-info = { path = "account-info", version = "2.2.1" }
+solana-address-lookup-table-interface = { path = "address-lookup-table-interface", version = "2.2.2" }
+solana-atomic-u64 = { path = "atomic-u64", version = "2.2.1" }
+solana-big-mod-exp = { path = "big-mod-exp", version = "2.2.1" }
+solana-bincode = { path = "bincode", version = "2.2.1" }
+solana-blake3-hasher = { path = "blake3-hasher", version = "2.2.1" }
+solana-bn254 = { path = "bn254", version = "2.2.1" }
+solana-borsh = { path = "borsh", version = "2.2.1" }
+solana-client-traits = { path = "client-traits", version = "2.2.1" }
+solana-clock = { path = "clock", version = "2.2.1" }
+solana-cluster-type = { path = "cluster-type", version = "2.2.1" }
+solana-commitment-config = { path = "commitment-config", version = "2.2.1" }
+solana-compute-budget-interface = { path = "compute-budget-interface", version = "2.2.1" }
+solana-cpi = { path = "cpi", version = "2.2.1" }
+solana-decode-error = { path = "decode-error", version = "2.2.1" }
+solana-define-syscall = { path = "define-syscall", version = "2.2.1" }
+solana-derivation-path = { path = "derivation-path", version = "2.2.1" }
+solana-ed25519-program = { path = "ed25519-program", version = "2.2.1" }
+solana-program-entrypoint = { path = "program-entrypoint", version = "2.2.1" }
+solana-epoch-info = { path = "epoch-info", version = "2.2.1" }
+solana-epoch-rewards = { path = "epoch-rewards", version = "2.2.1" }
+solana-epoch-rewards-hasher = { path = "epoch-rewards-hasher", version = "2.2.1" }
+solana-epoch-schedule = { path = "epoch-schedule", version = "2.2.1" }
+solana-example-mocks = { path = "example-mocks", version = "2.2.1" }
+solana-feature-gate-interface = { path = "feature-gate-interface", version = "2.2.1" }
+solana-feature-set = { path = "feature-set", version = "2.2.1" }
+solana-fee-calculator = { path = "fee-calculator", version = "2.2.1" }
+solana-fee-structure = { path = "fee-structure", version = "2.2.1" }
+solana-frozen-abi = { path = "frozen-abi", version = "2.2.1" }
+solana-frozen-abi-macro = { path = "frozen-abi-macro", version = "2.2.1" }
+solana-file-download = { path = "file-download", version = "2.2.1" }
+solana-genesis-config = { path = "genesis-config", version = "2.2.1" }
+solana-hard-forks = { path = "hard-forks", version = "2.2.1", default-features = false }
+solana-hash = { path = "hash", version = "2.2.1", default-features = false }
+solana-inflation = { path = "inflation", version = "2.2.1" }
+solana-instruction = { path = "instruction", version = "2.2.1", default-features = false }
+solana-instructions-sysvar = { path = "instructions-sysvar", version = "2.2.1" }
+solana-keccak-hasher = { path = "keccak-hasher", version = "2.2.1" }
+solana-keypair = { path = "keypair", version = "2.2.1" }
+solana-last-restart-slot = { path = "last-restart-slot", version = "2.2.1" }
+solana-loader-v2-interface = { path = "loader-v2-interface", version = "2.2.1" }
+solana-loader-v3-interface = { path = "loader-v3-interface", version = "3.0.0" }
+solana-loader-v4-interface = { path = "loader-v4-interface", version = "2.2.1" }
+solana-logger = { path = "logger", version = "2.2.1" }
+solana-message = { path = "message", version = "2.2.1" }
+solana-msg = { path = "msg", version = "2.2.1" }
+solana-native-token = { path = "native-token", version = "2.2.1" }
+solana-nonce = { path = "nonce", version = "2.2.1" }
+solana-nonce-account = { path = "nonce-account", version = "2.2.1" }
+solana-offchain-message = { path = "offchain-message", version = "2.2.1" }
+solana-package-metadata = { path = "package-metadata", version = "2.2.1" }
+solana-package-metadata-macro = { path = "package-metadata-macro", version = "2.2.1" }
+solana-packet = { path = "packet", version = "2.2.1" }
+solana-poh-config = { path = "poh-config", version = "2.2.1" }
+solana-precompile-error = { path = "precompile-error", version = "2.2.1" }
+solana-precompiles = { path = "precompiles", version = "2.2.1" }
+solana-presigner = { path = "presigner", version = "2.2.1" }
+solana-program = { path = "program", version = "2.2.1", default-features = false }
+solana-program-error = { path = "program-error", version = "2.2.1" }
+solana-program-memory = { path = "program-memory", version = "2.2.1" }
+solana-program-option = { path = "program-option", version = "2.2.1" }
+solana-program-pack = { path = "program-pack", version = "2.2.1" }
+solana-pubkey = { path = "pubkey", version = "2.2.1", default-features = false }
+solana-quic-definitions = { path = "quic-definitions", version = "2.2.1" }
+solana-rent = { path = "rent", version = "2.2.1", default-features = false }
+solana-rent-collector = { path = "rent-collector", version = "2.2.1" }
+solana-rent-debits = { path = "rent-debits", version = "2.2.1" }
+solana-reserved-account-keys = { path = "reserved-account-keys", version = "2.2.1", default-features = false }
+solana-reward-info = { path = "reward-info", version = "2.2.1" }
+solana-sanitize = { path = "sanitize", version = "2.2.1" }
+solana-secp256r1-program = { path = "secp256r1-program", version = "2.2.1", default-features = false }
+solana-seed-derivable = { path = "seed-derivable", version = "2.2.1" }
+solana-seed-phrase = { path = "seed-phrase", version = "2.2.1" }
+solana-serde = { path = "serde", version = "2.2.1" }
+solana-serde-varint = { path = "serde-varint", version = "2.2.1" }
+solana-serialize-utils = { path = "serialize-utils", version = "2.2.1" }
+solana-sha256-hasher = { path = "sha256-hasher", version = "2.2.1" }
+solana-signature = { path = "signature", version = "2.2.1", default-features = false }
+solana-signer = { path = "signer", version = "2.2.1" }
+solana-slot-hashes = { path = "slot-hashes", version = "2.2.1" }
+solana-slot-history = { path = "slot-history", version = "2.2.1" }
+solana-time-utils = { path = "time-utils", version = "2.2.1" }
+solana-sdk = { path = "sdk", version = "2.2.1" }
+solana-sdk-ids = { path = "sdk-ids", version = "2.2.1" }
+solana-sdk-macro = { path = "sdk-macro", version = "2.2.1" }
+solana-secp256k1-program = { path = "secp256k1-program", version = "2.2.1" }
+solana-secp256k1-recover = { path = "secp256k1-recover", version = "2.2.1" }
+solana-short-vec = { path = "short-vec", version = "2.2.1" }
+solana-shred-version = { path = "shred-version", version = "2.2.1" }
+solana-stable-layout = { path = "stable-layout", version = "2.2.1" }
 solana-stake-interface = { version = "1.2.1" }
 solana-system-interface = "1.0"
-solana-system-transaction = { path = "system-transaction", version = "2.2.0" }
-solana-sysvar = { path = "sysvar", version = "2.2.0" }
-solana-sysvar-id = { path = "sysvar-id", version = "2.2.0" }
-solana-transaction = { path = "transaction", version = "2.2.0" }
-solana-transaction-error = { path = "transaction-error", version = "2.2.0" }
-solana-transaction-context = { path = "transaction-context", version = "2.2.0" }
-solana-validator-exit = { path = "validator-exit", version = "2.2.0" }
-solana-vote-interface = { path = "vote-interface", version = "2.2.0" }
+solana-system-transaction = { path = "system-transaction", version = "2.2.1" }
+solana-sysvar = { path = "sysvar", version = "2.2.1" }
+solana-sysvar-id = { path = "sysvar-id", version = "2.2.1" }
+solana-transaction = { path = "transaction", version = "2.2.1" }
+solana-transaction-error = { path = "transaction-error", version = "2.2.1" }
+solana-transaction-context = { path = "transaction-context", version = "2.2.1" }
+solana-validator-exit = { path = "validator-exit", version = "2.2.1" }
+solana-vote-interface = { path = "vote-interface", version = "2.2.1" }
 static_assertions = "1.1.0"
 strum = "0.24"
 strum_macros = "0.24"
@@ -315,7 +315,7 @@ wasm-bindgen = "0.2"
 # on `solana-instruction`.  And we explicitly specify `solana-instruction` above
 # as a local path dependency:
 #
-#     solana-instruction = { path = "instruction", version = "2.2.0" }
+#     solana-instruction = { path = "instruction", version = "2.2.1" }
 #
 # Unfortunately, Cargo will try to resolve the `solana-system-interface`
 # `solana-instruction` dependency only using what is available on crates.io.

--- a/account-info/Cargo.toml
+++ b/account-info/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-account-info"
 description = "Solana AccountInfo and related definitions."
 documentation = "https://docs.rs/solana-account-info"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/account/Cargo.toml
+++ b/account/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-account"
 description = "Solana Account type"
 documentation = "https://docs.rs/solana-account"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/address-lookup-table-interface/Cargo.toml
+++ b/address-lookup-table-interface/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-address-lookup-table-interface"
 description = "Solana address lookup table interface."
 documentation = "https://docs.rs/solana-address-lookup-table-interface"
-version = "2.2.1"
+version = "2.2.2"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/atomic-u64/Cargo.toml
+++ b/atomic-u64/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-atomic-u64"
 description = "Solana atomic u64 implementation. For internal use only."
 documentation = "https://docs.rs/solana-atomic-u64"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/big-mod-exp/Cargo.toml
+++ b/big-mod-exp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-big-mod-exp"
 description = "Solana big integer modular exponentiation"
 documentation = "https://docs.rs/solana-big-mod-exp"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/bincode/Cargo.toml
+++ b/bincode/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-bincode"
 description = "Solana bincode utilities"
 documentation = "https://docs.rs/solana-bincode"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/blake3-hasher/Cargo.toml
+++ b/blake3-hasher/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-blake3-hasher"
 description = "Solana BLAKE3 hashing"
 documentation = "https://docs.rs/solana-blake3-hasher"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/bn254/Cargo.toml
+++ b/bn254/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-bn254"
 description = "Solana BN254"
 documentation = "https://docs.rs/solana-bn254"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-borsh"
 description = "Solana Borsh utilities"
 documentation = "https://docs.rs/solana-borsh"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/client-traits/Cargo.toml
+++ b/client-traits/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-client-traits"
 description = "Traits for Solana clients"
 documentation = "https://docs.rs/solana-client-traits"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/clock/Cargo.toml
+++ b/clock/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-clock"
 description = "Solana Clock and Time Definitions"
 documentation = "https://docs.rs/solana-clock"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/cluster-type/Cargo.toml
+++ b/cluster-type/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-cluster-type"
 description = "Solana ClusterType enum"
 documentation = "https://docs.rs/solana-cluster-type"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/commitment-config/Cargo.toml
+++ b/commitment-config/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-commitment-config"
 description = "Solana commitment config."
 documentation = "https://docs.rs/solana-commitment-config"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/compute-budget-interface/Cargo.toml
+++ b/compute-budget-interface/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-compute-budget-interface"
 description = "Solana compute budget interface."
 documentation = "https://docs.rs/solana-compute-budget-interface"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/cpi/Cargo.toml
+++ b/cpi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-cpi"
 description = "Solana Cross-program Invocation"
 documentation = "https://docs.rs/solana-cpi"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/decode-error/Cargo.toml
+++ b/decode-error/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-decode-error"
 description = "Solana DecodeError Trait"
 documentation = "https://docs.rs/solana-decode-error"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/define-syscall/Cargo.toml
+++ b/define-syscall/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-define-syscall"
 description = "Solana define_syscall macro and core syscall definitions."
 documentation = "https://docs.rs/solana-define-syscall"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/derivation-path/Cargo.toml
+++ b/derivation-path/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-derivation-path"
 description = "Solana BIP44 derivation paths."
 documentation = "https://docs.rs/solana-derivation-path"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/ed25519-program/Cargo.toml
+++ b/ed25519-program/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-ed25519-program"
 description = "Instructions for the Solana ed25519 native program"
 documentation = "https://docs.rs/solana-ed25519-program"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/epoch-info/Cargo.toml
+++ b/epoch-info/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-epoch-info"
 description = "Information about a Solana epoch."
 documentation = "https://docs.rs/solana-epoch-info"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/epoch-rewards-hasher/Cargo.toml
+++ b/epoch-rewards-hasher/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-epoch-rewards-hasher"
 description = "Solana epoch rewards hasher."
 documentation = "https://docs.rs/solana-epoch-rewards-hasher"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/epoch-rewards/Cargo.toml
+++ b/epoch-rewards/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-epoch-rewards"
 description = "Solana epoch rewards sysvar."
 documentation = "https://docs.rs/solana-epoch-rewards"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/epoch-schedule/Cargo.toml
+++ b/epoch-schedule/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-epoch-schedule"
 description = "Configuration for Solana epochs and slots."
 documentation = "https://docs.rs/solana-epoch-schedule"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/example-mocks/Cargo.toml
+++ b/example-mocks/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-example-mocks"
 description = "Solana mock types for use in examples"
 documentation = "https://docs.rs/solana-example-mocks"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/feature-gate-interface/Cargo.toml
+++ b/feature-gate-interface/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-feature-gate-interface"
 description = "Solana feature gate program interface."
 documentation = "https://docs.rs/solana-feature-gate-interface"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/feature-set/Cargo.toml
+++ b/feature-set/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-feature-set"
 description = "Solana runtime features."
 documentation = "https://docs.rs/solana-feature-set"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/fee-calculator/Cargo.toml
+++ b/fee-calculator/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-fee-calculator"
 description = "Solana transaction fee calculation"
 documentation = "https://docs.rs/solana-fee-calculator"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/fee-structure/Cargo.toml
+++ b/fee-structure/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-fee-structure"
 description = "Solana fee structures."
 documentation = "https://docs.rs/solana-fee-structure"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/file-download/Cargo.toml
+++ b/file-download/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-file-download"
 description = "Solana File Download Utility"
 documentation = "https://docs.rs/solana-file-download"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/frozen-abi-macro/Cargo.toml
+++ b/frozen-abi-macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-frozen-abi-macro"
 description = "Solana Frozen ABI Macro"
 documentation = "https://docs.rs/solana-frozen-abi-macro"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/frozen-abi/Cargo.toml
+++ b/frozen-abi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-frozen-abi"
 description = "Solana Frozen ABI"
 documentation = "https://docs.rs/solana-frozen-abi"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/genesis-config/Cargo.toml
+++ b/genesis-config/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-genesis-config"
 description = "A Solana network's genesis config."
 documentation = "https://docs.rs/solana-genesis-config"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/hard-forks/Cargo.toml
+++ b/hard-forks/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-hard-forks"
 description = "The list of slot boundaries at which a hard fork should occur."
 documentation = "https://docs.rs/solana-hard-forks"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/hash/Cargo.toml
+++ b/hash/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-hash"
 description = "Solana wrapper for the 32-byte output of a hashing algorithm."
 documentation = "https://docs.rs/solana-hash"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/inflation/Cargo.toml
+++ b/inflation/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-inflation"
 description = "Configuration for Solana network inflation"
 documentation = "https://docs.rs/solana-inflation"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/instruction/Cargo.toml
+++ b/instruction/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-instruction"
 description = "Types for directing the execution of Solana programs."
 documentation = "https://docs.rs/solana-instruction"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/instructions-sysvar/Cargo.toml
+++ b/instructions-sysvar/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-instructions-sysvar"
 description = "Type for instruction introspection during execution of Solana programs."
 documentation = "https://docs.rs/solana-instructions-sysvar"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/keccak-hasher/Cargo.toml
+++ b/keccak-hasher/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-keccak-hasher"
 description = "Solana Keccak hashing"
 documentation = "https://docs.rs/solana-keccak-hasher"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/keypair/Cargo.toml
+++ b/keypair/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-keypair"
 description = "Concrete implementation of a Solana `Signer`."
 documentation = "https://docs.rs/solana-keypair"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/last-restart-slot/Cargo.toml
+++ b/last-restart-slot/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-last-restart-slot"
 description = "Types and utilities for the Solana LastRestartSlot sysvar."
 documentation = "https://docs.rs/solana-last-restart-slot"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/loader-v2-interface/Cargo.toml
+++ b/loader-v2-interface/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-loader-v2-interface"
 description = "Solana non-upgradable BPF loader v2 instructions."
 documentation = "https://docs.rs/solana-loader-v2-interface"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/loader-v3-interface/Cargo.toml
+++ b/loader-v3-interface/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-loader-v3-interface"
 description = "Solana loader V3 interface."
 documentation = "https://docs.rs/solana-loader-v3-interface"
-version = "2.2.0"
+version = "3.0.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/loader-v4-interface/Cargo.toml
+++ b/loader-v4-interface/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-loader-v4-interface"
 description = "Solana loader V4 interface."
 documentation = "https://docs.rs/solana-loader-v4-interface"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-logger"
 description = "Solana Logger"
 documentation = "https://docs.rs/solana-logger"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/message/Cargo.toml
+++ b/message/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-message"
 description = "Solana transaction message types."
 documentation = "https://docs.rs/solana-message"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/msg/Cargo.toml
+++ b/msg/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-msg"
 description = "Solana msg macro."
 documentation = "https://docs.rs/solana-msg"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/native-token/Cargo.toml
+++ b/native-token/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-native-token"
 description = "Definitions for the native SOL token and its fractional lamports."
 documentation = "https://docs.rs/solana-native-token"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/nonce-account/Cargo.toml
+++ b/nonce-account/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-nonce-account"
 description = "Solana nonce account utils."
 documentation = "https://docs.rs/solana-nonce-account"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/nonce/Cargo.toml
+++ b/nonce/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-nonce"
 description = "Solana durable transaction nonces."
 documentation = "https://docs.rs/solana-nonce"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/offchain-message/Cargo.toml
+++ b/offchain-message/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-offchain-message"
 description = "Solana offchain message signing"
 documentation = "https://docs.rs/solana-offchain-message"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/package-metadata-macro/Cargo.toml
+++ b/package-metadata-macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-package-metadata-macro"
 description = "Solana Package Metadata Macro"
 documentation = "https://docs.rs/solana-package-metadata-macro"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/package-metadata/Cargo.toml
+++ b/package-metadata/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-package-metadata"
 description = "Solana Package Metadata"
 documentation = "https://docs.rs/solana-package-metadata"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/packet/Cargo.toml
+++ b/packet/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-packet"
 description = "The definition of a Solana network packet."
 documentation = "https://docs.rs/solana-packet"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/poh-config/Cargo.toml
+++ b/poh-config/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-poh-config"
 description = "Definitions of Solana's proof of history."
 documentation = "https://docs.rs/solana-poh-config"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/precompile-error/Cargo.toml
+++ b/precompile-error/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-precompile-error"
 description = "Solana PrecompileError type"
 documentation = "https://docs.rs/solana-precompile-error"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/precompiles/Cargo.toml
+++ b/precompiles/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-precompiles"
 description = "Solana precompiled programs."
 documentation = "https://docs.rs/solana-precompiles"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/presigner/Cargo.toml
+++ b/presigner/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-presigner"
 description = "A Solana `Signer` implementation representing an externally-constructed `Signature`."
 documentation = "https://docs.rs/solana-presigner"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/program-entrypoint/Cargo.toml
+++ b/program-entrypoint/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-program-entrypoint"
 description = "The Solana BPF program entrypoint supported by the latest BPF loader."
 documentation = "https://docs.rs/solana-program-entrypoint"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/program-error/Cargo.toml
+++ b/program-error/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-program-error"
 description = "Solana ProgramError type and related definitions."
 documentation = "https://docs.rs/solana-program-error"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/program-memory/Cargo.toml
+++ b/program-memory/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-program-memory"
 description = "Basic low-level memory operations for Solana."
 documentation = "https://docs.rs/solana-program-memory"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/program-option/Cargo.toml
+++ b/program-option/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-program-option"
 description = "A C representation of Rust's Option, used in Solana programs."
 documentation = "https://docs.rs/solana-program-option"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/program-pack/Cargo.toml
+++ b/program-pack/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-program-pack"
 description = "Solana Pack serialization trait."
 documentation = "https://docs.rs/solana-program-pack"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -3,7 +3,7 @@ name = "solana-program"
 description = "Solana Program"
 documentation = "https://docs.rs/solana-program"
 readme = "README.md"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/pubkey/Cargo.toml
+++ b/pubkey/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-pubkey"
 description = "Solana account addresses"
 documentation = "https://docs.rs/solana-pubkey"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/quic-definitions/Cargo.toml
+++ b/quic-definitions/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-quic-definitions"
 description = "Definitions related to Solana over QUIC."
 documentation = "https://docs.rs/solana-quic-definitions"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/rent-collector/Cargo.toml
+++ b/rent-collector/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-rent-collector"
 description = "Calculate and collect rent from accounts."
 documentation = "https://docs.rs/solana-rent-collector"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/rent-debits/Cargo.toml
+++ b/rent-debits/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-rent-debits"
 description = "Solana rent debit types."
 documentation = "https://docs.rs/solana-rent-debits"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/rent/Cargo.toml
+++ b/rent/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-rent"
 description = "Configuration for Solana network rent."
 documentation = "https://docs.rs/solana-rent"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/reserved-account-keys/Cargo.toml
+++ b/reserved-account-keys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-reserved-account-keys"
 description = "Reserved Solana account keys"
 documentation = "https://docs.rs/solana-reserved-account-keys"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/reward-info/Cargo.toml
+++ b/reward-info/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-reward-info"
 description = "Solana vote reward info types"
 documentation = "https://docs.rs/solana-reward-info"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/sanitize/Cargo.toml
+++ b/sanitize/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-sanitize"
 description = "Solana Message Sanitization"
 documentation = "https://docs.rs/solana-sanitize"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/sdk-ids/Cargo.toml
+++ b/sdk-ids/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-sdk-ids"
 description = "Solana SDK IDs"
 documentation = "https://docs.rs/solana-sdk-ids"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/sdk-macro/Cargo.toml
+++ b/sdk-macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-sdk-macro"
 description = "Solana SDK Macro"
 documentation = "https://docs.rs/solana-sdk-macro"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -3,7 +3,7 @@ name = "solana-sdk"
 description = "Solana SDK"
 documentation = "https://docs.rs/solana-sdk"
 readme = "README.md"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/secp256k1-program/Cargo.toml
+++ b/secp256k1-program/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-secp256k1-program"
 description = "Instructions for the Solana Secp256k1 native program."
 documentation = "https://docs.rs/solana-secp256k1-program"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/secp256k1-recover/Cargo.toml
+++ b/secp256k1-recover/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-secp256k1-recover"
 description = "Solana SECP256K1 Recover"
 documentation = "https://docs.rs/solana-secp256k1-recover"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/secp256r1-program/Cargo.toml
+++ b/secp256r1-program/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-secp256r1-program"
 description = "Precompile implementation for the secp256r1 elliptic curve."
 documentation = "https://docs.rs/solana-secp256r1"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/seed-derivable/Cargo.toml
+++ b/seed-derivable/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-seed-derivable"
 description = "Solana trait defining the interface by which keys are derived."
 documentation = "https://docs.rs/solana-seed-derivable"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/seed-phrase/Cargo.toml
+++ b/seed-phrase/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-seed-phrase"
 description = "Solana functions for generating keypairs from seed phrases."
 documentation = "https://docs.rs/solana-seed-phrase"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/serde-varint/Cargo.toml
+++ b/serde-varint/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-serde-varint"
 description = "Solana definitions for integers that serialize to variable size"
 documentation = "https://docs.rs/solana-serde-varint"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-serde"
 description = "Solana serde helpers"
 documentation = "https://docs.rs/solana-serde"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/serialize-utils/Cargo.toml
+++ b/serialize-utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-serialize-utils"
 description = "Solana helpers for reading and writing bytes."
 documentation = "https://docs.rs/solana-serialize-utils"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/sha256-hasher/Cargo.toml
+++ b/sha256-hasher/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-sha256-hasher"
 description = "Solana SHA256 hashing"
 documentation = "https://docs.rs/solana-sha256-hasher"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/short-vec/Cargo.toml
+++ b/short-vec/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-short-vec"
 description = "Solana compact serde-encoding of vectors with small length."
 documentation = "https://docs.rs/solana-short-vec"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/shred-version/Cargo.toml
+++ b/shred-version/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-shred-version"
 description = "Calculation of shred versions."
 documentation = "https://docs.rs/solana-shred-version"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-signature"
 description = "Solana 64-byte signature type"
 documentation = "https://docs.rs/solana-signature"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-signer"
 description = "Abstractions for Solana transaction signers. See `solana-keypair` for a concrete implementation."
 documentation = "https://docs.rs/solana-signer"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/slot-hashes/Cargo.toml
+++ b/slot-hashes/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-slot-hashes"
 description = "Types and utilities for the Solana SlotHashes sysvar."
 documentation = "https://docs.rs/solana-slot-hashes"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/slot-history/Cargo.toml
+++ b/slot-history/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-slot-history"
 description = "Types and utilities for the Solana SlotHistory sysvar."
 documentation = "https://docs.rs/solana-slot-history"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/stable-layout/Cargo.toml
+++ b/stable-layout/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-stable-layout"
 description = "Solana types with stable memory layouts. Internal use only."
 documentation = "https://docs.rs/solana-stable-layout"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/system-transaction/Cargo.toml
+++ b/system-transaction/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-system-transaction"
 description = "Functionality for creating system transactions."
 documentation = "https://docs.rs/solana-system-transaction"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/sysvar-id/Cargo.toml
+++ b/sysvar-id/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-sysvar-id"
 description = "Definition for the sysvar id trait and associated macros."
 documentation = "https://docs.rs/solana-sysvar-id"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/sysvar/Cargo.toml
+++ b/sysvar/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-sysvar"
 description = "Solana sysvar account types"
 documentation = "https://docs.rs/solana-sysvar"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/time-utils/Cargo.toml
+++ b/time-utils/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-time-utils"
 description = "`std::time` utilities for Solana"
 documentation = "https://docs.rs/solana-time-utils"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/transaction-context/Cargo.toml
+++ b/transaction-context/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-transaction-context"
 description = "Solana data shared between program runtime and built-in programs as well as SBF programs."
 documentation = "https://docs.rs/solana-transaction-context"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/transaction-error/Cargo.toml
+++ b/transaction-error/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-transaction-error"
 description = "Solana TransactionError type"
 documentation = "https://docs.rs/solana-transaction-error"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/transaction/Cargo.toml
+++ b/transaction/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-transaction"
 description = "Solana transaction-types"
 documentation = "https://docs.rs/solana-transaction"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/validator-exit/Cargo.toml
+++ b/validator-exit/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-validator-exit"
 description = "Solana validator exit handling."
 documentation = "https://docs.rs/solana-validator-exit"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/vote-interface/Cargo.toml
+++ b/vote-interface/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-vote-interface"
 description = "Solana vote interface."
 documentation = "https://docs.rs/solana-vote-interface"
-version = "2.2.0"
+version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }


### PR DESCRIPTION
#### Problem

As mentioned at #27, the sdk crates were pinning their versions internally, which made them more difficult to use outside of the repo. Now that the version has been relaxed, we need to publish these crates, but they're almost all still on v2.2.0.

#### Summary of changes

Normally crate publishing will be done one-by-one through the GitHub Actions publish workflow, but with ~100 crates, we need to go faster.

Bump all of the v2.2.0 crates to v2.2.1, bump address-lookup-table-interface to v2.2.2, and bump loader-v3-interface to v3.0.0 since it contains a breaking change.

Once this lands, we can publish all of the crates in the repo.