### PR TITLE
pubkey: Don't always mark variable as mut

### DIFF
--- a/pubkey/src/lib.rs
+++ b/pubkey/src/lib.rs
@@ -480,7 +480,10 @@ impl Pubkey {
         type T = u32;
         const COUNTER_BYTES: usize = size_of::<T>();
         let mut b = [0u8; PUBKEY_BYTES];
+        #[cfg(any(feature = "std", target_arch = "wasm32"))]
         let mut i = I.fetch_add(1) as T;
+        #[cfg(not(any(feature = "std", target_arch = "wasm32")))]
+        let i = I.fetch_add(1) as T;
         // use big endian representation to ensure that recent unique pubkeys
         // are always greater than less recent unique pubkeys.
         b[0..COUNTER_BYTES].copy_from_slice(&i.to_be_bytes());
@@ -488,7 +491,6 @@ impl Pubkey {
         // data statistically similar to real pubkeys.
         #[cfg(any(feature = "std", target_arch = "wasm32"))]
         {
-            extern crate std;
             let mut hash = std::hash::DefaultHasher::new();
             for slice in b[COUNTER_BYTES..].chunks_mut(COUNTER_BYTES) {
                 hash.write_u32(i);


### PR DESCRIPTION
#### Problem

If the `std` feature is disabled on `solana-pubkey`, there's currently a warning in the build due to a variable that doesn't need to be marked as `mut`.

#### Summary of changes

Gate marking the variable as `mut` depending on the feature / target. Also, we already pull in the std crate earlier if the `std` feature is enabled, so we don't need to do it twice.