### PR TITLE
CI: Add rebase step during publish

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -130,6 +130,9 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
+      - name: Rebase (in case any changes landed after)
+        run: git pull --rebase origin
+
       - name: Publish Crate
         id: publish
         env:


### PR DESCRIPTION
#### Problem

The publish job failed recently because a commit landed *after* the job was started at
https://github.com/anza-xyz/solana-sdk/actions/runs/14089935529/job/39463977139

This happened because the job has an out-of-date view of the repo.

#### Summary of changes

Similar to how this was done in SPL, rebase before publish.