### PR TITLE
CI: Remove nightly check, add more to hack check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,7 +185,7 @@ jobs:
       - name: Run semver checks
         run: ./scripts/check-semver.sh
 
-  hack:
+  check:
     name: Cargo hack check
     runs-on: ubuntu-latest
     needs: [sanity]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,24 +83,6 @@ jobs:
       - name: Check formatting
         run: ./scripts/check-fmt.sh
 
-  check:
-    name: Cargo check
-    runs-on: ubuntu-latest
-    needs: [sanity]
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Environment
-        uses: ./.github/actions/setup
-        with:
-          nightly-toolchain: true
-          cargo-cache-key: cargo-nightly-check
-          cargo-cache-fallback-key: cargo-nightly
-
-      - name: Run checks
-        run: ./scripts/check-nightly.sh
-
   check-downstream-agave:
     if: false # re-enable after agave uses loader-v3-interface v3
     name: Cargo check Agave master

--- a/scripts/check-hack.sh
+++ b/scripts/check-hack.sh
@@ -5,4 +5,4 @@ here="$(dirname "$0")"
 src_root="$(readlink -f "${here}/..")"
 cd "${src_root}"
 
-./cargo nightly hack check --all-targets
+./cargo nightly hack check --all-targets --locked --features frozen-abi --ignore-unknown-features

--- a/scripts/check-nightly.sh
+++ b/scripts/check-nightly.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -eo pipefail
-here="$(dirname "$0")"
-src_root="$(readlink -f "${here}/..")"
-cd "${src_root}"
-
-./cargo nightly check --locked --workspace --all-targets --features frozen-abi


### PR DESCRIPTION
#### Problem

We've been adding a lot of new CI steps to the SDK, but some of them might be redundant, causing us to use more CI resources than necessary.

For example, we run `./cargo nightly check` and `./cargo nightly hack check`. Are both of those really necessary?

#### Summary of changes

Remove the nightly check CI job and script, and add some of those features and flags to the hack check.

NOTE: I'm not 100% sure about this, so let me know what you think!