### PR TITLE
deprecate `solana-feature-set-interface` crate

### DIFF
--- a/feature-set-interface/src/lib.rs
+++ b/feature-set-interface/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![deprecated(
     since = "4.0.1",
-    note = "DO NOT USE. crates that need to break consesus should expose their own minimal configuration type"
+    note = "DO NOT USE. Crates that need to break consensus should expose their own minimal configuration type"
 )]
 
 use {

--- a/feature-set-interface/src/lib.rs
+++ b/feature-set-interface/src/lib.rs
@@ -1,4 +1,8 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
+#![deprecated(
+    since = "4.0.1",
+    note = "DO NOT USE. crates that need to break consesus should expose their own minimal configuration type"
+)]
 
 use {
     ahash::{AHashMap, AHashSet},


### PR DESCRIPTION
turns out `solana-feature-set-interface` was a bad idea after all. let's kill it before it takes root