### PR TITLE
secp256k1: Deprecate libsecp256k1 from public interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3708,6 +3708,7 @@ dependencies = [
  "solana-sdk",
  "solana-sdk-ids",
  "solana-secp256k1-program",
+ "solana-signature",
  "solana-signer",
 ]
 

--- a/secp256k1-program/Cargo.toml
+++ b/secp256k1-program/Cargo.toml
@@ -20,6 +20,7 @@ solana-feature-set = { workspace = true, optional = true }
 solana-instruction = { workspace = true, features = ["std"], optional = true }
 solana-precompile-error = { workspace = true, optional = true }
 solana-sdk-ids = { workspace = true, optional = true }
+solana-signature = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
#### Problem

The libsecp256k1 crate used by the secp256k1-program is unmaintained, but its types appear in the public API of the crate, so we can't upgrade or change the library without breaking users.

#### Summary of changes

Abstract away the usage of libsecp256k1 by introducing new generic functions that simply take in byte arrays.