### PR TITLE
program-error: Deprecate PrintProgramError

### DIFF
--- a/program-error/src/lib.rs
+++ b/program-error/src/lib.rs
@@ -122,12 +122,17 @@ impl fmt::Display for ProgramError {
     }
 }
 
+#[deprecated(
+    since = "2.2.2",
+    note = "Use `ToStr` instead with `solana_msg::msg!` or any other logging"
+)]
 pub trait PrintProgramError {
     fn print<E>(&self)
     where
         E: 'static + std::error::Error + DecodeError<E> + PrintProgramError + FromPrimitive;
 }
 
+#[allow(deprecated)]
 impl PrintProgramError for ProgramError {
     fn print<E>(&self)
     where
@@ -172,6 +177,57 @@ impl PrintProgramError for ProgramError {
             Self::ArithmeticOverflow => msg!("Error: ArithmeticOverflow"),
             Self::Immutable => msg!("Error: Immutable"),
             Self::IncorrectAuthority => msg!("Error: IncorrectAuthority"),
+        }
+    }
+}
+
+/// A trait for converting a program error to a `&str`.
+pub trait ToStr {
+    fn to_str<E>(&self) -> &'static str
+    where
+        E: 'static + ToStr + TryFrom<u32>;
+}
+
+impl ToStr for ProgramError {
+    fn to_str<E>(&self) -> &'static str
+    where
+        E: 'static + ToStr + TryFrom<u32>,
+    {
+        match self {
+            Self::Custom(error) => {
+                if let Ok(custom_error) = E::try_from(*error) {
+                    custom_error.to_str::<E>()
+                } else {
+                    "Error: Unknown"
+                }
+            }
+            Self::InvalidArgument => "Error: InvalidArgument",
+            Self::InvalidInstructionData => "Error: InvalidInstructionData",
+            Self::InvalidAccountData => "Error: InvalidAccountData",
+            Self::AccountDataTooSmall => "Error: AccountDataTooSmall",
+            Self::InsufficientFunds => "Error: InsufficientFunds",
+            Self::IncorrectProgramId => "Error: IncorrectProgramId",
+            Self::MissingRequiredSignature => "Error: MissingRequiredSignature",
+            Self::AccountAlreadyInitialized => "Error: AccountAlreadyInitialized",
+            Self::UninitializedAccount => "Error: UninitializedAccount",
+            Self::NotEnoughAccountKeys => "Error: NotEnoughAccountKeys",
+            Self::AccountBorrowFailed => "Error: AccountBorrowFailed",
+            Self::MaxSeedLengthExceeded => "Error: MaxSeedLengthExceeded",
+            Self::InvalidSeeds => "Error: InvalidSeeds",
+            Self::BorshIoError(_) => "Error: BorshIoError",
+            Self::AccountNotRentExempt => "Error: AccountNotRentExempt",
+            Self::UnsupportedSysvar => "Error: UnsupportedSysvar",
+            Self::IllegalOwner => "Error: IllegalOwner",
+            Self::MaxAccountsDataAllocationsExceeded => "Error: MaxAccountsDataAllocationsExceeded",
+            Self::InvalidRealloc => "Error: InvalidRealloc",
+            Self::MaxInstructionTraceLengthExceeded => "Error: MaxInstructionTraceLengthExceeded",
+            Self::BuiltinProgramsMustConsumeComputeUnits => {
+                "Error: BuiltinProgramsMustConsumeComputeUnits"
+            }
+            Self::InvalidAccountOwner => "Error: InvalidAccountOwner",
+            Self::ArithmeticOverflow => "Error: ArithmeticOverflow",
+            Self::Immutable => "Error: Immutable",
+            Self::IncorrectAuthority => "Error: IncorrectAuthority",
         }
     }
 }

--- a/program/src/program_error.rs
+++ b/program/src/program_error.rs
@@ -1,3 +1,5 @@
+#[allow(deprecated)]
+pub use solana_program_error::PrintProgramError;
 pub use {
     solana_instruction::error::{
         ACCOUNT_ALREADY_INITIALIZED, ACCOUNT_BORROW_FAILED, ACCOUNT_DATA_TOO_SMALL,
@@ -10,5 +12,5 @@ pub use {
         MISSING_REQUIRED_SIGNATURES, NOT_ENOUGH_ACCOUNT_KEYS, UNINITIALIZED_ACCOUNT,
         UNSUPPORTED_SYSVAR,
     },
-    solana_program_error::{PrintProgramError, ProgramError},
+    solana_program_error::ProgramError,
 };


### PR DESCRIPTION
#### Problem

As part of the breaking change to unite pinocchio's program error with the sdk's program error in #12, we are introducing a new `ToStr` trait that doesn't rely on any particular logging.

To go with that, we want to deprecate `PrintProgramError`.

#### Summary of changes

Before landing the breaking change, let's deprecate `PrintProgramError` properly and add `ToStr` as an alternative for downstream users.

Once this lands, we'll do the patch release with the deprecation, then we can finally land #12.

cc @kevinheavey 