### PR TITLE
feature-set: Bump to v2.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2867,7 +2867,7 @@ dependencies = [
 
 [[package]]
 name = "solana-feature-set"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "ahash",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,7 +219,7 @@ solana-epoch-rewards-hasher = { path = "epoch-rewards-hasher", version = "2.2.1"
 solana-epoch-schedule = { path = "epoch-schedule", version = "2.2.1" }
 solana-example-mocks = { path = "example-mocks", version = "2.2.1" }
 solana-feature-gate-interface = { path = "feature-gate-interface", version = "2.2.1" }
-solana-feature-set = { path = "feature-set", version = "2.2.1" }
+solana-feature-set = { path = "feature-set", version = "2.2.2" }
 solana-fee-calculator = { path = "fee-calculator", version = "2.2.1" }
 solana-fee-structure = { path = "fee-structure", version = "2.2.1" }
 solana-frozen-abi = { path = "frozen-abi", version = "2.2.1" }

--- a/feature-set/Cargo.toml
+++ b/feature-set/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-feature-set"
 description = "Solana runtime features."
 documentation = "https://docs.rs/solana-feature-set"
-version = "2.2.1"
+version = "2.2.2"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }


### PR DESCRIPTION
#### Problem

The auto-publish job for v2.2.2 had a bug in it during run https://github.com/anza-xyz/solana-sdk/actions/runs/13297445413/job/37132523790 and wasn't able to push the updated version to the repo.

#### Summary of changes

Update the version manually.