### PR TITLE
move less important methods from Sysvar to SysvarSerialize

### DIFF
--- a/account/src/lib.rs
+++ b/account/src/lib.rs
@@ -759,7 +759,10 @@ pub fn from_account<S: SysvarSerialize, T: ReadableAccount>(account: &T) -> Opti
 
 #[cfg(feature = "bincode")]
 /// Serialize a `Sysvar` into an `Account`'s data.
-pub fn to_account<S: SysvarSerialize, T: WritableAccount>(sysvar: &S, account: &mut T) -> Option<()> {
+pub fn to_account<S: SysvarSerialize, T: WritableAccount>(
+    sysvar: &S,
+    account: &mut T,
+) -> Option<()> {
     bincode::serialize_into(account.data_as_mut_slice(), sysvar).ok()
 }
 

--- a/account/src/lib.rs
+++ b/account/src/lib.rs
@@ -9,7 +9,7 @@ use serde::ser::{Serialize, Serializer};
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::{frozen_abi, AbiExample};
 #[cfg(feature = "bincode")]
-use solana_sysvar::Sysvar;
+use solana_sysvar::SysvarSerialize;
 use {
     solana_account_info::{debug_account_data::*, AccountInfo},
     solana_clock::{Epoch, INITIAL_RENT_EPOCH},
@@ -718,7 +718,7 @@ pub type InheritableAccountFields = (u64, Epoch);
 pub const DUMMY_INHERITABLE_ACCOUNT_FIELDS: InheritableAccountFields = (1, INITIAL_RENT_EPOCH);
 
 #[cfg(feature = "bincode")]
-pub fn create_account_with_fields<S: Sysvar>(
+pub fn create_account_with_fields<S: SysvarSerialize>(
     sysvar: &S,
     (lamports, rent_epoch): InheritableAccountFields,
 ) -> Account {
@@ -730,13 +730,13 @@ pub fn create_account_with_fields<S: Sysvar>(
 }
 
 #[cfg(feature = "bincode")]
-pub fn create_account_for_test<S: Sysvar>(sysvar: &S) -> Account {
+pub fn create_account_for_test<S: SysvarSerialize>(sysvar: &S) -> Account {
     create_account_with_fields(sysvar, DUMMY_INHERITABLE_ACCOUNT_FIELDS)
 }
 
 #[cfg(feature = "bincode")]
 /// Create an `Account` from a `Sysvar`.
-pub fn create_account_shared_data_with_fields<S: Sysvar>(
+pub fn create_account_shared_data_with_fields<S: SysvarSerialize>(
     sysvar: &S,
     fields: InheritableAccountFields,
 ) -> AccountSharedData {
@@ -744,7 +744,7 @@ pub fn create_account_shared_data_with_fields<S: Sysvar>(
 }
 
 #[cfg(feature = "bincode")]
-pub fn create_account_shared_data_for_test<S: Sysvar>(sysvar: &S) -> AccountSharedData {
+pub fn create_account_shared_data_for_test<S: SysvarSerialize>(sysvar: &S) -> AccountSharedData {
     AccountSharedData::from(create_account_with_fields(
         sysvar,
         DUMMY_INHERITABLE_ACCOUNT_FIELDS,
@@ -753,13 +753,13 @@ pub fn create_account_shared_data_for_test<S: Sysvar>(sysvar: &S) -> AccountShar
 
 #[cfg(feature = "bincode")]
 /// Create a `Sysvar` from an `Account`'s data.
-pub fn from_account<S: Sysvar, T: ReadableAccount>(account: &T) -> Option<S> {
+pub fn from_account<S: SysvarSerialize, T: ReadableAccount>(account: &T) -> Option<S> {
     bincode::deserialize(account.data()).ok()
 }
 
 #[cfg(feature = "bincode")]
 /// Serialize a `Sysvar` into an `Account`'s data.
-pub fn to_account<S: Sysvar, T: WritableAccount>(sysvar: &S, account: &mut T) -> Option<()> {
+pub fn to_account<S: SysvarSerialize, T: WritableAccount>(sysvar: &S, account: &mut T) -> Option<()> {
     bincode::serialize_into(account.data_as_mut_slice(), sysvar).ok()
 }
 

--- a/program/src/sysvar.rs
+++ b/program/src/sysvar.rs
@@ -6,7 +6,7 @@ pub use {
     solana_sdk_ids::sysvar::{check_id, id, ID},
     solana_sysvar::{
         clock, epoch_rewards, epoch_schedule, fees, last_restart_slot, recent_blockhashes, rent,
-        rewards, slot_hashes, slot_history, stake_history, Sysvar,
+        rewards, slot_hashes, slot_history, stake_history, Sysvar, SysvarSerialize,
     },
 };
 

--- a/sysvar/src/clock.rs
+++ b/sysvar/src/clock.rs
@@ -122,16 +122,16 @@
 //! ```
 
 #[cfg(feature = "bincode")]
-use crate::Sysvar;
-use crate::{impl_sysvar_get, SysvarGet};
+use crate::SysvarSerialize;
+use crate::{impl_sysvar_get, Sysvar};
 pub use {
     solana_clock::Clock,
     solana_sdk_ids::sysvar::clock::{check_id, id, ID},
 };
 
-impl SysvarGet for Clock {
+impl Sysvar for Clock {
     impl_sysvar_get!(sol_get_clock_sysvar);
 }
 
 #[cfg(feature = "bincode")]
-impl Sysvar for Clock {}
+impl SysvarSerialize for Clock {}

--- a/sysvar/src/clock.rs
+++ b/sysvar/src/clock.rs
@@ -57,7 +57,7 @@
 //! # use solana_msg::msg;
 //! # use solana_program_error::{ProgramError, ProgramResult};
 //! # use solana_pubkey::Pubkey;
-//! # use solana_sysvar::Sysvar;
+//! # use solana_sysvar::{Sysvar, SysvarSerialize};
 //! # use solana_sdk_ids::sysvar::clock;
 //! #
 //! fn process_instruction(

--- a/sysvar/src/clock.rs
+++ b/sysvar/src/clock.rs
@@ -122,13 +122,16 @@
 //! ```
 
 #[cfg(feature = "bincode")]
-use crate::{impl_sysvar_get, Sysvar};
+use crate::Sysvar;
+use crate::{impl_sysvar_get, SysvarGet};
 pub use {
     solana_clock::Clock,
     solana_sdk_ids::sysvar::clock::{check_id, id, ID},
 };
 
-#[cfg(feature = "bincode")]
-impl Sysvar for Clock {
+impl SysvarGet for Clock {
     impl_sysvar_get!(sol_get_clock_sysvar);
 }
+
+#[cfg(feature = "bincode")]
+impl Sysvar for Clock {}

--- a/sysvar/src/epoch_rewards.rs
+++ b/sysvar/src/epoch_rewards.rs
@@ -155,13 +155,16 @@
 //! ```
 
 #[cfg(feature = "bincode")]
-use crate::{impl_sysvar_get, Sysvar};
+use crate::Sysvar;
+use crate::{impl_sysvar_get, SysvarGet};
 pub use {
     solana_epoch_rewards::EpochRewards,
     solana_sdk_ids::sysvar::epoch_rewards::{check_id, id, ID},
 };
 
-#[cfg(feature = "bincode")]
-impl Sysvar for EpochRewards {
+impl SysvarGet for EpochRewards {
     impl_sysvar_get!(sol_get_epoch_rewards_sysvar);
 }
+
+#[cfg(feature = "bincode")]
+impl Sysvar for EpochRewards {}

--- a/sysvar/src/epoch_rewards.rs
+++ b/sysvar/src/epoch_rewards.rs
@@ -155,16 +155,16 @@
 //! ```
 
 #[cfg(feature = "bincode")]
-use crate::Sysvar;
-use crate::{impl_sysvar_get, SysvarGet};
+use crate::SysvarSerialize;
+use crate::{impl_sysvar_get, Sysvar};
 pub use {
     solana_epoch_rewards::EpochRewards,
     solana_sdk_ids::sysvar::epoch_rewards::{check_id, id, ID},
 };
 
-impl SysvarGet for EpochRewards {
+impl Sysvar for EpochRewards {
     impl_sysvar_get!(sol_get_epoch_rewards_sysvar);
 }
 
 #[cfg(feature = "bincode")]
-impl Sysvar for EpochRewards {}
+impl SysvarSerialize for EpochRewards {}

--- a/sysvar/src/epoch_rewards.rs
+++ b/sysvar/src/epoch_rewards.rs
@@ -75,7 +75,7 @@
 //! # use solana_msg::msg;
 //! # use solana_program_error::{ProgramError, ProgramResult};
 //! # use solana_pubkey::Pubkey;
-//! # use solana_sysvar::Sysvar;
+//! # use solana_sysvar::{Sysvar, SysvarSerialize};
 //! # use solana_sdk_ids::sysvar::epoch_rewards;
 //! #
 //! fn process_instruction(

--- a/sysvar/src/epoch_schedule.rs
+++ b/sysvar/src/epoch_schedule.rs
@@ -120,13 +120,16 @@
 //! # Ok::<(), anyhow::Error>(())
 //! ```
 #[cfg(feature = "bincode")]
-use crate::{impl_sysvar_get, Sysvar};
+use crate::Sysvar;
+use crate::{impl_sysvar_get, SysvarGet};
 pub use {
     solana_epoch_schedule::EpochSchedule,
     solana_sdk_ids::sysvar::epoch_schedule::{check_id, id, ID},
 };
 
-#[cfg(feature = "bincode")]
-impl Sysvar for EpochSchedule {
+impl SysvarGet for EpochSchedule {
     impl_sysvar_get!(sol_get_epoch_schedule_sysvar);
 }
+
+#[cfg(feature = "bincode")]
+impl Sysvar for EpochSchedule {}

--- a/sysvar/src/epoch_schedule.rs
+++ b/sysvar/src/epoch_schedule.rs
@@ -120,16 +120,16 @@
 //! # Ok::<(), anyhow::Error>(())
 //! ```
 #[cfg(feature = "bincode")]
-use crate::Sysvar;
-use crate::{impl_sysvar_get, SysvarGet};
+use crate::SysvarSerialize;
+use crate::{impl_sysvar_get, Sysvar};
 pub use {
     solana_epoch_schedule::EpochSchedule,
     solana_sdk_ids::sysvar::epoch_schedule::{check_id, id, ID},
 };
 
-impl SysvarGet for EpochSchedule {
+impl Sysvar for EpochSchedule {
     impl_sysvar_get!(sol_get_epoch_schedule_sysvar);
 }
 
 #[cfg(feature = "bincode")]
-impl Sysvar for EpochSchedule {}
+impl SysvarSerialize for EpochSchedule {}

--- a/sysvar/src/epoch_schedule.rs
+++ b/sysvar/src/epoch_schedule.rs
@@ -58,7 +58,7 @@
 //! # use solana_program_error::{ProgramError, ProgramResult};
 //! # use solana_pubkey::Pubkey;
 //! # use solana_sdk_ids::sysvar::epoch_schedule;
-//! # use solana_sysvar::Sysvar;
+//! # use solana_sysvar::{Sysvar, SysvarSerialize};
 //! fn process_instruction(
 //!     program_id: &Pubkey,
 //!     accounts: &[AccountInfo],

--- a/sysvar/src/fees.rs
+++ b/sysvar/src/fees.rs
@@ -21,12 +21,14 @@
 #![allow(deprecated)]
 
 #[cfg(feature = "bincode")]
-use crate::{impl_sysvar_get, Sysvar};
+use crate::Sysvar;
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
 pub use solana_sdk_ids::sysvar::fees::{check_id, id, ID};
 use {
-    solana_fee_calculator::FeeCalculator, solana_sdk_macro::CloneZeroed,
+    crate::{impl_sysvar_get, SysvarGet},
+    solana_fee_calculator::FeeCalculator,
+    solana_sdk_macro::CloneZeroed,
     solana_sysvar_id::impl_deprecated_sysvar_id,
 };
 
@@ -53,10 +55,12 @@ impl Fees {
     }
 }
 
-#[cfg(feature = "bincode")]
-impl Sysvar for Fees {
+impl SysvarGet for Fees {
     impl_sysvar_get!(sol_get_fees_sysvar);
 }
+
+#[cfg(feature = "bincode")]
+impl Sysvar for Fees {}
 
 #[cfg(test)]
 mod tests {

--- a/sysvar/src/fees.rs
+++ b/sysvar/src/fees.rs
@@ -21,12 +21,12 @@
 #![allow(deprecated)]
 
 #[cfg(feature = "bincode")]
-use crate::Sysvar;
+use crate::SysvarSerialize;
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
 pub use solana_sdk_ids::sysvar::fees::{check_id, id, ID};
 use {
-    crate::{impl_sysvar_get, SysvarGet},
+    crate::{impl_sysvar_get, Sysvar},
     solana_fee_calculator::FeeCalculator,
     solana_sdk_macro::CloneZeroed,
     solana_sysvar_id::impl_deprecated_sysvar_id,
@@ -55,12 +55,12 @@ impl Fees {
     }
 }
 
-impl SysvarGet for Fees {
+impl Sysvar for Fees {
     impl_sysvar_get!(sol_get_fees_sysvar);
 }
 
 #[cfg(feature = "bincode")]
-impl Sysvar for Fees {}
+impl SysvarSerialize for Fees {}
 
 #[cfg(test)]
 mod tests {

--- a/sysvar/src/last_restart_slot.rs
+++ b/sysvar/src/last_restart_slot.rs
@@ -37,16 +37,16 @@
 //! ```
 //!
 #[cfg(feature = "bincode")]
-use crate::Sysvar;
-use crate::{impl_sysvar_get, SysvarGet};
+use crate::SysvarSerialize;
+use crate::{impl_sysvar_get, Sysvar};
 pub use {
     solana_last_restart_slot::LastRestartSlot,
     solana_sdk_ids::sysvar::last_restart_slot::{check_id, id, ID},
 };
 
-impl SysvarGet for LastRestartSlot {
+impl Sysvar for LastRestartSlot {
     impl_sysvar_get!(sol_get_last_restart_slot);
 }
 
 #[cfg(feature = "bincode")]
-impl Sysvar for LastRestartSlot {}
+impl SysvarSerialize for LastRestartSlot {}

--- a/sysvar/src/last_restart_slot.rs
+++ b/sysvar/src/last_restart_slot.rs
@@ -37,13 +37,16 @@
 //! ```
 //!
 #[cfg(feature = "bincode")]
-use crate::{impl_sysvar_get, Sysvar};
+use crate::Sysvar;
+use crate::{impl_sysvar_get, SysvarGet};
 pub use {
     solana_last_restart_slot::LastRestartSlot,
     solana_sdk_ids::sysvar::last_restart_slot::{check_id, id, ID},
 };
 
-#[cfg(feature = "bincode")]
-impl Sysvar for LastRestartSlot {
+impl SysvarGet for LastRestartSlot {
     impl_sysvar_get!(sol_get_last_restart_slot);
 }
+
+#[cfg(feature = "bincode")]
+impl Sysvar for LastRestartSlot {}

--- a/sysvar/src/lib.rs
+++ b/sysvar/src/lib.rs
@@ -83,9 +83,9 @@ pub mod __private {
     pub use solana_define_syscall::definitions;
     pub use {solana_program_entrypoint::SUCCESS, solana_program_error::ProgramError};
 }
-use {solana_pubkey::Pubkey, solana_program_error::ProgramError};
 #[cfg(feature = "bincode")]
 use {solana_account_info::AccountInfo, solana_sysvar_id::SysvarId};
+use {solana_program_error::ProgramError, solana_pubkey::Pubkey};
 
 pub mod clock;
 pub mod epoch_rewards;

--- a/sysvar/src/lib.rs
+++ b/sysvar/src/lib.rs
@@ -128,9 +128,7 @@ pub trait SysvarGet: Default + Sized {
 
 #[cfg(feature = "bincode")]
 /// A type that holds sysvar data.
-pub trait Sysvar:
-    SysvarGet + SysvarId + serde::Serialize + serde::de::DeserializeOwned
-{
+pub trait Sysvar: SysvarGet + SysvarId + serde::Serialize + serde::de::DeserializeOwned {
     /// The size in bytes of the sysvar as serialized account data.
     fn size_of() -> usize {
         bincode::serialized_size(&Self::default()).unwrap() as usize

--- a/sysvar/src/lib.rs
+++ b/sysvar/src/lib.rs
@@ -31,7 +31,7 @@
 //!
 //! Since Solana sysvars are accounts, if the `AccountInfo` is provided to the
 //! program, then the program can deserialize the sysvar with
-//! [`Sysvar::from_account_info`] to access its data, as in this example that
+//! [`SysvarSerialize::from_account_info`] to access its data, as in this example that
 //! again logs the [`clock`] sysvar.
 //!
 //! ```
@@ -158,7 +158,7 @@ pub trait SysvarSerialize:
         bincode::serialize_into(&mut account_info.data.borrow_mut()[..], self).ok()
     }
 
-    /// Calls [`SysvarGet::get`].
+    /// Calls [`Sysvar::get`].
     fn get() -> Result<Self, ProgramError> {
         <Self as Sysvar>::get()
     }

--- a/sysvar/src/lib.rs
+++ b/sysvar/src/lib.rs
@@ -128,7 +128,9 @@ pub trait Sysvar: Default + Sized {
 
 #[cfg(feature = "bincode")]
 /// A type that holds sysvar data.
-pub trait SysvarSerialize: Sysvar + SysvarId + serde::Serialize + serde::de::DeserializeOwned {
+pub trait SysvarSerialize:
+    Sysvar + SysvarId + serde::Serialize + serde::de::DeserializeOwned
+{
     /// The size in bytes of the sysvar as serialized account data.
     fn size_of() -> usize {
         bincode::serialized_size(&Self::default()).unwrap() as usize

--- a/sysvar/src/lib.rs
+++ b/sysvar/src/lib.rs
@@ -37,7 +37,7 @@
 //! ```
 //! use solana_account_info::{AccountInfo, next_account_info};
 //! use solana_msg::msg;
-//! use solana_sysvar::Sysvar;
+//! use solana_sysvar::{Sysvar, SysvarSerialize};
 //! use solana_program_error::ProgramResult;
 //! use solana_pubkey::Pubkey;
 //!

--- a/sysvar/src/lib.rs
+++ b/sysvar/src/lib.rs
@@ -112,7 +112,7 @@ const OFFSET_LENGTH_EXCEEDS_SYSVAR: u64 = 1;
 const SYSVAR_NOT_FOUND: u64 = 2;
 
 /// Interface for loading a sysvar.
-pub trait SysvarGet: Sized {
+pub trait SysvarGet: Default + Sized {
     /// Load the sysvar directly from the runtime.
     ///
     /// This is the preferred way to load a sysvar. Calling this method does not
@@ -129,7 +129,7 @@ pub trait SysvarGet: Sized {
 #[cfg(feature = "bincode")]
 /// A type that holds sysvar data.
 pub trait Sysvar:
-    SysvarGet + SysvarId + Default + serde::Serialize + serde::de::DeserializeOwned
+    SysvarGet + SysvarId + serde::Serialize + serde::de::DeserializeOwned
 {
     /// The size in bytes of the sysvar as serialized account data.
     fn size_of() -> usize {

--- a/sysvar/src/lib.rs
+++ b/sysvar/src/lib.rs
@@ -112,7 +112,7 @@ const OFFSET_LENGTH_EXCEEDS_SYSVAR: u64 = 1;
 const SYSVAR_NOT_FOUND: u64 = 2;
 
 /// Interface for loading a sysvar.
-pub trait SysvarGet: Default + Sized {
+pub trait Sysvar: Default + Sized {
     /// Load the sysvar directly from the runtime.
     ///
     /// This is the preferred way to load a sysvar. Calling this method does not
@@ -128,7 +128,7 @@ pub trait SysvarGet: Default + Sized {
 
 #[cfg(feature = "bincode")]
 /// A type that holds sysvar data.
-pub trait Sysvar: SysvarGet + SysvarId + serde::Serialize + serde::de::DeserializeOwned {
+pub trait SysvarSerialize: Sysvar + SysvarId + serde::Serialize + serde::de::DeserializeOwned {
     /// The size in bytes of the sysvar as serialized account data.
     fn size_of() -> usize {
         bincode::serialized_size(&Self::default()).unwrap() as usize
@@ -158,7 +158,7 @@ pub trait Sysvar: SysvarGet + SysvarId + serde::Serialize + serde::de::Deseriali
 
     /// Calls [`SysvarGet::get`].
     fn get() -> Result<Self, ProgramError> {
-        <Self as SysvarGet>::get()
+        <Self as Sysvar>::get()
     }
 }
 
@@ -246,8 +246,8 @@ mod tests {
             check_id(pubkey)
         }
     }
-    impl SysvarGet for TestSysvar {}
     impl Sysvar for TestSysvar {}
+    impl SysvarSerialize for TestSysvar {}
 
     // NOTE tests that use this mock MUST carry the #[serial] attribute
     struct MockGetSysvarSyscall {

--- a/sysvar/src/lib.rs
+++ b/sysvar/src/lib.rs
@@ -157,11 +157,6 @@ pub trait SysvarSerialize:
     fn to_account_info(&self, account_info: &mut AccountInfo) -> Option<()> {
         bincode::serialize_into(&mut account_info.data.borrow_mut()[..], self).ok()
     }
-
-    /// Calls [`Sysvar::get`].
-    fn get() -> Result<Self, ProgramError> {
-        <Self as Sysvar>::get()
-    }
 }
 
 /// Implements the [`Sysvar::get`] method for both SBF and host targets.

--- a/sysvar/src/program_stubs.rs
+++ b/sysvar/src/program_stubs.rs
@@ -155,12 +155,10 @@ pub(crate) fn sol_get_sysvar(
         .sol_get_sysvar(sysvar_id_addr, var_addr, offset, length)
 }
 
-#[cfg(feature = "bincode")]
 pub(crate) fn sol_get_clock_sysvar(var_addr: *mut u8) -> u64 {
     SYSCALL_STUBS.read().unwrap().sol_get_clock_sysvar(var_addr)
 }
 
-#[cfg(feature = "bincode")]
 pub(crate) fn sol_get_epoch_schedule_sysvar(var_addr: *mut u8) -> u64 {
     SYSCALL_STUBS
         .read()
@@ -168,17 +166,14 @@ pub(crate) fn sol_get_epoch_schedule_sysvar(var_addr: *mut u8) -> u64 {
         .sol_get_epoch_schedule_sysvar(var_addr)
 }
 
-#[cfg(feature = "bincode")]
 pub(crate) fn sol_get_fees_sysvar(var_addr: *mut u8) -> u64 {
     SYSCALL_STUBS.read().unwrap().sol_get_fees_sysvar(var_addr)
 }
 
-#[cfg(feature = "bincode")]
 pub(crate) fn sol_get_rent_sysvar(var_addr: *mut u8) -> u64 {
     SYSCALL_STUBS.read().unwrap().sol_get_rent_sysvar(var_addr)
 }
 
-#[cfg(feature = "bincode")]
 pub(crate) fn sol_get_last_restart_slot(var_addr: *mut u8) -> u64 {
     SYSCALL_STUBS
         .read()
@@ -216,7 +211,6 @@ pub fn sol_get_stack_height() -> u64 {
     SYSCALL_STUBS.read().unwrap().sol_get_stack_height()
 }
 
-#[cfg(feature = "bincode")]
 pub(crate) fn sol_get_epoch_rewards_sysvar(var_addr: *mut u8) -> u64 {
     SYSCALL_STUBS
         .read()

--- a/sysvar/src/recent_blockhashes.rs
+++ b/sysvar/src/recent_blockhashes.rs
@@ -19,12 +19,12 @@
 #![allow(deprecated)]
 #![allow(clippy::arithmetic_side_effects)]
 #[cfg(feature = "bincode")]
-use crate::Sysvar;
+use crate::SysvarSerialize;
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
 pub use solana_sdk_ids::sysvar::recent_blockhashes::{check_id, id, ID};
 use {
-    crate::SysvarGet,
+    crate::Sysvar,
     solana_fee_calculator::FeeCalculator,
     solana_hash::Hash,
     solana_sysvar_id::impl_sysvar_id,
@@ -151,10 +151,10 @@ impl<T: Ord> Iterator for IntoIterSorted<T> {
     }
 }
 
-impl SysvarGet for RecentBlockhashes {}
+impl Sysvar for RecentBlockhashes {}
 
 #[cfg(feature = "bincode")]
-impl Sysvar for RecentBlockhashes {
+impl SysvarSerialize for RecentBlockhashes {
     fn size_of() -> usize {
         // hard-coded so that we don't have to construct an empty
         6008 // golden, update if MAX_ENTRIES changes

--- a/sysvar/src/recent_blockhashes.rs
+++ b/sysvar/src/recent_blockhashes.rs
@@ -24,6 +24,7 @@ use crate::Sysvar;
 use serde_derive::{Deserialize, Serialize};
 pub use solana_sdk_ids::sysvar::recent_blockhashes::{check_id, id, ID};
 use {
+    crate::SysvarGet,
     solana_fee_calculator::FeeCalculator,
     solana_hash::Hash,
     solana_sysvar_id::impl_sysvar_id,
@@ -149,6 +150,8 @@ impl<T: Ord> Iterator for IntoIterSorted<T> {
         (exact, Some(exact))
     }
 }
+
+impl SysvarGet for RecentBlockhashes {}
 
 #[cfg(feature = "bincode")]
 impl Sysvar for RecentBlockhashes {

--- a/sysvar/src/rent.rs
+++ b/sysvar/src/rent.rs
@@ -122,15 +122,15 @@
 //! # Ok::<(), anyhow::Error>(())
 //! ```
 #[cfg(feature = "bincode")]
-use crate::Sysvar;
-use crate::{impl_sysvar_get, SysvarGet};
+use crate::SysvarSerialize;
+use crate::{impl_sysvar_get, Sysvar};
 pub use {
     solana_rent::Rent,
     solana_sdk_ids::sysvar::rent::{check_id, id, ID},
 };
-impl SysvarGet for Rent {
+impl Sysvar for Rent {
     impl_sysvar_get!(sol_get_rent_sysvar);
 }
 
 #[cfg(feature = "bincode")]
-impl Sysvar for Rent {}
+impl SysvarSerialize for Rent {}

--- a/sysvar/src/rent.rs
+++ b/sysvar/src/rent.rs
@@ -122,13 +122,15 @@
 //! # Ok::<(), anyhow::Error>(())
 //! ```
 #[cfg(feature = "bincode")]
-use crate::{impl_sysvar_get, Sysvar};
+use crate::Sysvar;
+use crate::{impl_sysvar_get, SysvarGet};
 pub use {
     solana_rent::Rent,
     solana_sdk_ids::sysvar::rent::{check_id, id, ID},
 };
-
-#[cfg(feature = "bincode")]
-impl Sysvar for Rent {
+impl SysvarGet for Rent {
     impl_sysvar_get!(sol_get_rent_sysvar);
 }
+
+#[cfg(feature = "bincode")]
+impl Sysvar for Rent {}

--- a/sysvar/src/rent.rs
+++ b/sysvar/src/rent.rs
@@ -55,7 +55,7 @@
 //! ```
 //! # use solana_account_info::{AccountInfo, next_account_info};
 //! # use solana_msg::msg;
-//! # use solana_sysvar::Sysvar;
+//! # use solana_sysvar::{Sysvar, SysvarSerialize};
 //! # use solana_program_error::{ProgramError, ProgramResult};
 //! # use solana_pubkey::Pubkey;
 //! # use solana_rent::Rent;

--- a/sysvar/src/rewards.rs
+++ b/sysvar/src/rewards.rs
@@ -4,7 +4,7 @@ use crate::Sysvar;
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
 pub use solana_sdk_ids::sysvar::rewards::{check_id, id, ID};
-use solana_sysvar_id::impl_sysvar_id;
+use {crate::SysvarGet, solana_sysvar_id::impl_sysvar_id};
 
 impl_sysvar_id!(Rewards);
 
@@ -23,5 +23,6 @@ impl Rewards {
         }
     }
 }
+impl SysvarGet for Rewards {}
 #[cfg(feature = "bincode")]
 impl Sysvar for Rewards {}

--- a/sysvar/src/rewards.rs
+++ b/sysvar/src/rewards.rs
@@ -1,10 +1,10 @@
 //! This sysvar is deprecated and unused.
 #[cfg(feature = "bincode")]
-use crate::Sysvar;
+use crate::SysvarSerialize;
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
 pub use solana_sdk_ids::sysvar::rewards::{check_id, id, ID};
-use {crate::SysvarGet, solana_sysvar_id::impl_sysvar_id};
+use {crate::Sysvar, solana_sysvar_id::impl_sysvar_id};
 
 impl_sysvar_id!(Rewards);
 
@@ -23,6 +23,6 @@ impl Rewards {
         }
     }
 }
-impl SysvarGet for Rewards {}
-#[cfg(feature = "bincode")]
 impl Sysvar for Rewards {}
+#[cfg(feature = "bincode")]
+impl SysvarSerialize for Rewards {}

--- a/sysvar/src/slot_hashes.rs
+++ b/sysvar/src/slot_hashes.rs
@@ -2,11 +2,11 @@
 //!
 //! The _slot hashes sysvar_ provides access to the [`SlotHashes`] type.
 //!
-//! The [`Sysvar::from_account_info`] and [`Sysvar::get`] methods always return
+//! The [`SysvarSerialize::from_account_info`] and [`Sysvar::get`] methods always return
 //! [`solana_program_error::ProgramError::UnsupportedSysvar`] because this sysvar account is too large
 //! to process on-chain. Thus this sysvar cannot be accessed on chain, though
 //! one can still use the [`SysvarId::id`], [`SysvarId::check_id`] and
-//! [`Sysvar::size_of`] methods in an on-chain program, and it can be accessed
+//! [`SysvarSerialize::size_of`] methods in an on-chain program, and it can be accessed
 //! off-chain through RPC.
 //!
 //! [`SysvarId::id`]: https://docs.rs/solana-sysvar-id/latest/solana_sysvar_id/trait.SysvarId.html#tymethod.id

--- a/sysvar/src/slot_hashes.rs
+++ b/sysvar/src/slot_hashes.rs
@@ -47,8 +47,8 @@
 #[cfg(feature = "bytemuck")]
 use bytemuck_derive::{Pod, Zeroable};
 #[cfg(feature = "bincode")]
-use {crate::Sysvar, solana_account_info::AccountInfo};
-use {crate::SysvarGet, solana_clock::Slot, solana_hash::Hash};
+use {crate::SysvarSerialize, solana_account_info::AccountInfo};
+use {crate::Sysvar, solana_clock::Slot, solana_hash::Hash};
 
 #[cfg(feature = "bytemuck")]
 const U64_SIZE: usize = std::mem::size_of::<u64>();
@@ -62,9 +62,9 @@ pub use {
     solana_sysvar_id::SysvarId,
 };
 
-impl SysvarGet for SlotHashes {}
+impl Sysvar for SlotHashes {}
 #[cfg(feature = "bincode")]
-impl Sysvar for SlotHashes {
+impl SysvarSerialize for SlotHashes {
     // override
     fn size_of() -> usize {
         // hard-coded so that we don't have to construct an empty

--- a/sysvar/src/slot_hashes.rs
+++ b/sysvar/src/slot_hashes.rs
@@ -46,9 +46,9 @@
 //! ```
 #[cfg(feature = "bytemuck")]
 use bytemuck_derive::{Pod, Zeroable};
+use {crate::Sysvar, solana_clock::Slot, solana_hash::Hash};
 #[cfg(feature = "bincode")]
 use {crate::SysvarSerialize, solana_account_info::AccountInfo};
-use {crate::Sysvar, solana_clock::Slot, solana_hash::Hash};
 
 #[cfg(feature = "bytemuck")]
 const U64_SIZE: usize = std::mem::size_of::<u64>();

--- a/sysvar/src/slot_hashes.rs
+++ b/sysvar/src/slot_hashes.rs
@@ -44,12 +44,11 @@
 //! #
 //! # Ok::<(), anyhow::Error>(())
 //! ```
-
 #[cfg(feature = "bytemuck")]
 use bytemuck_derive::{Pod, Zeroable};
 #[cfg(feature = "bincode")]
 use {crate::Sysvar, solana_account_info::AccountInfo};
-use {solana_clock::Slot, solana_hash::Hash};
+use {crate::SysvarGet, solana_clock::Slot, solana_hash::Hash};
 
 #[cfg(feature = "bytemuck")]
 const U64_SIZE: usize = std::mem::size_of::<u64>();
@@ -63,6 +62,7 @@ pub use {
     solana_sysvar_id::SysvarId,
 };
 
+impl SysvarGet for SlotHashes {}
 #[cfg(feature = "bincode")]
 impl Sysvar for SlotHashes {
     // override

--- a/sysvar/src/slot_history.rs
+++ b/sysvar/src/slot_history.rs
@@ -48,17 +48,17 @@
 //! ```
 
 #[cfg(feature = "bincode")]
+use crate::SysvarSerialize;
 use crate::Sysvar;
-use crate::SysvarGet;
 pub use {
     solana_account_info::AccountInfo,
     solana_program_error::ProgramError,
     solana_sdk_ids::sysvar::slot_history::{check_id, id, ID},
     solana_slot_history::SlotHistory,
 };
-impl SysvarGet for SlotHistory {}
+impl Sysvar for SlotHistory {}
 #[cfg(feature = "bincode")]
-impl Sysvar for SlotHistory {
+impl SysvarSerialize for SlotHistory {
     // override
     fn size_of() -> usize {
         // hard-coded so that we don't have to construct an empty

--- a/sysvar/src/slot_history.rs
+++ b/sysvar/src/slot_history.rs
@@ -49,13 +49,14 @@
 
 #[cfg(feature = "bincode")]
 use crate::Sysvar;
+use crate::SysvarGet;
 pub use {
     solana_account_info::AccountInfo,
     solana_program_error::ProgramError,
     solana_sdk_ids::sysvar::slot_history::{check_id, id, ID},
     solana_slot_history::SlotHistory,
 };
-
+impl SysvarGet for SlotHistory {}
 #[cfg(feature = "bincode")]
 impl Sysvar for SlotHistory {
     // override

--- a/sysvar/src/slot_history.rs
+++ b/sysvar/src/slot_history.rs
@@ -2,11 +2,11 @@
 //!
 //! The _slot history sysvar_ provides access to the [`SlotHistory`] type.
 //!
-//! The [`Sysvar::from_account_info`] and [`Sysvar::get`] methods always return
+//! The [`SysvarSerialize::from_account_info`] and [`Sysvar::get`] methods always return
 //! [`ProgramError::UnsupportedSysvar`] because this sysvar account is too large
 //! to process on-chain. Thus this sysvar cannot be accessed on chain, though
 //! one can still use the [`SysvarId::id`], [`SysvarId::check_id`] and
-//! [`Sysvar::size_of`] methods in an on-chain program, and it can be accessed
+//! [`SysvarSerialize::size_of`] methods in an on-chain program, and it can be accessed
 //! off-chain through RPC.
 //!
 //! [`SysvarId::id`]: https://docs.rs/solana-sysvar-id/latest/solana_sysvar_id/trait.SysvarId.html#tymethod.id

--- a/sysvar/src/slot_history.rs
+++ b/sysvar/src/slot_history.rs
@@ -47,9 +47,9 @@
 //! # Ok::<(), anyhow::Error>(())
 //! ```
 
+use crate::Sysvar;
 #[cfg(feature = "bincode")]
 use crate::SysvarSerialize;
-use crate::Sysvar;
 pub use {
     solana_account_info::AccountInfo,
     solana_program_error::ProgramError,

--- a/sysvar/src/stake_history.rs
+++ b/sysvar/src/stake_history.rs
@@ -5,7 +5,7 @@
 //! The [`Sysvar::get`] method always returns
 //! [`ProgramError::UnsupportedSysvar`], and in practice the data size of this
 //! sysvar is too large to process on chain. One can still use the
-//! [`SysvarId::id`], [`SysvarId::check_id`] and [`Sysvar::size_of`] methods in
+//! [`SysvarId::id`], [`SysvarId::check_id`] and [`SysvarSerialize::size_of`] methods in
 //! an on-chain program, and it can be accessed off-chain through RPC.
 //!
 //! [`ProgramError::UnsupportedSysvar`]: https://docs.rs/solana-program-error/latest/solana_program_error/enum.ProgramError.html#variant.UnsupportedSysvar

--- a/sysvar/src/stake_history.rs
+++ b/sysvar/src/stake_history.rs
@@ -45,7 +45,7 @@
 //! ```
 
 #[cfg(feature = "bincode")]
-use crate::Sysvar;
+use crate::SysvarSerialize;
 pub use solana_sdk_ids::sysvar::stake_history::{check_id, id, ID};
 #[deprecated(
     since = "2.2.0",
@@ -55,13 +55,13 @@ pub use solana_stake_interface::stake_history::{
     StakeHistory, StakeHistoryEntry, StakeHistoryGetEntry, MAX_ENTRIES,
 };
 use {
-    crate::{get_sysvar, SysvarGet},
+    crate::{get_sysvar, Sysvar},
     solana_clock::Epoch,
 };
 
-impl SysvarGet for StakeHistory {}
+impl Sysvar for StakeHistory {}
 #[cfg(feature = "bincode")]
-impl Sysvar for StakeHistory {
+impl SysvarSerialize for StakeHistory {
     // override
     fn size_of() -> usize {
         // hard-coded so that we don't have to construct an empty

--- a/sysvar/src/stake_history.rs
+++ b/sysvar/src/stake_history.rs
@@ -54,8 +54,12 @@ pub use solana_sdk_ids::sysvar::stake_history::{check_id, id, ID};
 pub use solana_stake_interface::stake_history::{
     StakeHistory, StakeHistoryEntry, StakeHistoryGetEntry, MAX_ENTRIES,
 };
-use {crate::get_sysvar, solana_clock::Epoch};
+use {
+    crate::{get_sysvar, SysvarGet},
+    solana_clock::Epoch,
+};
 
+impl SysvarGet for StakeHistory {}
 #[cfg(feature = "bincode")]
 impl Sysvar for StakeHistory {
     // override


### PR DESCRIPTION
Problem: the Sysvar trait relies on bincode, but most of the time people just want `Sysvar::get` which doesn't rely on bincode

~Solution: make a `SysvarGet` trait that has one method: `get`. Make the `Sysvar` trait use `SysvarGet::get`. Annoyingly this is still technically a breaking change because we are adding a constraint to `Sysvar`, but for the vast majority of users nothing should break~

Solution: move the other methods out of `Sysvar` and into a new `SysvarSerialize` trait