### PR TITLE
CI: Update commit message for cargo-release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,11 @@ check-cfg = [
     'cfg(feature, values("frozen-abi", "no-entrypoint"))',
 ]
 
+[workspace.metadata.release]
+pre-release-commit-message = "Publish {{crate_name}} v{{version}}"
+tag-message = "Publish {{crate_name}} v{{version}}"
+consolidate-commits = false
+
 [workspace.dependencies]
 ahash = "0.8.11"
 anyhow = "1.0.96"


### PR DESCRIPTION
#### Problem

Right now, the publish job uses a default message for the commit and tag message of `chore: Release`, which isn't very descriptive, especially when there are many possible crates to release.

#### Summary of changes

Similar to what was done at SPL, configure `cargo-release` to use a better tag and commit message.

Here's an example commit:
https://github.com/solana-labs/solana-program-library/commit/a85d36141d639da42fb5f9163ca6aadfc60d8326