### PR TITLE
pin bytemuck_derive <1.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ borsh0-10 = { package = "borsh", version = "0.10.3" }
 bs58 = { version = "0.5.1", default-features = false }
 bv = "0.11.1"
 bytemuck = "1.21.0"
-bytemuck_derive = "1.8.1"
+bytemuck_derive = ">=1.8.0, <1.9.0"
 cfg_eval = "0.1.2"
 chrono = { version = "0.4.39", default-features = false }
 console = "0.15.10"


### PR DESCRIPTION
Temporary update to pin bytemuck_derive <1.9.0 until we have platform tools for 2.2 using rust >=rustc 1.84