### PR TITLE
Add `solana-address` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2579,9 +2579,17 @@ version = "2.2.1"
 dependencies = [
  "bincode",
  "serde",
- "solana-program-error",
+ "solana-program-error 2.2.1",
  "solana-program-memory",
  "solana-pubkey",
+]
+
+[[package]]
+name = "solana-address"
+version = "0.0.0"
+dependencies = [
+ "solana-define-syscall",
+ "solana-program-error 2.2.1 (git+https://github.com/kevinheavey/solana-sdk.git?branch=program-error-pinocchio-compat)",
 ]
 
 [[package]]
@@ -2748,7 +2756,7 @@ dependencies = [
  "solana-define-syscall",
  "solana-instruction",
  "solana-program-entrypoint",
- "solana-program-error",
+ "solana-program-error 2.2.1",
  "solana-pubkey",
  "solana-sdk-ids",
  "solana-stable-layout",
@@ -2876,7 +2884,7 @@ dependencies = [
  "solana-account-info",
  "solana-feature-gate-interface",
  "solana-instruction",
- "solana-program-error",
+ "solana-program-error 2.2.1",
  "solana-pubkey",
  "solana-rent",
  "solana-sdk-ids",
@@ -3069,7 +3077,7 @@ dependencies = [
  "qualifier_attr",
  "solana-account-info",
  "solana-instruction",
- "solana-program-error",
+ "solana-program-error 2.2.1",
  "solana-pubkey",
  "solana-sanitize",
  "solana-sdk-ids",
@@ -3408,7 +3416,7 @@ dependencies = [
  "solana-native-token",
  "solana-nonce",
  "solana-program-entrypoint",
- "solana-program-error",
+ "solana-program-error 2.2.1",
  "solana-program-memory",
  "solana-program-option",
  "solana-program-pack",
@@ -3440,7 +3448,7 @@ version = "2.2.1"
 dependencies = [
  "solana-account-info",
  "solana-msg",
- "solana-program-error",
+ "solana-program-error 2.2.1",
  "solana-pubkey",
 ]
 
@@ -3459,6 +3467,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-program-error"
+version = "2.2.1"
+source = "git+https://github.com/kevinheavey/solana-sdk.git?branch=program-error-pinocchio-compat#d5cd36e744d2df090b2bc8bb32182a136f4eb24f"
+
+[[package]]
 name = "solana-program-memory"
 version = "2.2.1"
 dependencies = [
@@ -3473,7 +3486,7 @@ version = "2.2.1"
 name = "solana-program-pack"
 version = "2.2.1"
 dependencies = [
- "solana-program-error",
+ "solana-program-error 2.2.1",
 ]
 
 [[package]]
@@ -3495,6 +3508,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_derive",
+ "solana-address",
  "solana-atomic-u64",
  "solana-decode-error",
  "solana-define-syscall",
@@ -3704,7 +3718,7 @@ dependencies = [
  "solana-logger",
  "solana-msg",
  "solana-precompile-error",
- "solana-program-error",
+ "solana-program-error 2.2.1",
  "solana-sdk",
  "solana-sdk-ids",
  "solana-secp256k1-program",
@@ -3898,7 +3912,7 @@ dependencies = [
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-instruction",
- "solana-program-error",
+ "solana-program-error 2.2.1",
  "solana-pubkey",
  "solana-system-interface",
  "solana-sysvar-id",
@@ -3961,7 +3975,7 @@ dependencies = [
  "solana-msg",
  "solana-program",
  "solana-program-entrypoint",
- "solana-program-error",
+ "solana-program-error 2.2.1",
  "solana-program-memory",
  "solana-pubkey",
  "solana-rent",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3511,7 +3511,6 @@ dependencies = [
  "solana-address",
  "solana-atomic-u64",
  "solana-decode-error",
- "solana-define-syscall",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-program",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ opt-level = 1
 members = [
     "account",
     "account-info",
+    "address",
     "address-lookup-table-interface",
     "atomic-u64",
     "big-mod-exp",
@@ -210,6 +211,7 @@ signal-hook = "0.3.17"
 siphasher = "0.3.11"
 solana-account = { path = "account", version = "2.2.1" }
 solana-account-info = { path = "account-info", version = "2.2.1" }
+solana-address = { path = "address", version = "0.0.0" }
 solana-address-lookup-table-interface = { path = "address-lookup-table-interface", version = "2.2.2" }
 solana-atomic-u64 = { path = "atomic-u64", version = "2.2.1" }
 solana-big-mod-exp = { path = "big-mod-exp", version = "2.2.1" }

--- a/address/Cargo.toml
+++ b/address/Cargo.toml
@@ -17,4 +17,4 @@ syscalls = ["dep:solana-define-syscall", "dep:solana-program-error"]
 
 [dependencies]
 solana-define-syscall = { workspace = true, optional = true }
-solana-program-error = { workspace = true, optional = true }
+solana-program-error = { version = "2.2.1", git = "https://github.com/kevinheavey/solana-sdk.git", branch = "program-error-pinocchio-compat", optional = true }

--- a/address/Cargo.toml
+++ b/address/Cargo.toml
@@ -13,8 +13,8 @@ edition = { workspace = true }
 workspace = true
 
 [features]
-syscall = ["dep:solana-define-syscall", "dep:solana-program-error"]
+syscalls = ["dep:solana-define-syscall", "dep:solana-program-error"]
 
 [dependencies]
 solana-define-syscall = { workspace = true, optional = true }
-solana-program-error = { version = "2.2.1", git = "https://github.com/kevinheavey/solana-sdk.git", branch = "program-error-pinocchio-compat", optional = true }
+solana-program-error = { workspace = true, optional = true }

--- a/address/Cargo.toml
+++ b/address/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "solana-address"
+description = "Solana account addresses"
+documentation = "https://docs.rs/solana-address"
+version = "0.0.0"
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[lints]
+workspace = true
+
+[features]
+syscall = ["dep:solana-define-syscall", "dep:solana-program-error"]
+
+[dependencies]
+solana-define-syscall = { workspace = true, optional = true }
+solana-program-error = { version = "2.2.1", git = "https://github.com/kevinheavey/solana-sdk.git", branch = "program-error-pinocchio-compat", optional = true }

--- a/address/src/lib.rs
+++ b/address/src/lib.rs
@@ -28,3 +28,44 @@ pub const MAX_SEEDS: usize = 16;
 /// [ed25519]: https://ed25519.cr.yp.to/
 /// [pdas]: https://solana.com/docs/core/cpi#program-derived-addresses
 pub type Address = [u8; ADDRESS_BYTES];
+
+/// Convenience macro to declare a static address and functions to interact with it.
+///
+/// This macro is useful to declare a constant representing a program ID for a
+/// Solana program.
+///
+/// # Example
+///
+/// ```
+/// # // wrapper is used so that the macro invocation occurs in the item position
+/// # // rather than in the statement position which isn't allowed.
+/// use solana_address::{declare_id, Address};
+///
+/// # mod program {
+/// #   use solana_address::declare_id;
+/// declare_id!([0; 32]);
+/// # }
+/// # use program::id;
+///
+/// let address = [0; 32];
+/// assert_eq!(id(), address);
+/// ```
+#[macro_export]
+macro_rules! declare_id {
+    ( $id:expr ) => {
+        #[doc = "The constant program ID."]
+        pub const ID: $crate::Address = $id;
+
+        #[doc = "Returns `true` if the given address is equal to the program ID."]
+        #[inline]
+        pub fn check_id(id: &$crate::Address) -> bool {
+            id == &ID
+        }
+
+        #[doc = "Returns the program ID."]
+        #[inline]
+        pub const fn id() -> $crate::Address {
+            ID
+        }
+    };
+}

--- a/address/src/lib.rs
+++ b/address/src/lib.rs
@@ -2,9 +2,9 @@
 
 #![no_std]
 
-#[cfg(feature = "syscall")]
+#[cfg(feature = "syscalls")]
 mod syscalls;
-#[cfg(feature = "syscall")]
+#[cfg(feature = "syscalls")]
 pub use syscalls::*;
 
 /// Number of bytes in an address.
@@ -18,5 +18,13 @@ pub const MAX_SEEDS: usize = 16;
 
 /// The address of a [Solana account][account].
 ///
+/// Some account addresses are [ed25519] public keys, with corresponding secret
+/// keys that are managed off-chain. Often, though, account addresses do not
+/// have corresponding secret keys &mdash; as with [_program derived
+/// addresses_][pdas] &mdash; or the secret key is not relevant to the operation
+/// of a program, and may have even been disposed of.
+///
 /// [account]: https://solana.com/docs/core/accounts
+/// [ed25519]: https://ed25519.cr.yp.to/
+/// [pdas]: https://solana.com/docs/core/cpi#program-derived-addresses
 pub type Address = [u8; PUBKEY_BYTES];

--- a/address/src/lib.rs
+++ b/address/src/lib.rs
@@ -8,7 +8,7 @@ mod syscalls;
 pub use syscalls::*;
 
 /// Number of bytes in an address.
-pub const PUBKEY_BYTES: usize = 32;
+pub const ADDRESS_BYTES: usize = 32;
 
 /// Maximum length of derived `Address` seed.
 pub const MAX_SEED_LEN: usize = 32;
@@ -27,4 +27,4 @@ pub const MAX_SEEDS: usize = 16;
 /// [account]: https://solana.com/docs/core/accounts
 /// [ed25519]: https://ed25519.cr.yp.to/
 /// [pdas]: https://solana.com/docs/core/cpi#program-derived-addresses
-pub type Address = [u8; PUBKEY_BYTES];
+pub type Address = [u8; ADDRESS_BYTES];

--- a/address/src/lib.rs
+++ b/address/src/lib.rs
@@ -1,0 +1,22 @@
+//! Define how a Solana account address is represented.
+
+#![no_std]
+
+#[cfg(feature = "syscall")]
+mod syscalls;
+#[cfg(feature = "syscall")]
+pub use syscalls::*;
+
+/// Number of bytes in an address.
+pub const PUBKEY_BYTES: usize = 32;
+
+/// Maximum length of derived `Address` seed.
+pub const MAX_SEED_LEN: usize = 32;
+
+/// Maximum number of seeds for address derivation.
+pub const MAX_SEEDS: usize = 16;
+
+/// The address of a [Solana account][account].
+///
+/// [account]: https://solana.com/docs/core/accounts
+pub type Address = [u8; PUBKEY_BYTES];

--- a/address/src/syscalls.rs
+++ b/address/src/syscalls.rs
@@ -112,7 +112,7 @@ pub fn try_find_program_address(
 ) -> Result<(Address, u8), ProgramError> {
     #[cfg(target_os = "solana")]
     {
-        let mut bytes = core::mem::MaybeUninit::<[u8; crate::PUBKEY_BYTES]>::uninit();
+        let mut bytes = core::mem::MaybeUninit::<[u8; crate::ADDRESS_BYTES]>::uninit();
         let mut bump_seed = u8::MAX;
 
         let result = unsafe {
@@ -164,7 +164,7 @@ pub fn try_create_program_address(
     // Call via a system call to perform the calculation
     #[cfg(target_os = "solana")]
     {
-        let mut bytes = core::mem::MaybeUninit::<[u8; crate::PUBKEY_BYTES]>::uninit();
+        let mut bytes = core::mem::MaybeUninit::<[u8; crate::ADDRESS_BYTES]>::uninit();
 
         let result = unsafe {
             sol_create_program_address(

--- a/address/src/syscalls.rs
+++ b/address/src/syscalls.rs
@@ -1,0 +1,235 @@
+#[cfg(target_os = "solana")]
+use {
+    crate::PUBKEY_BYTES,
+    solana_define_syscall::definitions::{
+        sol_create_program_address, sol_log_pubkey, sol_try_find_program_address,
+    },
+};
+use {
+    crate::{Address, MAX_SEEDS, MAX_SEED_LEN},
+    solana_program_error::ProgramError,
+};
+
+#[cfg(target_os = "solana")]
+/// Value representing a success syscall invocation.
+const SUCCESS: u64 = 0;
+
+/// Log an `Address`.
+#[inline(always)]
+pub fn log(address: &Address) {
+    #[cfg(target_os = "solana")]
+    unsafe {
+        sol_log_pubkey(address as *const u8)
+    };
+
+    #[cfg(not(target_os = "solana"))]
+    core::hint::black_box(address);
+}
+
+/// Find a valid [program derived address][pda] and its corresponding bump seed.
+///
+/// [pda]: https://solana.com/docs/core/cpi#program-derived-addresses
+///
+/// Program derived addresses (PDAs) are account keys that only the program,
+/// `program_id`, has the authority to sign. The address is of the same form
+/// as a Solana `Address`, except they are ensured to not be on the ed25519
+/// curve and thus have no associated private key. When performing
+/// cross-program invocations the program can "sign" for the key by calling
+/// [`invoke_signed`] and passing the same seeds used to generate the
+/// address, along with the calculated _bump seed_, which this function
+/// returns as the second tuple element. The runtime will verify that the
+/// program associated with this address is the caller and thus authorized
+/// to be the signer.
+///
+/// [`invoke_signed`]: crate::program::invoke_signed
+///
+/// The `seeds` are application-specific, and must be carefully selected to
+/// uniquely derive accounts per application requirements. It is common to
+/// use static strings and other addresses as seeds.
+///
+/// Because the program derived address must not lie on the ed25519 curve,
+/// there may be seed and program id combinations that are invalid. For this
+/// reason, an extra seed (the bump seed) is calculated that results in a
+/// point off the curve. The bump seed must be passed as an additional seed
+/// when calling `invoke_signed`.
+///
+/// The processes of finding a valid program address is by trial and error,
+/// and even though it is deterministic given a set of inputs it can take a
+/// variable amount of time to succeed across different inputs.  This means
+/// that when called from an on-chain program it may incur a variable amount
+/// of the program's compute budget.  Programs that are meant to be very
+/// performant may not want to use this function because it could take a
+/// considerable amount of time. Programs that are already at risk
+/// of exceeding their compute budget should call this with care since
+/// there is a chance that the program's budget may be occasionally
+/// and unpredictably exceeded.
+///
+/// As all account addresses accessed by an on-chain Solana program must be
+/// explicitly passed to the program, it is typical for the PDAs to be
+/// derived in off-chain client programs, avoiding the compute cost of
+/// generating the address on-chain. The address may or may not then be
+/// verified by re-deriving it on-chain, depending on the requirements of
+/// the program. This verification may be performed without the overhead of
+/// re-searching for the bump key by using the [`create_program_address`]
+/// function.
+///
+/// [`create_program_address`]: crate::pubkey::create_program_address
+///
+/// **Warning**: Because of the way the seeds are hashed there is a potential
+/// for program address collisions for the same program id. The seeds are
+/// hashed sequentially which means that seeds {"abcdef"}, {"abc", "def"},
+/// and {"ab", "cd", "ef"} will all result in the same program address given
+/// the same program id. Since the chance of collision is local to a given
+/// program id, the developer of that program must take care to choose seeds
+/// that do not collide with each other. For seed schemes that are susceptible
+/// to this type of hash collision, a common remedy is to insert separators
+/// between seeds, e.g. transforming {"abc", "def"} into {"abc", "-", "def"}.
+///
+/// # Panics
+///
+/// Panics in the statistically improbable event that a bump seed could not be
+/// found. Use [`try_find_program_address`] to handle this case.
+///
+/// [`try_find_program_address`]: #try_find_program_address
+///
+/// Panics if any of the following are true:
+///
+/// - the number of provided seeds is greater than, _or equal to_, [`MAX_SEEDS`],
+/// - any individual seed's length is greater than [`MAX_SEED_LEN`].
+#[inline(always)]
+pub fn find_program_address(seeds: &[&[u8]], program_id: &Address) -> (Address, u8) {
+    try_find_program_address(seeds, program_id)
+        .unwrap_or_else(|_error| panic!("Unable to find a viable program address bump seed"))
+}
+
+/// Find a valid [program derived address][pda] and its corresponding bump seed.
+///
+/// [pda]: https://solana.com/docs/core/cpi#program-derived-addresses
+///
+/// The only difference between this method and [`find_program_address`]
+/// is that this one returns `PubkeyError::InvalidSeeds` in the statistically
+/// improbable event that a bump seed cannot be found; or if any of
+/// `find_program_address`'s preconditions are violated.
+///
+/// See the documentation for [`find_program_address`] for a full description.
+///
+/// [`find_program_address`]: #find_program_address
+#[inline]
+pub fn try_find_program_address(
+    seeds: &[&[u8]],
+    program_id: &Address,
+) -> Result<(Address, u8), ProgramError> {
+    #[cfg(target_os = "solana")]
+    {
+        let mut bytes = core::mem::MaybeUninit::<[u8; PUBKEY_BYTES]>::uninit();
+        let mut bump_seed = u8::MAX;
+
+        let result = unsafe {
+            sol_try_find_program_address(
+                seeds as *const _ as *const u8,
+                seeds.len() as u64,
+                program_id as *const _,
+                bytes.as_mut_ptr() as *mut _,
+                &mut bump_seed as *mut _,
+            )
+        };
+        match result {
+            // SAFETY: The syscall has initialized the bytes.
+            SUCCESS => Ok((unsafe { bytes.assume_init() }, bump_seed)),
+            _ => Err(ProgramError::InvalidSeeds),
+        }
+    }
+
+    #[cfg(not(target_os = "solana"))]
+    {
+        core::hint::black_box((seeds, program_id));
+        panic!("try_find_program_address is only available on target `solana`")
+    }
+}
+
+/// Create a valid [program derived address][pda] without searching for a bump seed.
+///
+/// [pda]: https://solana.com/docs/core/cpi#program-derived-addresses
+///
+/// Because this function does not create a bump seed, it may unpredictably
+/// return an error for any given set of seeds and is not generally suitable
+/// for creating program derived addresses.
+///
+/// However, it can be used for efficiently verifying that a set of seeds plus
+/// bump seed generated by [`find_program_address`] derives a particular
+/// address as expected. See the example for details.
+///
+/// See the documentation for [`find_program_address`] for a full description
+/// of program derived addresses and bump seeds.
+///
+/// Note that this function does *not* validate whether the given `seeds` are within
+/// the valid length or not. It will return an error in case of invalid seeds length,
+/// incurring the cost of the syscall.
+///
+/// [`find_program_address`]: #find_program_address
+#[inline]
+pub fn try_create_program_address(
+    seeds: &[&[u8]],
+    program_id: &Address,
+) -> Result<Address, ProgramError> {
+    // Call via a system call to perform the calculation
+    #[cfg(target_os = "solana")]
+    {
+        let mut bytes = core::mem::MaybeUninit::<[u8; PUBKEY_BYTES]>::uninit();
+
+        let result = unsafe {
+            sol_create_program_address(
+                seeds as *const _ as *const u8,
+                seeds.len() as u64,
+                program_id as *const _ as *const u8,
+                bytes.as_mut_ptr() as *mut u8,
+            )
+        };
+
+        match result {
+            // SAFETY: The syscall has initialized the bytes.
+            SUCCESS => Ok(unsafe { bytes.assume_init() }),
+            _ => Err(ProgramError::InvalidSeeds),
+        }
+    }
+
+    #[cfg(not(target_os = "solana"))]
+    {
+        core::hint::black_box((seeds, program_id));
+        panic!("try_create_program_address is only available on target `solana`")
+    }
+}
+
+/// Create a valid [program derived address][pda] without searching for a bump seed.
+///
+/// [pda]: https://solana.com/docs/core/cpi#program-derived-addresses
+///
+/// Because this function does not create a bump seed, it may unpredictably
+/// return an error for any given set of seeds and is not generally suitable
+/// for creating program derived addresses.
+///
+/// However, it can be used for efficiently verifying that a set of seeds plus
+/// bump seed generated by [`find_program_address`] derives a particular
+/// address as expected. See the example for details.
+///
+/// See the documentation for [`find_program_address`] for a full description
+/// of program derived addresses and bump seeds.
+///
+/// Note that this function validates whether the given `seeds` are within the valid
+/// length or not, returning an error without incurring the cost of the syscall.
+///
+/// [`find_program_address`]: #find_program_address
+#[inline(always)]
+pub fn checked_try_create_program_address(
+    seeds: &[&[u8]],
+    program_id: &Address,
+) -> Result<Address, ProgramError> {
+    if seeds.len() > MAX_SEEDS {
+        return Err(ProgramError::MaxSeedLengthExceeded);
+    }
+    if seeds.iter().any(|seed| seed.len() > MAX_SEED_LEN) {
+        return Err(ProgramError::MaxSeedLengthExceeded);
+    }
+
+    try_create_program_address(seeds, program_id)
+}

--- a/address/src/syscalls.rs
+++ b/address/src/syscalls.rs
@@ -1,9 +1,6 @@
 #[cfg(target_os = "solana")]
-use {
-    crate::PUBKEY_BYTES,
-    solana_define_syscall::definitions::{
-        sol_create_program_address, sol_log_pubkey, sol_try_find_program_address,
-    },
+pub use solana_define_syscall::definitions::{
+    sol_create_program_address, sol_log_pubkey, sol_try_find_program_address,
 };
 use {
     crate::{Address, MAX_SEEDS, MAX_SEED_LEN},
@@ -121,7 +118,7 @@ pub fn try_find_program_address(
 ) -> Result<(Address, u8), ProgramError> {
     #[cfg(target_os = "solana")]
     {
-        let mut bytes = core::mem::MaybeUninit::<[u8; PUBKEY_BYTES]>::uninit();
+        let mut bytes = core::mem::MaybeUninit::<[u8; crate::PUBKEY_BYTES]>::uninit();
         let mut bump_seed = u8::MAX;
 
         let result = unsafe {
@@ -175,7 +172,7 @@ pub fn try_create_program_address(
     // Call via a system call to perform the calculation
     #[cfg(target_os = "solana")]
     {
-        let mut bytes = core::mem::MaybeUninit::<[u8; PUBKEY_BYTES]>::uninit();
+        let mut bytes = core::mem::MaybeUninit::<[u8; crate::PUBKEY_BYTES]>::uninit();
 
         let result = unsafe {
             sol_create_program_address(

--- a/address/src/syscalls.rs
+++ b/address/src/syscalls.rs
@@ -38,7 +38,7 @@ pub fn log(address: &Address) {
 /// program associated with this address is the caller and thus authorized
 /// to be the signer.
 ///
-/// [`invoke_signed`]: crate::program::invoke_signed
+/// [`invoke_signed`]: https://docs.rs/solana-cpi/latest/solana_cpi/fn.invoke_signed.html
 ///
 /// The `seeds` are application-specific, and must be carefully selected to
 /// uniquely derive accounts per application requirements. It is common to
@@ -67,10 +67,8 @@ pub fn log(address: &Address) {
 /// generating the address on-chain. The address may or may not then be
 /// verified by re-deriving it on-chain, depending on the requirements of
 /// the program. This verification may be performed without the overhead of
-/// re-searching for the bump key by using the [`create_program_address`]
+/// re-searching for the bump key by using the [`try_create_program_address`]
 /// function.
-///
-/// [`create_program_address`]: crate::pubkey::create_program_address
 ///
 /// **Warning**: Because of the way the seeds are hashed there is a potential
 /// for program address collisions for the same program id. The seeds are
@@ -87,8 +85,6 @@ pub fn log(address: &Address) {
 /// Panics in the statistically improbable event that a bump seed could not be
 /// found. Use [`try_find_program_address`] to handle this case.
 ///
-/// [`try_find_program_address`]: #try_find_program_address
-///
 /// Panics if any of the following are true:
 ///
 /// - the number of provided seeds is greater than, _or equal to_, [`MAX_SEEDS`],
@@ -104,13 +100,11 @@ pub fn find_program_address(seeds: &[&[u8]], program_id: &Address) -> (Address, 
 /// [pda]: https://solana.com/docs/core/cpi#program-derived-addresses
 ///
 /// The only difference between this method and [`find_program_address`]
-/// is that this one returns `PubkeyError::InvalidSeeds` in the statistically
+/// is that this one returns `ProgramError::InvalidSeeds` in the statistically
 /// improbable event that a bump seed cannot be found; or if any of
-/// `find_program_address`'s preconditions are violated.
+/// [`find_program_address`]'s preconditions are violated.
 ///
 /// See the documentation for [`find_program_address`] for a full description.
-///
-/// [`find_program_address`]: #find_program_address
 #[inline]
 pub fn try_find_program_address(
     seeds: &[&[u8]],
@@ -162,8 +156,6 @@ pub fn try_find_program_address(
 /// Note that this function does *not* validate whether the given `seeds` are within
 /// the valid length or not. It will return an error in case of invalid seeds length,
 /// incurring the cost of the syscall.
-///
-/// [`find_program_address`]: #find_program_address
 #[inline]
 pub fn try_create_program_address(
     seeds: &[&[u8]],
@@ -214,8 +206,6 @@ pub fn try_create_program_address(
 ///
 /// Note that this function validates whether the given `seeds` are within the valid
 /// length or not, returning an error without incurring the cost of the syscall.
-///
-/// [`find_program_address`]: #find_program_address
 #[inline(always)]
 pub fn checked_try_create_program_address(
     seeds: &[&[u8]],

--- a/pubkey/Cargo.toml
+++ b/pubkey/Cargo.toml
@@ -21,6 +21,7 @@ num-traits = { workspace = true }
 rand = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
+solana-address = { workspace = true }
 solana-atomic-u64 = { workspace = true }
 solana-decode-error = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [

--- a/pubkey/Cargo.toml
+++ b/pubkey/Cargo.toml
@@ -21,7 +21,7 @@ num-traits = { workspace = true }
 rand = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-solana-address = { workspace = true }
+solana-address = { workspace = true, features = ["syscalls"] }
 solana-atomic-u64 = { workspace = true }
 solana-decode-error = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [

--- a/pubkey/Cargo.toml
+++ b/pubkey/Cargo.toml
@@ -33,7 +33,6 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
 solana-sanitize = { workspace = true }
 
 [target.'cfg(target_os = "solana")'.dependencies]
-solana-define-syscall = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]

--- a/pubkey/src/lib.rs
+++ b/pubkey/src/lib.rs
@@ -26,7 +26,7 @@ use {
         convert::{Infallible, TryFrom},
         fmt,
         hash::{Hash, Hasher},
-        mem::{self, size_of},
+        mem::size_of,
         str::{from_utf8, FromStr},
     },
     num_traits::{FromPrimitive, ToPrimitive},
@@ -47,11 +47,6 @@ const MAX_BASE58_LEN: usize = 44;
 
 #[cfg(any(target_os = "solana", feature = "sha2", feature = "curve25519"))]
 const PDA_MARKER: &[u8; 21] = b"ProgramDerivedAddress";
-
-/// Copied from `solana_program::entrypoint::SUCCESS`
-/// to avoid a `solana_program` dependency
-#[cfg(target_os = "solana")]
-const SUCCESS: u64 = 0;
 
 // Use strum when testing to ensure our FromPrimitive
 // impl is exhaustive
@@ -134,18 +129,8 @@ impl From<u64> for PubkeyError {
 
 /// The address of a [Solana account][acc].
 ///
-/// Some account addresses are [ed25519] public keys, with corresponding secret
-/// keys that are managed off-chain. Often, though, account addresses do not
-/// have corresponding secret keys &mdash; as with [_program derived
-/// addresses_][pdas] &mdash; or the secret key is not relevant to the operation
-/// of a program, and may have even been disposed of. As running Solana programs
-/// can not safely create or manage secret keys, the full [`Keypair`] is not
-/// defined in `solana-program` but in `solana-sdk`.
-///
-/// [acc]: https://solana.com/docs/core/accounts
-/// [ed25519]: https://ed25519.cr.yp.to/
-/// [pdas]: https://solana.com/docs/core/cpi#program-derived-addresses
-/// [`Keypair`]: https://docs.rs/solana-sdk/latest/solana_sdk/signer/keypair/struct.Keypair.html
+/// This is a wrapper around the [`Address`] type from the `solana_address`
+/// crate.
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 #[repr(transparent)]
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
@@ -392,7 +377,7 @@ impl FromStr for Pubkey {
         let decoded_size = bs58::decode(s)
             .onto(&mut bytes)
             .map_err(|_| ParsePubkeyError::Invalid)?;
-        if decoded_size != mem::size_of::<Pubkey>() {
+        if decoded_size != size_of::<Pubkey>() {
             Err(ParsePubkeyError::WrongSize)
         } else {
             Ok(Pubkey(bytes))
@@ -533,74 +518,9 @@ impl Pubkey {
 
     /// Find a valid [program derived address][pda] and its corresponding bump seed.
     ///
-    /// [pda]: https://solana.com/docs/core/cpi#program-derived-addresses
-    ///
-    /// Program derived addresses (PDAs) are account keys that only the program,
-    /// `program_id`, has the authority to sign. The address is of the same form
-    /// as a Solana `Pubkey`, except they are ensured to not be on the ed25519
-    /// curve and thus have no associated private key. When performing
-    /// cross-program invocations the program can "sign" for the key by calling
-    /// [`invoke_signed`] and passing the same seeds used to generate the
-    /// address, along with the calculated _bump seed_, which this function
-    /// returns as the second tuple element. The runtime will verify that the
-    /// program associated with this address is the caller and thus authorized
-    /// to be the signer.
-    ///
-    /// [`invoke_signed`]: https://docs.rs/solana-program/latest/solana_program/program/fn.invoke_signed.html
-    ///
-    /// The `seeds` are application-specific, and must be carefully selected to
-    /// uniquely derive accounts per application requirements. It is common to
-    /// use static strings and other pubkeys as seeds.
-    ///
-    /// Because the program address must not lie on the ed25519 curve, there may
-    /// be seed and program id combinations that are invalid. For this reason,
-    /// an extra seed (the bump seed) is calculated that results in a
-    /// point off the curve. The bump seed must be passed as an additional seed
-    /// when calling `invoke_signed`.
-    ///
-    /// The processes of finding a valid program address is by trial and error,
-    /// and even though it is deterministic given a set of inputs it can take a
-    /// variable amount of time to succeed across different inputs.  This means
-    /// that when called from an on-chain program it may incur a variable amount
-    /// of the program's compute budget.  Programs that are meant to be very
-    /// performant may not want to use this function because it could take a
-    /// considerable amount of time. Programs that are already at risk
-    /// of exceeding their compute budget should call this with care since
-    /// there is a chance that the program's budget may be occasionally
-    /// and unpredictably exceeded.
-    ///
-    /// As all account addresses accessed by an on-chain Solana program must be
-    /// explicitly passed to the program, it is typical for the PDAs to be
-    /// derived in off-chain client programs, avoiding the compute cost of
-    /// generating the address on-chain. The address may or may not then be
-    /// verified by re-deriving it on-chain, depending on the requirements of
-    /// the program. This verification may be performed without the overhead of
-    /// re-searching for the bump key by using the [`create_program_address`]
-    /// function.
-    ///
-    /// [`create_program_address`]: Pubkey::create_program_address
-    ///
-    /// **Warning**: Because of the way the seeds are hashed there is a potential
-    /// for program address collisions for the same program id.  The seeds are
-    /// hashed sequentially which means that seeds {"abcdef"}, {"abc", "def"},
-    /// and {"ab", "cd", "ef"} will all result in the same program address given
-    /// the same program id. Since the chance of collision is local to a given
-    /// program id, the developer of that program must take care to choose seeds
-    /// that do not collide with each other. For seed schemes that are susceptible
-    /// to this type of hash collision, a common remedy is to insert separators
-    /// between seeds, e.g. transforming {"abc", "def"} into {"abc", "-", "def"}.
-    ///
-    /// # Panics
-    ///
-    /// Panics in the statistically improbable event that a bump seed could not be
-    /// found. Use [`try_find_program_address`] to handle this case.
-    ///
-    /// [`try_find_program_address`]: Pubkey::try_find_program_address
-    ///
-    /// Panics if any of the following are true:
-    ///
-    /// - the number of provided seeds is greater than, _or equal to_,  [`MAX_SEEDS`],
-    /// - any individual seed's length is greater than [`MAX_SEED_LEN`].
+    /// This behaves like [`solana_address::find_program_address`] when `target_os = "solana"`,
+    /// but adds support for `target_os != "solana"` – it requires the `curve25519` feature to
+    /// be enabled in this case.
     ///
     /// # Examples
     ///
@@ -784,10 +704,6 @@ impl Pubkey {
     /// #
     /// # Ok::<(), anyhow::Error>(())
     /// ```
-    // If target_os = "solana", then the function will use
-    // syscalls which bring no dependencies.
-    // When target_os != "solana", this should be opt-in so users
-    // don't need the curve25519 dependency.
     #[cfg(any(target_os = "solana", feature = "curve25519"))]
     pub fn find_program_address(seeds: &[&[u8]], program_id: &Pubkey) -> (Pubkey, u8) {
         Self::try_find_program_address(seeds, program_id)
@@ -796,20 +712,9 @@ impl Pubkey {
 
     /// Find a valid [program derived address][pda] and its corresponding bump seed.
     ///
-    /// [pda]: https://solana.com/docs/core/cpi#program-derived-addresses
-    ///
-    /// The only difference between this method and [`find_program_address`]
-    /// is that this one returns `None` in the statistically improbable event
-    /// that a bump seed cannot be found; or if any of `find_program_address`'s
-    /// preconditions are violated.
-    ///
-    /// See the documentation for [`find_program_address`] for a full description.
-    ///
-    /// [`find_program_address`]: Pubkey::find_program_address
-    // If target_os = "solana", then the function will use
-    // syscalls which bring no dependencies.
-    // When target_os != "solana", this should be opt-in so users
-    // don't need the curve25519 dependency.
+    /// This behaves like [`solana_address::try_find_program_address`] when `target_os = "solana"`,
+    /// but adds support for `target_os != "solana"` – it requires the `curve25519` feature to
+    /// be enabled in this case.
     #[cfg(any(target_os = "solana", feature = "curve25519"))]
     #[allow(clippy::same_item_push)]
     pub fn try_find_program_address(seeds: &[&[u8]], program_id: &Pubkey) -> Option<(Pubkey, u8)> {
@@ -834,41 +739,17 @@ impl Pubkey {
         }
         // Call via a system call to perform the calculation
         #[cfg(target_os = "solana")]
-        {
-            let mut bytes = [0; 32];
-            let mut bump_seed = u8::MAX;
-            let result = unsafe {
-                crate::syscalls::sol_try_find_program_address(
-                    seeds as *const _ as *const u8,
-                    seeds.len() as u64,
-                    program_id as *const _ as *const u8,
-                    &mut bytes as *mut _ as *mut u8,
-                    &mut bump_seed as *mut _ as *mut u8,
-                )
-            };
-            match result {
-                SUCCESS => Some((Pubkey::from(bytes), bump_seed)),
-                _ => None,
-            }
+        match solana_address::try_find_program_address(seeds, program_id.as_array()) {
+            Ok((address, bump)) => Some((Pubkey::from(address), bump)),
+            Err(_) => None,
         }
     }
 
     /// Create a valid [program derived address][pda] without searching for a bump seed.
     ///
-    /// [pda]: https://solana.com/docs/core/cpi#program-derived-addresses
-    ///
-    /// Because this function does not create a bump seed, it may unpredictably
-    /// return an error for any given set of seeds and is not generally suitable
-    /// for creating program derived addresses.
-    ///
-    /// However, it can be used for efficiently verifying that a set of seeds plus
-    /// bump seed generated by [`find_program_address`] derives a particular
-    /// address as expected. See the example for details.
-    ///
-    /// See the documentation for [`find_program_address`] for a full description
-    /// of program derived addresses and bump seeds.
-    ///
-    /// [`find_program_address`]: Pubkey::find_program_address
+    /// This behaves like [`solana_address::checked_try_create_program_address`] when
+    /// `target_os = "solana"`, but adds support for `target_os != "solana"` – it requires
+    /// the `curve25519` feature to be enabled in this case.
     ///
     /// # Examples
     ///
@@ -895,10 +776,6 @@ impl Pubkey {
     /// assert_eq!(expected_pda, actual_pda);
     /// # Ok::<(), anyhow::Error>(())
     /// ```
-    // If target_os = "solana", then the function will use
-    // syscalls which bring no dependencies.
-    // When target_os != "solana", this should be opt-in so users
-    // don't need the curve225519 dep.
     #[cfg(any(target_os = "solana", feature = "curve25519"))]
     pub fn create_program_address(
         seeds: &[&[u8]],
@@ -932,20 +809,9 @@ impl Pubkey {
         }
         // Call via a system call to perform the calculation
         #[cfg(target_os = "solana")]
-        {
-            let mut bytes = [0; 32];
-            let result = unsafe {
-                crate::syscalls::sol_create_program_address(
-                    seeds as *const _ as *const u8,
-                    seeds.len() as u64,
-                    program_id as *const _ as *const u8,
-                    &mut bytes as *mut _ as *mut u8,
-                )
-            };
-            match result {
-                SUCCESS => Ok(Pubkey::from(bytes)),
-                _ => Err(result.into()),
-            }
+        match solana_address::try_create_program_address(seeds, program_id.as_array()) {
+            Ok(address) => Ok(Pubkey::from(address)),
+            _ => Err(PubkeyError::InvalidSeeds),
         }
     }
 

--- a/pubkey/src/lib.rs
+++ b/pubkey/src/lib.rs
@@ -27,6 +27,7 @@ use {
         fmt,
         hash::{Hash, Hasher},
         mem::size_of,
+        ops::Deref,
         str::{from_utf8, FromStr},
     },
     num_traits::{FromPrimitive, ToPrimitive},
@@ -145,6 +146,15 @@ impl From<u64> for PubkeyError {
 #[derive(Clone, Copy, Default, Eq, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "dev-context-only-utils", derive(Arbitrary))]
 pub struct Pubkey(pub(crate) Address);
+
+impl Deref for Pubkey {
+    type Target = Address;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.as_array()
+    }
+}
 
 /// Custom impl of Hash for Pubkey
 /// allows us to skip hashing the length of the pubkey
@@ -1463,5 +1473,14 @@ mod tests {
         assert_eq!(key.as_array(), &key.to_bytes());
         // Sanity check: ensure the pointer is the same.
         assert_eq!(key.as_array().as_ptr(), key.0.as_ptr());
+    }
+
+    #[test]
+    fn test_deref_to_address() {
+        let address: Address = [1u8; 32];
+        let pubkey: Pubkey = address.into();
+        assert_eq!(*pubkey, address);
+        // Sanity check: ensure the pointer is the same.
+        assert_eq!(pubkey.as_ptr(), pubkey.as_array().as_ptr());
     }
 }

--- a/pubkey/src/lib.rs
+++ b/pubkey/src/lib.rs
@@ -12,7 +12,7 @@ use arbitrary::Arbitrary;
 use bytemuck_derive::{Pod, Zeroable};
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
-pub use solana_address::{MAX_SEEDS, MAX_SEED_LEN, PUBKEY_BYTES};
+pub use solana_address::{ADDRESS_BYTES as PUBKEY_BYTES, MAX_SEEDS, MAX_SEED_LEN};
 #[cfg(any(feature = "std", target_arch = "wasm32"))]
 use std::vec::Vec;
 #[cfg(feature = "borsh")]

--- a/pubkey/src/syscalls.rs
+++ b/pubkey/src/syscalls.rs
@@ -1,4 +1,4 @@
 /// Syscall definitions used by `solana_pubkey`.
-pub use solana_define_syscall::definitions::{
+pub use solana_address::{
     sol_create_program_address, sol_log_pubkey, sol_try_find_program_address,
 };


### PR DESCRIPTION
### Problem

While a Solana address is represented by a `[u8; 32]` array, addresses are currently represented by a "wrapper" `Pubkey` type over the `[u8; 32]` array.

It is very common to use the `Pubkey` type in user-defined structs representing account data, which eventually are serialized.  The drawback of using a `Pubkey` in this context is that a `Pubkey` needs to implement additional traits to support all the different serialization frameworks. For example, to use the [`zerocopy`](https://crates.io/crates/zerocopy) crate to interact with account data, its traits need to be implemented on the SDK's `Pubkey` type; the same is true for any other/new serialization framework.

### Solution

Define a lightweight `Address` type to represent Solana addresses:
```rust
pub const ADDRESS_BYTES: usize = 32;

pub type Address = [u8; ADDRESS_BYTES];
```
Since an `Address` is simply an alias to a `[u8; 32]` array, most (if not all) serialization frameworks include support for byte arrays.

The syscalls to derive program addresses are also moved to this crate, since they operate over a `[u8; 32]` array. The `solana-pubkey` crate provide wrappers around the provided helpers to add the implementation for targets other than "solana".

The `Address` type can be used to replace Pinocchio's `Pubkey` type (see https://github.com/anza-xyz/pinocchio/pull/118).

> [!NOTE]
> This PR depends on #12 so the failure of the "crate dependencies for publishing" is expected.

cc: @kevinheavey 