### PR TITLE
Add the responsible program's account index and inner instruction index to each `InstructionError`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4062,10 +4062,13 @@ version = "2.2.1"
 dependencies = [
  "serde",
  "serde_derive",
+ "serde_json",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-instruction",
+ "solana-pubkey",
  "solana-sanitize",
+ "test-case",
 ]
 
 [[package]]

--- a/transaction-error/Cargo.toml
+++ b/transaction-error/Cargo.toml
@@ -17,7 +17,12 @@ solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-instruction = { workspace = true, default-features = false, features = [
     "std",
 ] }
+solana-pubkey = { workspace = true }
 solana-sanitize = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
+test-case = { workspace = true }
 
 [features]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]

--- a/transaction/src/sanitized.rs
+++ b/transaction/src/sanitized.rs
@@ -298,11 +298,11 @@ impl SanitizedTransaction {
                 self.message().instructions(),
                 feature_set,
             )
-            .map_err(|err| {
-                TransactionError::InstructionError(
-                    index as u8,
-                    solana_instruction::error::InstructionError::Custom(err as u32),
-                )
+            .map_err(|err| TransactionError::InstructionError {
+                err: solana_instruction::error::InstructionError::Custom(err as u32),
+                inner_instruction_index: None,
+                outer_instruction_index: index as u8,
+                responsible_program_address: Some(*program_id),
             })?;
         }
         Ok(())


### PR DESCRIPTION
# Problem

Consider a transaction error that originates from a cross-program invocation (ie. an inner instruction). Currently `TransactionError` returns you the index of the outer instruction, which in no way helps you to correlate the content of the error message with the actual program from whence it came.

# Summary of changes

Added the transaction-level account index of the erroring program to the `TransactionError::InstructionError` variant, which will help consumers correlate instruction errors with their _actual_ source.

The account index of the program is designed to be from the perspective of the transaction and not the perspective of the instruction to make this change safe from [SIMD-163](https://github.com/solana-foundation/solana-improvement-documents/pull/163).

Addresses https://github.com/anza-xyz/agave/issues/5152 and https://github.com/anza-xyz/kit/issues/149.
Blocks https://github.com/anza-xyz/agave/pull/6083.