### PR TITLE
CI: Add powerset clippy check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -238,6 +238,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           nightly-toolchain: true
+          clippy: true
           cargo-cache-key: cargo-nightly-hack
           cargo-cache-fallback-key: cargo-nightly
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -239,7 +239,7 @@ jobs:
         with:
           nightly-toolchain: true
           clippy: true
-          cargo-cache-key: cargo-nightly-hack
+          cargo-cache-key: cargo-nightly-powerset
           cargo-cache-fallback-key: cargo-nightly
 
       - name: Install cargo-hack

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -226,6 +226,29 @@ jobs:
       - name: Run hack check
         run: ./scripts/check-hack.sh
 
+  powerset:
+    name: Cargo check powerset
+    runs-on: ubuntu-latest
+    needs: [sanity]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          nightly-toolchain: true
+          cargo-cache-key: cargo-nightly-hack
+          cargo-cache-fallback-key: cargo-nightly
+
+      - name: Install cargo-hack
+        uses: taiki-e/cache-cargo-install-action@v2
+        with:
+          tool: cargo-hack
+
+      - name: Check feature powerset
+        run: ./scripts/check-powerset.sh
+
   minimal-versions:
     name: Check minimal-versions
     runs-on: ubuntu-latest

--- a/message/Cargo.toml
+++ b/message/Cargo.toml
@@ -61,6 +61,7 @@ frozen-abi = [
     "dep:solana-logger",
     "solana-hash/frozen-abi",
     "solana-pubkey/frozen-abi",
+    "serde",
 ]
 serde = [
     "dep:serde",

--- a/scripts/check-powerset.sh
+++ b/scripts/check-powerset.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+here="$(dirname "$0")"
+src_root="$(readlink -f "${here}/..")"
+cd "${src_root}"
+
+./cargo nightly hack clippy --feature-powerset --no-dev-deps -- --deny=warnings

--- a/signature/src/error.rs
+++ b/signature/src/error.rs
@@ -1,7 +1,7 @@
 //! Signature error copied directly from RustCrypto's opaque signature error at
 //! https://github.com/RustCrypto/traits/tree/master/signature
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "std", feature = "alloc"))]
 use alloc::boxed::Box;
 use core::fmt::{self, Debug, Display};
 
@@ -22,7 +22,7 @@ use core::fmt::{self, Debug, Display};
 #[non_exhaustive]
 pub struct Error {
     /// Source of the error (if applicable).
-    #[cfg(feature = "std")]
+    #[cfg(all(feature = "std", feature = "alloc"))]
     source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
 }
 
@@ -33,7 +33,7 @@ impl Error {
     /// errors e.g. signature parsing or verification errors. The intended use
     /// cases are for propagating errors related to external signers, e.g.
     /// communication/authentication errors with HSMs, KMS, etc.
-    #[cfg(feature = "std")]
+    #[cfg(all(feature = "std", feature = "alloc"))]
     pub fn from_source(
         source: impl Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
     ) -> Self {
@@ -44,12 +44,12 @@ impl Error {
 }
 
 impl Debug for Error {
-    #[cfg(not(feature = "std"))]
+    #[cfg(not(all(feature = "std", feature = "alloc")))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("signature::Error {}")
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(all(feature = "std", feature = "alloc"))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("signature::Error { source: ")?;
 
@@ -69,7 +69,7 @@ impl Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", feature = "alloc"))]
 impl From<Box<dyn std::error::Error + Send + Sync + 'static>> for Error {
     fn from(source: Box<dyn std::error::Error + Send + Sync + 'static>) -> Error {
         Self::from_source(source)

--- a/sysvar/src/slot_hashes.rs
+++ b/sysvar/src/slot_hashes.rs
@@ -182,7 +182,6 @@ impl PodSlotHashes {
 #[deprecated(since = "2.1.0", note = "Please use `PodSlotHashes` instead")]
 pub struct SlotHashesSysvar;
 
-#[cfg(feature = "bincode")]
 #[allow(deprecated)]
 impl SlotHashesSysvar {
     #[cfg(feature = "bytemuck")]
@@ -209,7 +208,7 @@ impl SlotHashesSysvar {
     }
 }
 
-#[cfg(all(feature = "bincode", feature = "bytemuck"))]
+#[cfg(feature = "bytemuck")]
 fn get_pod_slot_hashes() -> Result<Vec<PodSlotHash>, solana_program_error::ProgramError> {
     let mut pod_hashes = vec![PodSlotHash::default(); solana_slot_hashes::MAX_ENTRIES];
     {

--- a/sysvar/src/slot_hashes.rs
+++ b/sysvar/src/slot_hashes.rs
@@ -52,8 +52,11 @@ use bytemuck_derive::{Pod, Zeroable};
 use {crate::Sysvar, solana_account_info::AccountInfo};
 use {solana_clock::Slot, solana_hash::Hash};
 
-#[cfg(all(feature = "bincode", feature = "bytemuck"))]
+#[cfg(feature = "bytemuck")]
 const U64_SIZE: usize = std::mem::size_of::<u64>();
+
+#[cfg(any(feature = "bytemuck", feature = "bincode"))]
+const SYSVAR_LEN: usize = 20_488; // golden, update if MAX_ENTRIES changes
 
 pub use {
     solana_sdk_ids::sysvar::slot_hashes::{check_id, id, ID},
@@ -66,7 +69,7 @@ impl Sysvar for SlotHashes {
     // override
     fn size_of() -> usize {
         // hard-coded so that we don't have to construct an empty
-        20_488 // golden, update if MAX_ENTRIES changes
+        SYSVAR_LEN
     }
     fn from_account_info(
         _account_info: &AccountInfo,
@@ -102,7 +105,7 @@ impl PodSlotHashes {
     /// Fetch all of the raw sysvar data using the `sol_get_sysvar` syscall.
     pub fn fetch() -> Result<Self, solana_program_error::ProgramError> {
         // Allocate an uninitialized buffer for the raw sysvar data.
-        let sysvar_len = SlotHashes::size_of();
+        let sysvar_len = SYSVAR_LEN;
         let mut data = vec![0; sysvar_len];
 
         // Ensure the created buffer is aligned to 8.
@@ -206,7 +209,7 @@ impl SlotHashesSysvar {
     }
 }
 
-#[cfg(feature = "bytemuck")]
+#[cfg(all(feature = "bincode", feature = "bytemuck"))]
 fn get_pod_slot_hashes() -> Result<Vec<PodSlotHash>, solana_program_error::ProgramError> {
     let mut pod_hashes = vec![PodSlotHash::default(); solana_slot_hashes::MAX_ENTRIES];
     {
@@ -219,7 +222,7 @@ fn get_pod_slot_hashes() -> Result<Vec<PodSlotHash>, solana_program_error::Progr
         }
 
         let offset = 8; // Vector length as `u64`.
-        let length = (SlotHashes::size_of() as u64).saturating_sub(offset);
+        let length = (SYSVAR_LEN as u64).saturating_sub(offset);
         crate::get_sysvar(data, &SlotHashes::id(), offset, length)?;
     }
     Ok(pod_hashes)


### PR DESCRIPTION
#### Problem

As pointed out in #108, we don't explicitly check for all combinations of features in the sdk, and more specifically, we miss warnings.

#### Summary of changes

Add a CI step to run `cargo clippy -- --deny=warnings` on the powerset of features in the sdk. Currently, this means 888 different crate builds, but most of them are quite short.

Let's see how long it takes to run in CI to see if it's worth adding.

Also, fix some little issues that came up while running this.