### PR TITLE
vote: Use wrapping pow with min lockout history in `lockout()` calculation

### DIFF
--- a/vote-interface/src/state/mod.rs
+++ b/vote-interface/src/state/mod.rs
@@ -101,7 +101,10 @@ impl Lockout {
 
     // The number of slots for which this vote is locked
     pub fn lockout(&self) -> u64 {
-        (INITIAL_LOCKOUT as u64).pow(self.confirmation_count())
+        (INITIAL_LOCKOUT as u64).wrapping_pow(std::cmp::min(
+            self.confirmation_count(),
+            MAX_LOCKOUT_HISTORY as u32,
+        ))
     }
 
     // The last slot at which a vote is still locked out. Validators should not


### PR DESCRIPTION
The default behavior in the vote lockouts calculation is to panic on larger confirmation counts. This case never gets hit in production / mainnet, but our fuzzers often hit this case when fuzzing at the instruction / transaction level and providing arbitrary confirmation counts within the account data. Since this case is incredibly difficult to prevent in the fuzzer's mutations, we choose to handle this behavior more gracefully by avoiding the panic due to overflow.