### PR TITLE
chore(pubkey): (may be) proper serde json support (encode as base58 string, not as array) and json schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3528,7 +3528,7 @@ dependencies = [
 
 [[package]]
 name = "solana-pubkey"
-version = "2.3.0"
+version = "3.0"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,6 +905,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+
+[[package]]
 name = "ed25519"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1177,7 +1183,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1193,6 +1199,12 @@ dependencies = [
  "cfg-if",
  "crunchy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1513,6 +1525,17 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
@@ -1548,7 +1571,7 @@ checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi 0.4.0",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2306,6 +2329,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "indexmap 1.9.3",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2359,6 +2407,17 @@ name = "serde_derive"
 version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3469,7 +3528,7 @@ dependencies = [
 
 [[package]]
 name = "solana-pubkey"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -3484,8 +3543,10 @@ dependencies = [
  "js-sys",
  "num-traits",
  "rand 0.8.5",
+ "schemars",
  "serde",
  "serde_derive",
+ "serde_json",
  "solana-atomic-u64",
  "solana-decode-error",
  "solana-define-syscall",
@@ -4396,7 +4457,7 @@ version = "0.22.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
 dependencies = [
- "indexmap",
+ "indexmap 2.7.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4662,7 +4723,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/pubkey/Cargo.toml
+++ b/pubkey/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-pubkey"
 description = "Solana account addresses"
 documentation = "https://docs.rs/solana-pubkey"
-version = "2.2.1"
+version = "2.3.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
@@ -19,6 +19,7 @@ bytemuck_derive = { workspace = true, optional = true }
 five8_const = { workspace = true }
 num-traits = { workspace = true }
 rand = { workspace = true, optional = true }
+schemars = { version = "0.8", default-features = false, optional = true, features = ["derive", "preserve_order"] }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 solana-atomic-u64 = { workspace = true }
@@ -48,6 +49,7 @@ wasm-bindgen = { workspace = true }
 anyhow = { workspace = true }
 arbitrary = { workspace = true, features = ["derive"] }
 bs58 = { workspace = true, features = ["alloc"] }
+serde_json = { workspace = true }
 # circular dev deps need to be path deps for `cargo publish` to be happy,
 # and for now the doc tests need solana-program
 solana-program = { path = "../program" }
@@ -72,7 +74,8 @@ frozen-abi = [
     "std",
 ]
 rand = ["dep:rand", "std"]
-serde = ["dep:serde", "dep:serde_derive"]
+schemars = ["dep:schemars", "serde", "std"]
+serde = ["dep:serde", "dep:serde_derive", "bs58/alloc"]
 sha2 = ["dep:solana-sha256-hasher", "solana-sha256-hasher/sha2"]
 std = []
 

--- a/pubkey/Cargo.toml
+++ b/pubkey/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-pubkey"
 description = "Solana account addresses"
 documentation = "https://docs.rs/solana-pubkey"
-version = "2.3.0"
+version = "3.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }


### PR DESCRIPTION
- wasm, display, debug are base58 encoded. so serde json to be too
- json schema for serde
- some hopefully proper alloc/std shuffling (as forced by serde impl)
- because breaking, bumped +1 major version

not sure: is anybody uses serde for not json? like if anybody needs serde to array instead of base58 string? anyway, bumped major. also assuming binary can impl serde manually, while json expect convenience (especially in public apis) 