### PR TITLE
feature-set: Gate ahash's rng usage for non-solana builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ check-cfg = [
 ]
 
 [workspace.dependencies]
-ahash = "0.8.11"
+ahash = { version = "0.8.11", default-features = false }
 anyhow = "1.0.96"
 arbitrary = "1.4.1"
 ark-bn254 = "0.4.0"

--- a/feature-set/Cargo.toml
+++ b/feature-set/Cargo.toml
@@ -10,7 +10,6 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-ahash = { workspace = true }
 lazy_static = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
@@ -19,8 +18,14 @@ solana-frozen-abi = { workspace = true, optional = true, features = [
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
-solana-hash = { workspace = true }
 solana-pubkey = { workspace = true }
+
+[target.'cfg(target_os = "solana")'.dependencies]
+ahash = { workspace = true, default-features = false, features = ["std", "no-rng"] }
+
+[target.'cfg(not(target_os = "solana"))'.dependencies]
+ahash = { workspace = true, default-features = true }
+solana-hash = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 
 [features]

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -23,9 +23,7 @@ use {
     ahash::{AHashMap, AHashSet},
     lazy_static::lazy_static,
     solana_epoch_schedule::EpochSchedule,
-    solana_hash::Hash,
     solana_pubkey::Pubkey,
-    solana_sha256_hasher::Hasher,
 };
 
 pub mod deprecate_rewards_sysvar {
@@ -1190,10 +1188,13 @@ lazy_static! {
     .iter()
     .cloned()
     .collect();
+}
 
+#[cfg(not(target_os = "solana"))]
+lazy_static! {
     /// Unique identifier of the current software's feature set
-    pub static ref ID: Hash = {
-        let mut hasher = Hasher::default();
+    pub static ref ID: solana_hash::Hash = {
+        let mut hasher = solana_sha256_hasher::Hasher::default();
         let mut feature_ids = FEATURE_NAMES.keys().collect::<Vec<_>>();
         feature_ids.sort();
         for feature in feature_ids {


### PR DESCRIPTION
#### Problem

The secp256r1-program crate has code to support being used with on-chain programs at
https://github.com/anza-xyz/solana-sdk/blob/f58afe952551601f3c7fcf60f371fbb9f38003d8/secp256r1-program/src/lib.rs#L739-L750

Unfortunately, `solana-feature-set` uses `ahash`, which uses `getrandom` by default, so the build fails.

#### Summary of changes

The ahash crate has a `no-rng` feature to disable usage of `getrandom` at
https://github.com/tkaitchuck/aHash/blob/7d5c661a74b12d5bc5448b0b83fdb429190db1a3/Cargo.toml#L40-L42, so use that feature for `solana` builds, and properly gate all hasher usage outside of `solana` builds.

Side-note: let me know if there's someone better to tag for review, but since you did the ahash update, I thought you'd be a good reviewer.