### PR TITLE
add solana-feature-set-interface crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2898,6 +2898,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-feature-set-interface"
+version = "2.2.4"
+dependencies = [
+ "ahash",
+ "solana-epoch-schedule",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-hash",
+ "solana-pubkey",
+ "solana-sha256-hasher",
+]
+
+[[package]]
 name = "solana-fee-calculator"
 version = "2.2.1"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2902,12 +2902,9 @@ name = "solana-feature-set-interface"
 version = "2.2.4"
 dependencies = [
  "ahash",
- "solana-epoch-schedule",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-hash",
  "solana-pubkey",
- "solana-sha256-hasher",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "example-mocks",
     "feature-gate-interface",
     "feature-set",
+    "feature-set-interface",
     "fee-calculator",
     "fee-structure",
     "file-download",
@@ -234,6 +235,7 @@ solana-epoch-schedule = { path = "epoch-schedule", version = "2.2.1" }
 solana-example-mocks = { path = "example-mocks", version = "2.2.1" }
 solana-feature-gate-interface = { path = "feature-gate-interface", version = "2.2.1" }
 solana-feature-set = { path = "feature-set", version = "2.2.4" }
+solana-feature-set-interface = { path = "feature-set-interface", version = "2.2.4" }
 solana-fee-calculator = { path = "fee-calculator", version = "2.2.1" }
 solana-fee-structure = { path = "fee-structure", version = "2.2.1" }
 solana-frozen-abi = { path = "frozen-abi", version = "2.2.1" }

--- a/feature-set-interface/Cargo.toml
+++ b/feature-set-interface/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "solana-feature-set-interface"
+description = "Interface for Solana runtime features."
+documentation = "https://docs.rs/solana-feature-set-interface"
+version = "2.2.4"
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+ahash = { workspace = true }
+solana-epoch-schedule = { workspace = true }
+solana-frozen-abi = { workspace = true, optional = true, features = [
+    "frozen-abi",
+] }
+solana-frozen-abi-macro = { workspace = true, optional = true, features = [
+    "frozen-abi",
+] }
+solana-hash = { workspace = true }
+solana-pubkey = { workspace = true }
+solana-sha256-hasher = { workspace = true }
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lints]
+workspace = true

--- a/feature-set-interface/Cargo.toml
+++ b/feature-set-interface/Cargo.toml
@@ -11,16 +11,13 @@ edition = { workspace = true }
 
 [dependencies]
 ahash = { workspace = true }
-solana-epoch-schedule = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
-solana-hash = { workspace = true }
 solana-pubkey = { workspace = true }
-solana-sha256-hasher = { workspace = true }
 
 [features]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]

--- a/feature-set-interface/src/lib.rs
+++ b/feature-set-interface/src/lib.rs
@@ -1,0 +1,75 @@
+//! Collection of all runtime features.
+//!
+//! Steps to add a new feature are outlined below. Note that these steps only cover
+//! the process of getting a feature into the core Solana code.
+//! - For features that are unambiguously good (ie bug fixes), these steps are sufficient.
+//! - For features that should go up for community vote (ie fee structure changes), more
+//!   information on the additional steps to follow can be found at:
+//!   <https://spl.solana.com/feature-proposal#feature-proposal-life-cycle>
+//!
+//! 1. Generate a new keypair with `solana-keygen new --outfile feature.json --no-passphrase`
+//!    - Keypairs should be held by core contributors only. If you're a non-core contributor going
+//!      through these steps, the PR process will facilitate a keypair holder being picked. That
+//!      person will generate the keypair, provide pubkey for PR, and ultimately enable the feature.
+//! 2. Add a public module for the feature, specifying keypair pubkey as the id with
+//!    `solana_pubkey::declare_id!()` within the module.
+//!    Additionally, add an entry to `FEATURE_NAMES` map.
+//! 3. Add desired logic to check for and switch on feature availability.
+//!
+//! For more information on how features are picked up, see comments for `Feature`.
+#![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
+
+use {
+    ahash::{AHashMap, AHashSet},
+    solana_pubkey::Pubkey,
+};
+
+/// `FeatureSet` holds the set of currently active/inactive runtime features
+#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct FeatureSet {
+    pub active: AHashMap<Pubkey, u64>,
+    pub inactive: AHashSet<Pubkey>,
+}
+
+impl FeatureSet {
+    pub fn is_active(&self, feature_id: &Pubkey) -> bool {
+        self.active.contains_key(feature_id)
+    }
+
+    pub fn activated_slot(&self, feature_id: &Pubkey) -> Option<u64> {
+        self.active.get(feature_id).copied()
+    }
+
+    /// Activate a feature
+    pub fn activate(&mut self, feature_id: &Pubkey, slot: u64) {
+        self.inactive.remove(feature_id);
+        self.active.insert(*feature_id, slot);
+    }
+
+    /// Deactivate a feature
+    pub fn deactivate(&mut self, feature_id: &Pubkey) {
+        self.active.remove(feature_id);
+        self.inactive.insert(*feature_id);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_feature_set_activate_deactivate() {
+        let mut feature_set = FeatureSet {
+            active: AHashMap::new(),
+            inactive: AHashSet::new(),
+        };
+
+        let feature = Pubkey::new_unique();
+        assert!(!feature_set.is_active(&feature));
+        feature_set.activate(&feature, 0);
+        assert!(feature_set.is_active(&feature));
+        feature_set.deactivate(&feature);
+        assert!(!feature_set.is_active(&feature));
+    }
+}

--- a/feature-set-interface/src/lib.rs
+++ b/feature-set-interface/src/lib.rs
@@ -1,22 +1,3 @@
-//! Collection of all runtime features.
-//!
-//! Steps to add a new feature are outlined below. Note that these steps only cover
-//! the process of getting a feature into the core Solana code.
-//! - For features that are unambiguously good (ie bug fixes), these steps are sufficient.
-//! - For features that should go up for community vote (ie fee structure changes), more
-//!   information on the additional steps to follow can be found at:
-//!   <https://spl.solana.com/feature-proposal#feature-proposal-life-cycle>
-//!
-//! 1. Generate a new keypair with `solana-keygen new --outfile feature.json --no-passphrase`
-//!    - Keypairs should be held by core contributors only. If you're a non-core contributor going
-//!      through these steps, the PR process will facilitate a keypair holder being picked. That
-//!      person will generate the keypair, provide pubkey for PR, and ultimately enable the feature.
-//! 2. Add a public module for the feature, specifying keypair pubkey as the id with
-//!    `solana_pubkey::declare_id!()` within the module.
-//!    Additionally, add an entry to `FEATURE_NAMES` map.
-//! 3. Add desired logic to check for and switch on feature availability.
-//!
-//! For more information on how features are picked up, see comments for `Feature`.
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 
 use {


### PR DESCRIPTION
step one of monorepo reclaiming the feature-set

this takes a copy of all generic symbols from solana-feature-set. we will wrap it in a new crate with the agave/cluster-specific symbols declared

possible that we don't want this at all and should just take a full copy back to monorepo