### PR TITLE
feat: add `From<&Pubkey> for Pubkey`

### DIFF
--- a/pubkey/src/lib.rs
+++ b/pubkey/src/lib.rs
@@ -248,6 +248,13 @@ impl FromStr for Pubkey {
     }
 }
 
+impl From<&Pubkey> for Pubkey {
+    #[inline]
+    fn from(value: &Pubkey) -> Self {
+        *value
+    }
+}
+
 impl From<[u8; 32]> for Pubkey {
     #[inline]
     fn from(from: [u8; 32]) -> Self {


### PR DESCRIPTION
`From<&Pubkey>` is required for the `EntryRef::insert` [trait bounds](https://docs.rs/hashbrown/latest/hashbrown/hash_map/enum.EntryRef.html#method.insert) in the hashbrown crate.