### PR TITLE
chore: update cargo workspace repository url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
-repository = "https://github.com/anza-xyz/agave"
+repository = "https://github.com/anza-xyz/solana-sdk"
 homepage = "https://anza.xyz/"
 license = "Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
#### problem

repo still points to agave on crates.io

#### changes

update it