### PR TITLE
keypair / signature / ed25519: Deprecate dalek types from public API

### DIFF
--- a/keypair/Cargo.toml
+++ b/keypair/Cargo.toml
@@ -18,7 +18,7 @@ solana-derivation-path = { workspace = true, optional = true }
 solana-pubkey = { workspace = true }
 solana-seed-derivable = { workspace = true, optional = true }
 solana-seed-phrase = { workspace = true }
-solana-signature = { workspace = true, features = ["verify"] }
+solana-signature = { workspace = true, features = ["std", "verify"] }
 solana-signer = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -36,7 +36,8 @@ solana-short-vec = { workspace = true }
 solana-signature = { path = ".", features = ["serde"] }
 
 [features]
-default = ["std"]
+default = ["std", "alloc"]
+alloc = []
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
@@ -44,7 +45,7 @@ frozen-abi = [
 ]
 rand = ["dep:rand"]
 serde = ["dep:serde", "dep:serde_derive", "dep:serde-big-array"]
-std = []
+std = ["alloc"]
 verify = ["dep:ed25519-dalek"]
 
 [package.metadata.docs.rs]

--- a/signature/src/error.rs
+++ b/signature/src/error.rs
@@ -1,0 +1,86 @@
+//! Signature error copied directly from RustCrypto's opaque signature error at
+//! https://github.com/RustCrypto/traits/tree/master/signature
+
+#[cfg(feature = "alloc")]
+use alloc::boxed::Box;
+use core::fmt::{self, Debug, Display};
+
+/// Signature errors.
+///
+/// This type is deliberately opaque as to avoid sidechannel leakage which
+/// could potentially be used recover signing private keys or forge signatures
+/// (e.g. [BB'06]).
+///
+/// When the `std` feature is enabled, it impls [`std::error::Error`].
+///
+/// When the `alloc` feature is enabled, it supports an optional
+/// [`std::error::Error::source`], which can be used by things like remote
+/// signers (e.g. HSM, KMS) to report I/O or auth errors.
+///
+/// [BB'06]: https://en.wikipedia.org/wiki/Daniel_Bleichenbacher
+#[derive(Default)]
+#[non_exhaustive]
+pub struct Error {
+    /// Source of the error (if applicable).
+    #[cfg(feature = "std")]
+    source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+}
+
+impl Error {
+    /// Create a new error with an associated source.
+    ///
+    /// **NOTE:** The "source" should **NOT** be used to propagate cryptographic
+    /// errors e.g. signature parsing or verification errors. The intended use
+    /// cases are for propagating errors related to external signers, e.g.
+    /// communication/authentication errors with HSMs, KMS, etc.
+    #[cfg(feature = "std")]
+    pub fn from_source(
+        source: impl Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    ) -> Self {
+        Self {
+            source: Some(source.into()),
+        }
+    }
+}
+
+impl Debug for Error {
+    #[cfg(not(feature = "std"))]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("signature::Error {}")
+    }
+
+    #[cfg(feature = "std")]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("signature::Error { source: ")?;
+
+        if let Some(source) = &self.source {
+            write!(f, "Some({})", source)?;
+        } else {
+            f.write_str("None")?;
+        }
+
+        f.write_str(" }")
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("signature error")
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<Box<dyn std::error::Error + Send + Sync + 'static>> for Error {
+    fn from(source: Box<dyn std::error::Error + Send + Sync + 'static>) -> Error {
+        Self::from_source(source)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        self.source
+            .as_ref()
+            .map(|source| source.as_ref() as &(dyn core::error::Error + 'static))
+    }
+}

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -8,6 +8,8 @@ use core::{
     fmt,
     str::{from_utf8, FromStr},
 };
+#[cfg(feature = "alloc")]
+extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 #[cfg(feature = "std")]
@@ -17,6 +19,8 @@ use {
     serde_big_array::BigArray,
     serde_derive::{Deserialize, Serialize},
 };
+
+pub mod error;
 
 /// Number of bytes in a signature
 pub const SIGNATURE_BYTES: usize = 64;


### PR DESCRIPTION
#### Problem

The keypair, signature, and ed25519-program crates all expose `ed25519_dalek` types in their public APIs, either as inputs or outputs.

This makes it difficult to land PRs like #26, since we'll just end up causing breaking changes.

#### Summary of changes

Rather than constantly break APIs whenever the ed25519_dalek crates publishes a new major version, deprecate all functions that use ed25519_dalek types and add non-dalek versions.

* 128d5e45043ac25517b52d968d3a4b9ed42216a0: ed25519-program changes
* 87f76f5b53aab128e65a0637341ab4e52d5fa7e3: new Signature error type
* c5be15e499c8841315852b3d2802b6b8f8da53ed: keypair changes

As part of this work, I copied over the Signature error from RustCrypto to use as a generic error. That way, we can choose when to make breaking changes, independent of dependency bumps. I wasn't able to do the same thing since we're not ready to start using `core::error::Error` everywhere.

cc @kevinheavey 