### PR TITLE
Bump stable rust version to 1.85.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.84.1"
+channel = "1.85.1"


### PR DESCRIPTION
#### Problem

Rust v1.85.1 is now available, but the sdk repo is still on 1.84.1

#### Summary of changes

Bump the version declared in rust-toolchain.toml