### PR TITLE
run cargo diet on all crates

### DIFF
--- a/bn254/Cargo.toml
+++ b/bn254/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+include = ["src/**/*"]
 
 [dependencies]
 bytemuck = { workspace = true, features = ["derive"] }

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -8,7 +8,6 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-include = ["src/lib.rs"]
 
 [dependencies]
 env_logger = { workspace = true }

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+include = ["src/lib.rs"]
 
 [dependencies]
 env_logger = { workspace = true }

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -10,6 +10,7 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 rust-version = "1.79.0"                          # solana platform-tools rust version
+include = ["src/**/*", "README.md"]
 
 [dependencies]
 bincode = { workspace = true }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -9,6 +9,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+include = ["src/**/*", "README.md"]
 
 [features]
 # "program" feature is a legacy feature retained to support v1.3 and older


### PR DESCRIPTION
Some crates are including useless extras in what gets uploaded to crates.io, such as benchmarks and test directories. `cargo diet` is a tool to remove this stuff by specifying a minimal `include` field in Cargo.toml.

I ran `find . -type f -name "Cargo.toml" -execdir cargo diet \;` and then removed the change for `solana-logger` because it made no difference to what I saw when I ran `cargo package -l`