### PR TITLE
CI: Fix windows clippy job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,9 +147,9 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: |
-          echo "PERL=$((where.exe perl)[0])" >> $GITHUB_ENV
-          echo "OPENSSL_SRC_PERL=$((where.exe perl)[0])" >> $GITHUB_ENV
-          choco install openssl --version 3.3.2 --install-arguments="'/DIR=C:\OpenSSL'" -y
+          echo "PERL=$(which perl)" >> $GITHUB_ENV
+          echo "OPENSSL_SRC_PERL=$(which perl)" >> $GITHUB_ENV
+          choco install openssl --version 3.4.1 --install-arguments="'/DIR=C:\OpenSSL'" -y
           echo "OPENSSL_LIB_DIR=\"C:\OpenSSL\lib\VC\x64\MT\"" >> $GITHUB_ENV
           echo "OPENSSL_INCLUDE_DIR=C:\OpenSSL\include" >> $GITHUB_ENV
 


### PR DESCRIPTION
#### Problem

Similar to https://github.com/anza-xyz/agave/pull/4944, we need to update the openssl version used in CI.

Also, I noticed some failing commands from a recent run.

#### Summary of changes

Update to openssl 3.4.1, and fixup those commands.