### PR TITLE
solana-rent-collector: remove calculation of slots_per_year

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2963,7 +2963,6 @@ dependencies = [
  "solana-hash",
  "solana-inflation",
  "solana-keypair",
- "solana-logger",
  "solana-native-token",
  "solana-poh-config",
  "solana-pubkey",

--- a/genesis-config/Cargo.toml
+++ b/genesis-config/Cargo.toml
@@ -25,7 +25,6 @@ solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-hash = { workspace = true }
 solana-inflation = { workspace = true }
 solana-keypair = { workspace = true }
-solana-logger = { workspace = true }
 solana-native-token = { workspace = true }
 solana-poh-config = { workspace = true }
 solana-pubkey = { workspace = true }

--- a/rent-collector/Cargo.toml
+++ b/rent-collector/Cargo.toml
@@ -17,13 +17,13 @@ solana-clock = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
-solana-genesis-config = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+solana-genesis-config = { workspace = true }
 solana-logger = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 

--- a/rent-collector/src/lib.rs
+++ b/rent-collector/src/lib.rs
@@ -6,7 +6,6 @@ use {
     solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
     solana_clock::Epoch,
     solana_epoch_schedule::EpochSchedule,
-    solana_genesis_config::GenesisConfig,
     solana_pubkey::Pubkey,
     solana_rent::{Rent, RentDue},
     solana_sdk_ids::incinerator,
@@ -27,11 +26,15 @@ pub struct RentCollector {
 
 impl Default for RentCollector {
     fn default() -> Self {
+        // slots_per_year derived from GenesisConfig::default() without calculations
+        // then checked in case it changes
+        let slots_per_year = 78892314.984;
+        #[cfg(test)]
+        assert!(slots_per_year == solana_genesis_config::GenesisConfig::default().slots_per_year());
         Self {
             epoch: Epoch::default(),
             epoch_schedule: EpochSchedule::default(),
-            // derive default value using GenesisConfig::default()
-            slots_per_year: GenesisConfig::default().slots_per_year(),
+            slots_per_year,
             rent: Rent::default(),
         }
     }


### PR DESCRIPTION
When `RentCollector::default()` is called (which can actually happen twice per transaction in SVM [here](https://github.com/anza-xyz/agave/blob/0cfcd4788ff943e4d5e6eee5475ae6e04d102838/svm/src/transaction_processor.rs#L415) and [here](https://github.com/anza-xyz/agave/blob/0cfcd4788ff943e4d5e6eee5475ae6e04d102838/svm/src/transaction_processor.rs#L429)) `GenesisConfig::default()` is called which does a lot of computations, including calling `SystemTime::now()`, but only one constant from it is needed.

This PR removes that call and replaces it with a pre-calculated constant. This constant is checked during testing.

Also removed unnecessary  `solana-logger` dependency from `genesis-config` `Cargo.toml`.