### PR TITLE
Fix a windows compilation issue

### DIFF
--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -137,7 +137,7 @@ pub fn redirect_stderr_to_file(logfile: Option<String>) -> Option<JoinHandle<()>
             #[cfg(not(unix))]
             {
                 println!("logrotate is not supported on this platform");
-                setup_file_with_default(&logfile, solana_logger::DEFAULT_FILTER);
+                setup_file_with_default(&logfile, DEFAULT_FILTER);
                 None
             }
         }


### PR DESCRIPTION
Ran into a comp issue on Windows platform:

140 |                 setup_file_with_default(&logfile, solana_logger::DEFAULT_FILTER);
       |                                                   ^^^^^^^^^^^^^ use of undeclared crate or module `solana_logger`

Maybe we should add windows comp/clippy checks?