### PR TITLE
program: Fix docs build by enabling dev-context-utils

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -237,6 +237,29 @@ jobs:
       - name: Check crates for publishing
         run: ./scripts/order-crates-for-publishing.py
 
+  doc:
+    name: Cargo hack doc
+    runs-on: ubuntu-latest
+    needs: [sanity]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          nightly-toolchain: true
+          cargo-cache-key: cargo-nightly-doc
+          cargo-cache-fallback-key: cargo-nightly
+
+      - name: Install cargo-hack
+        uses: taiki-e/cache-cargo-install-action@v2
+        with:
+          tool: cargo-hack
+
+      - name: Run doc check
+        run: ./scripts/check-doc.sh
+
   sort:
     name: Check sorting of crate dependencies
     runs-on: ubuntu-latest

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -141,7 +141,7 @@ borsh = [
     "solana-pubkey/borsh",
     "solana-stake-interface/borsh",
 ]
-dev-context-only-utils = []
+dev-context-only-utils = ["solana-instructions-sysvar/dev-context-only-utils"]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",

--- a/scripts/check-doc.sh
+++ b/scripts/check-doc.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+here="$(dirname "$0")"
+src_root="$(readlink -f "${here}/..")"
+cd "${src_root}"
+
+./cargo nightly hack doc --all-features


### PR DESCRIPTION
#### Problem

The solana-program docs build is currently failing, as mentioned in #98

#### Summary of changes

The core is that solana-program isn't enabling the dev-context-only-utils feature on solana-instructions-sysvar, so enable it.

Also, add a CI step to make sure the docs builds work on each crate.

Fixes #98