### PR TITLE
Make `revise_turbine_epoch_stakes` feature public 

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -676,7 +676,7 @@ pub mod reduce_stake_warmup_cooldown {
     solana_pubkey::declare_id!("GwtDQBghCTBgmX2cpEGNPxTEBUTQRaDMGTr5qychdGMj");
 }
 
-mod revise_turbine_epoch_stakes {
+pub mod revise_turbine_epoch_stakes {
     solana_pubkey::declare_id!("BTWmtJC8U5ZLMbBUUA1k6As62sYjPEjAiNAT55xYGdJU");
 }
 


### PR DESCRIPTION
`solfuzz-agave` uses the feature set defined here to create a list of supported features for fuzzing. Without this change, we cannot add this feature to our supported features list. This is also the only non-public feature that was made private when the feature was cleaned up from the codebase.