### PR TITLE
feature-set: Rekeys accounts_lt_hash

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -905,7 +905,7 @@ pub mod enable_secp256r1_precompile {
 }
 
 pub mod accounts_lt_hash {
-    solana_pubkey::declare_id!("LtHaSHHsUge7EWTPVrmpuexKz6uVHZXZL6cgJa7W7Zn");
+    solana_pubkey::declare_id!("LTHasHQX6661DaDD4S6A2TFi6QBuiwXKv66fB1obfHq");
 }
 
 pub mod snapshots_lt_hash {


### PR DESCRIPTION
The code implementing SIMD-215 did not match the actual SIMD text, so we need to update the code. Since the feature gate is already in a release (v2.2), we need to rekey it.

Refer to https://github.com/anza-xyz/agave/pull/5336 for more information.