### PR TITLE
audit: Update ring to 0.17.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2220,15 +2220,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -4083,12 +4082,6 @@ dependencies = [
  "solana-system-interface",
  "solana-vote-interface",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"


### PR DESCRIPTION
#### Problem

There's an audit issue on ring versions below 0.17.12.

#### Summary of changes

Bump ring to 0.17.13.