### PR TITLE
CI: Only get security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,4 @@ updates:
     interval: daily
     time: "08:00"
     timezone: UTC
-  open-pull-requests-limit: 6
+  open-pull-requests-limit: 0


### PR DESCRIPTION
#### Problem

Dependabot updates all versions of packages, which is less flexible for end users. This made sense for agave, which is focused on providing a binary, but libraries are more useful when dependencies are relaxed.

#### Summary of changes

Change the open pull request number to 0 to only enable security updates, as documented at
[Dependabot's documentation](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file)

Fixes #55

cc @kevinheavey