### PR TITLE
Fix vote account creation with seed

### DIFF
--- a/vote-interface/src/instruction.rs
+++ b/vote-interface/src/instruction.rs
@@ -286,13 +286,25 @@ pub fn create_account_with_config(
     lamports: u64,
     config: CreateVoteAccountConfig,
 ) -> Vec<Instruction> {
-    let create_ix = solana_system_interface::instruction::create_account(
-        from_pubkey,
-        vote_pubkey,
-        lamports,
-        config.space,
-        &id(),
-    );
+    let create_ix = if let Some((base, seed)) = config.with_seed {
+        solana_system_interface::instruction::create_account_with_seed(
+            from_pubkey,
+            vote_pubkey,
+            base,
+            seed,
+            lamports,
+            config.space,
+            &id(),
+        )
+    } else {
+        solana_system_interface::instruction::create_account(
+            from_pubkey,
+            vote_pubkey,
+            lamports,
+            config.space,
+            &id(),
+        )
+    };
     let init_ix = initialize_account(vote_pubkey, vote_init);
     vec![create_ix, init_ix]
 }


### PR DESCRIPTION
`create_account_with_config` did not properly support account creation using a seed, even though it was intended to. The function now correctly checks for the presence of a seed in `config.with_seed` and calls `create_account_with_seed` when applicable.

Closes https://github.com/anza-xyz/agave/pull/2819