### PR TITLE
rust: Bump version to 1.84.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.84.1"


### PR DESCRIPTION
#### Problem

The rust version used by this repo is still on v1.84.0, despite agave being on v1.84.1.

#### Summary of changes

Bump it to v1.84.1