### PR TITLE
CI: Add step to check minimal-versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -226,6 +226,29 @@ jobs:
       - name: Run hack check
         run: ./scripts/check-hack.sh
 
+  minimal-versions:
+    name: Check minimal-versions
+    runs-on: ubuntu-latest
+    needs: [sanity]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          nightly-toolchain: true
+          cargo-cache-key: cargo-nightly-minimal-versions
+          cargo-cache-fallback-key: cargo-nightly
+
+      - name: Install cargo-hack and cargo-minimal-versions
+        uses: taiki-e/cache-cargo-install-action@v2
+        with:
+          tool: cargo-hack,cargo-minimal-versions
+
+      - name: Run minimal-versions check
+        run: ./scripts/check-minimal-versions.sh
+
   check-crate-order-for-publishing:
     name: Check crate dependencies for publishing
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,16 +184,16 @@ memmap2 = "0.5.10"
 memoffset = "0.9"
 num-bigint = "0.4.6"
 num-derive = "0.4"
-num-traits = "0.2"
+num-traits = "0.2.18"
 num_enum = "0.7.3"
-openssl = "0.10"
+openssl = "0.10.39"
 parking_lot = "0.12"
 pbkdf2 = { version = "0.11.0", default-features = false }
 proc-macro2 = "1.0.93"
 proptest = "1.6"
 qstring = "0.7.2"
 qualifier_attr = { version = "0.2.2", default-features = false }
-quote = "1.0"
+quote = "1.0.35"
 rand = "0.8.5"
 rand0-7 = { package = "rand", version = "0.7" }
 reqwest = { version = "0.11.27", default-features = false }
@@ -313,13 +313,13 @@ solana-vote-interface = { path = "vote-interface", version = "2.2.1" }
 static_assertions = "1.1.0"
 strum = "0.24"
 strum_macros = "0.24"
-syn = "2.0"
+syn = "2.0.87"
 test-case = "3.3.1"
 thiserror = "2.0.11"
 tiny-bip39 = "0.8.2"
 toml = "0.8.20"
 uriparse = "0.6.4"
-wasm-bindgen = "0.2"
+wasm-bindgen = "0.2.100"
 
 [patch.crates-io]
 # We include the following crates as our dependencies above from crates.io:

--- a/scripts/check-minimal-versions.sh
+++ b/scripts/check-minimal-versions.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+here="$(dirname "$0")"
+src_root="$(readlink -f "${here}/..")"
+cd "${src_root}"
+
+./cargo nightly minimal-versions check --direct

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -175,7 +175,7 @@ solana-validator-exit = { workspace = true }
 thiserror = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.1", features = ["wasm-bindgen"] }
+getrandom = { version = "0.1.1", features = ["wasm-bindgen"] }
 js-sys = { workspace = true }
 wasm-bindgen = { workspace = true }
 


### PR DESCRIPTION
#### Problem

All of the dependencies are now relaxed and even bumped down to their lowest possible number, but we don't check to make sure that all of the packages can even build with the lowest declared dependencies.

#### Summary of changes

Use the [`cargo-minimal-versions`](https://github.com/taiki-e/cargo-minimal-versions) tool to do exactly that. It goes through each package in the workspace and tries to check it against its lowest declared dependencies.

The tool discovered a lot of instances where we declared a dependency that was too low, so I bumped those up.

And finally, add the check to CI.

IMPORTANT NOTE: This currently doesn't work for intra-repo dependencies. For example if `solana-message` adds a new function, and `solana-transaction` starts using it, then this check will still pass, since the tool doesn't temporarily detach the crate from the workspace when running the check.