### PR TITLE
Add null hasher for Pubkey

### DIFF
--- a/pubkey/Cargo.toml
+++ b/pubkey/Cargo.toml
@@ -30,13 +30,14 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
 solana-sanitize = { workspace = true }
-solana-sha256-hasher = { workspace = true }
 
 [target.'cfg(target_os = "solana")'.dependencies]
 solana-define-syscall = { workspace = true }
+solana-sha256-hasher = { workspace = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 curve25519-dalek = { workspace = true, optional = true }
+solana-sha256-hasher = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { workspace = true, features = ["js", "wasm-bindgen"] }
@@ -72,7 +73,7 @@ frozen-abi = [
 ]
 rand = ["dep:rand", "std"]
 serde = ["dep:serde", "dep:serde_derive"]
-sha2 = ["solana-sha256-hasher/sha2"]
+sha2 = ["dep:solana-sha256-hasher", "solana-sha256-hasher/sha2"]
 std = []
 
 [package.metadata.docs.rs]

--- a/pubkey/Cargo.toml
+++ b/pubkey/Cargo.toml
@@ -30,14 +30,13 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
 solana-sanitize = { workspace = true }
+solana-sha256-hasher = { workspace = true }
 
 [target.'cfg(target_os = "solana")'.dependencies]
 solana-define-syscall = { workspace = true }
-solana-sha256-hasher = { workspace = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 curve25519-dalek = { workspace = true, optional = true }
-solana-sha256-hasher = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { workspace = true, features = ["js", "wasm-bindgen"] }
@@ -73,7 +72,7 @@ frozen-abi = [
 ]
 rand = ["dep:rand", "std"]
 serde = ["dep:serde", "dep:serde_derive"]
-sha2 = ["dep:solana-sha256-hasher", "solana-sha256-hasher/sha2"]
+sha2 = ["solana-sha256-hasher/sha2"]
 std = []
 
 [package.metadata.docs.rs]

--- a/pubkey/src/lib.rs
+++ b/pubkey/src/lib.rs
@@ -177,7 +177,10 @@ impl Hash for Pubkey {
 mod hasher {
     use {
         crate::PUBKEY_BYTES,
-        core::cell::Cell,
+        core::{
+            cell::Cell,
+            hash::{BuildHasher, Hasher},
+        },
         rand::{thread_rng, Rng},
     };
 
@@ -194,7 +197,7 @@ mod hasher {
         state: u64,
     }
 
-    impl std::hash::Hasher for PubkeyHasher {
+    impl Hasher for PubkeyHasher {
         #[inline]
         fn finish(&self) -> u64 {
             self.state
@@ -252,7 +255,7 @@ mod hasher {
         }
     }
 
-    impl std::hash::BuildHasher for PubkeyHasherBuilder {
+    impl BuildHasher for PubkeyHasherBuilder {
         type Hasher = PubkeyHasher;
         #[inline]
         fn build_hasher(&self) -> Self::Hasher {
@@ -312,7 +315,7 @@ mod hasher {
     }
 }
 #[cfg(all(feature = "rand", not(target_os = "solana")))]
-pub use hasher::PubkeyHasherBuilder;
+pub use hasher::{PubkeyHasher, PubkeyHasherBuilder};
 
 impl solana_sanitize::Sanitize for Pubkey {}
 

--- a/pubkey/src/lib.rs
+++ b/pubkey/src/lib.rs
@@ -10,7 +10,6 @@ extern crate std;
 use arbitrary::Arbitrary;
 #[cfg(feature = "bytemuck")]
 use bytemuck_derive::{Pod, Zeroable};
-use core::hash::Hasher;
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
 #[cfg(any(feature = "std", target_arch = "wasm32"))]
@@ -24,7 +23,9 @@ use {
     core::{
         array,
         convert::{Infallible, TryFrom},
-        fmt, mem,
+        fmt,
+        hash::Hasher,
+        mem,
         str::{from_utf8, FromStr},
     },
     num_traits::{FromPrimitive, ToPrimitive},
@@ -218,12 +219,11 @@ mod hasher {
 
     #[cfg(test)]
     mod tests {
-        use core::hash::{BuildHasher, Hasher};
-
-        use crate::Pubkey;
-
-        use super::PubkeyHasherBuilder;
-
+        use {
+            super::PubkeyHasherBuilder,
+            crate::Pubkey,
+            core::hash::{BuildHasher, Hasher},
+        };
         #[test]
         fn test_pubkey_hasher_builder() {
             let key = Pubkey::new_unique();
@@ -237,7 +237,6 @@ mod hasher {
                 hasher2.finish(),
                 "Hashers made with same builder should be identical"
             );
-
             // Make sure that when we make new builders we get different slices
             // chosen for hashing
             let builder2 = PubkeyHasherBuilder::default();
@@ -266,7 +265,9 @@ mod hasher {
         }
     }
 }
+#[cfg(all(feature = "rand", not(target_os = "solana")))]
 pub use hasher::PubkeyHasherBuilder;
+
 impl solana_sanitize::Sanitize for Pubkey {}
 
 // Use strum when testing to ensure our FromPrimitive


### PR DESCRIPTION
Pubkey struct already contains random bytes, and is very commonly a key in a `HashMap`. Hashing pubkeys for hashmap purposes is not useful since they are already effectively random, so just picking a slice will do the trick.

Idea was proposed by @alessandrod to make some of the hashmap-intensive code a little bit faster. Hashing is not *the* bottleneck by any means, but there is truly no point doing useless work.

Implemenation notes:

- the custom Hash implementation prevents the hasher from consuming the length (which is always 32 so no point hashing it anyway)
- The custom hasher is not used by default, one needs to manually build HashMap with it to activate, so it will not break existing code
- The changes to new_unique() are needed to prevent the pubkeys that are full of zeros from creating pathalogical patterns in benchmarks. 
- new_unique uses SipHash from std to fill the Pubkey with random bytes when std is available, and simply pads with last byte of the counter in no_std contexts. This way benches give either correct (for std) or somewhat worse (for no-std) results.