### PR TITLE
msg!: make std optional

### DIFF
--- a/msg/Cargo.toml
+++ b/msg/Cargo.toml
@@ -9,12 +9,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [features]
 default = ["std"]
 std = []
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
 
 [target.'cfg(target_os = "solana")'.dependencies]
 solana-define-syscall = { workspace = true }

--- a/msg/Cargo.toml
+++ b/msg/Cargo.toml
@@ -9,6 +9,10 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[features]
+default = ["std"]
+std = []
+
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 

--- a/msg/src/lib.rs
+++ b/msg/src/lib.rs
@@ -42,12 +42,15 @@ pub mod syscalls;
 
 /// Print a string to the log.
 #[inline]
-pub fn sol_log(_message: &str) {
+pub fn sol_log(message: &str) {
     #[cfg(target_os = "solana")]
     unsafe {
-        syscalls::sol_log_(_message.as_ptr(), _message.len() as u64);
+        syscalls::sol_log_(message.as_ptr(), message.len() as u64);
     }
 
     #[cfg(all(not(target_os = "solana"), feature = "std"))]
-    std::println!("{_message}");
+    std::println!("{message}");
+
+    #[cfg(all(not(target_os = "solana"), not(feature = "std")))]
+    core::hint::black_box(message);
 }

--- a/msg/src/lib.rs
+++ b/msg/src/lib.rs
@@ -1,3 +1,6 @@
+#![no_std]
+#[cfg(feature = "std")]
+extern crate std;
 /// Print a message to the log.
 ///
 /// Supports simple strings as well as Rust [format strings][fs]. When passed a
@@ -25,6 +28,7 @@
 /// let err = "not enough signers";
 /// msg!("multisig failed: {}", err);
 /// ```
+#[cfg(feature = "std")]
 #[macro_export]
 macro_rules! msg {
     ($msg:expr) => {
@@ -38,12 +42,12 @@ pub mod syscalls;
 
 /// Print a string to the log.
 #[inline]
-pub fn sol_log(message: &str) {
+pub fn sol_log(_message: &str) {
     #[cfg(target_os = "solana")]
     unsafe {
-        syscalls::sol_log_(message.as_ptr(), message.len() as u64);
+        syscalls::sol_log_(_message.as_ptr(), _message.len() as u64);
     }
 
-    #[cfg(not(target_os = "solana"))]
-    println!("{message}");
+    #[cfg(all(not(target_os = "solana"), feature = "std"))]
+    std::println!("{_message}");
 }


### PR DESCRIPTION
In a follow-up PR I'd like to move `sol_log_data` here as I noticed it gets used in a few places

Note: this is a breaking change