### PR TITLE
CI: Run clippy script in bash

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,7 +150,7 @@ jobs:
           echo "PERL=$(which perl)" >> $GITHUB_ENV
           echo "OPENSSL_SRC_PERL=$(which perl)" >> $GITHUB_ENV
           choco install openssl --version 3.4.1 --install-arguments="'/DIR=C:\OpenSSL'" -y
-          echo "OPENSSL_LIB_DIR=\"C:\OpenSSL\lib\VC\x64\MT\"" >> $GITHUB_ENV
+          echo "OPENSSL_LIB_DIR=C:\OpenSSL\lib\VC\x64\MT" >> $GITHUB_ENV
           echo "OPENSSL_INCLUDE_DIR=C:\OpenSSL\include" >> $GITHUB_ENV
 
       - name: Run clippy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,6 +154,7 @@ jobs:
           echo "OPENSSL_INCLUDE_DIR=C:\OpenSSL\include" >> $GITHUB_ENV
 
       - name: Run clippy
+        shell: bash
         run: ./scripts/check-clippy.sh
 
   audit:


### PR DESCRIPTION
#### Problem

The windows CI job doesn't seem to be doing anything, likely because the clippy run step doesn't specify to run it under bash. See a no-op run at https://github.com/anza-xyz/solana-sdk/actions/runs/13663660460/job/38200289091

#### Summary of changes

Run the script under bash rather than the default shell.

NOTE: This should fail CI until #66 lands