### PR TITLE
Replace `std::error::Error` with `core::error::Error`

### DIFF
--- a/address-lookup-table-interface/Cargo.toml
+++ b/address-lookup-table-interface/Cargo.toml
@@ -3,6 +3,7 @@ name = "solana-address-lookup-table-interface"
 description = "Solana address lookup table interface."
 documentation = "https://docs.rs/solana-address-lookup-table-interface"
 version = "2.2.2"
+rust-version = "1.81.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/address-lookup-table-interface/src/error.rs
+++ b/address-lookup-table-interface/src/error.rs
@@ -15,7 +15,7 @@ pub enum AddressLookupError {
     InvalidLookupIndex,
 }
 
-impl std::error::Error for AddressLookupError {}
+impl core::error::Error for AddressLookupError {}
 
 impl fmt::Display for AddressLookupError {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> fmt::Result {

--- a/bls-signatures/Cargo.toml
+++ b/bls-signatures/Cargo.toml
@@ -3,6 +3,7 @@ name = "solana-bls-signatures"
 description = "Solana BLS Signatures"
 documentation = "https://docs.rs/solana-bls-signatures"
 version = "0.1.0"
+rust-version = "1.81.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/bls-signatures/src/keypair.rs
+++ b/bls-signatures/src/keypair.rs
@@ -120,7 +120,7 @@ impl Keypair {
     pub fn write_json_file<F: AsRef<Path>>(
         &self,
         outfile: F,
-    ) -> Result<String, Box<dyn std::error::Error>> {
+    ) -> Result<String, Box<dyn core::error::Error>> {
         let outfile = outfile.as_ref();
 
         if let Some(outdir) = outfile.parent() {

--- a/commitment-config/Cargo.toml
+++ b/commitment-config/Cargo.toml
@@ -3,6 +3,7 @@ name = "solana-commitment-config"
 description = "Solana commitment config."
 documentation = "https://docs.rs/solana-commitment-config"
 version = "2.2.1"
+rust-version = "1.81.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/commitment-config/src/lib.rs
+++ b/commitment-config/src/lib.rs
@@ -126,7 +126,7 @@ pub enum ParseCommitmentLevelError {
     Invalid,
 }
 
-impl std::error::Error for ParseCommitmentLevelError {}
+impl core::error::Error for ParseCommitmentLevelError {}
 
 impl fmt::Display for ParseCommitmentLevelError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/derivation-path/Cargo.toml
+++ b/derivation-path/Cargo.toml
@@ -3,6 +3,7 @@ name = "solana-derivation-path"
 description = "Solana BIP44 derivation paths."
 documentation = "https://docs.rs/solana-derivation-path"
 version = "2.2.1"
+rust-version = "1.81.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/derivation-path/src/lib.rs
+++ b/derivation-path/src/lib.rs
@@ -30,7 +30,7 @@ pub enum DerivationPathError {
     Infallible,
 }
 
-impl std::error::Error for DerivationPathError {}
+impl core::error::Error for DerivationPathError {}
 
 impl fmt::Display for DerivationPathError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -224,7 +224,7 @@ const QUERY_KEY_KEY: &str = "key";
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct QueryKeyError(String);
 
-impl std::error::Error for QueryKeyError {}
+impl core::error::Error for QueryKeyError {}
 
 impl fmt::Display for QueryKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/hash/Cargo.toml
+++ b/hash/Cargo.toml
@@ -3,6 +3,7 @@ name = "solana-hash"
 description = "Solana wrapper for the 32-byte output of a hashing algorithm."
 documentation = "https://docs.rs/solana-hash"
 version = "2.3.0"
+rust-version = "1.81.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/hash/src/lib.rs
+++ b/hash/src/lib.rs
@@ -91,8 +91,7 @@ pub enum ParseHashError {
     Invalid,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ParseHashError {}
+impl core::error::Error for ParseHashError {}
 
 impl fmt::Display for ParseHashError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/instruction-error/Cargo.toml
+++ b/instruction-error/Cargo.toml
@@ -3,6 +3,7 @@ name = "solana-instruction-error"
 description = "Solana InstructionError type."
 documentation = "https://docs.rs/solana-instruction-error"
 version = "1.0.0"
+rust-version = "1.81.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/instruction-error/src/lib.rs
+++ b/instruction-error/src/lib.rs
@@ -205,8 +205,7 @@ pub enum InstructionError {
     // conversions must also be added
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for InstructionError {}
+impl core::error::Error for InstructionError {}
 
 impl fmt::Display for InstructionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -403,8 +402,7 @@ pub enum LamportsError {
     ArithmeticOverflow,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for LamportsError {}
+impl core::error::Error for LamportsError {}
 
 impl fmt::Display for LamportsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/keypair/Cargo.toml
+++ b/keypair/Cargo.toml
@@ -3,6 +3,7 @@ name = "solana-keypair"
 description = "Concrete implementation of a Solana `Signer`."
 documentation = "https://docs.rs/solana-keypair"
 version = "2.2.3"
+rust-version = "1.81.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/keypair/src/lib.rs
+++ b/keypair/src/lib.rs
@@ -284,7 +284,7 @@ pub fn keypair_from_seed(seed: &[u8]) -> Result<Keypair, Box<dyn error::Error>> 
 pub fn keypair_from_seed_phrase_and_passphrase(
     seed_phrase: &str,
     passphrase: &str,
-) -> Result<Keypair, Box<dyn std::error::Error>> {
+) -> Result<Keypair, Box<dyn core::error::Error>> {
     keypair_from_seed(&generate_seed_from_seed_phrase_and_passphrase(
         seed_phrase,
         passphrase,

--- a/message/Cargo.toml
+++ b/message/Cargo.toml
@@ -3,6 +3,7 @@ name = "solana-message"
 description = "Solana transaction message types."
 documentation = "https://docs.rs/solana-message"
 version = "2.4.0"
+rust-version = "1.81.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/message/src/compiled_keys.rs
+++ b/message/src/compiled_keys.rs
@@ -27,7 +27,7 @@ pub enum CompileError {
     UnknownInstructionKey(Pubkey),
 }
 
-impl std::error::Error for CompileError {}
+impl core::error::Error for CompileError {}
 
 impl fmt::Display for CompileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/precompile-error/Cargo.toml
+++ b/precompile-error/Cargo.toml
@@ -3,6 +3,7 @@ name = "solana-precompile-error"
 description = "Solana PrecompileError type"
 documentation = "https://docs.rs/solana-precompile-error"
 version = "2.2.2"
+rust-version = "1.81.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/precompile-error/src/lib.rs
+++ b/precompile-error/src/lib.rs
@@ -53,7 +53,7 @@ impl num_traits::ToPrimitive for PrecompileError {
     }
 }
 
-impl std::error::Error for PrecompileError {}
+impl core::error::Error for PrecompileError {}
 
 impl fmt::Display for PrecompileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/program-error/Cargo.toml
+++ b/program-error/Cargo.toml
@@ -3,6 +3,7 @@ name = "solana-program-error"
 description = "Solana ProgramError type and related definitions."
 documentation = "https://docs.rs/solana-program-error"
 version = "2.2.2"
+rust-version = "1.81.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/program-error/src/lib.rs
+++ b/program-error/src/lib.rs
@@ -88,8 +88,7 @@ pub enum ProgramError {
     IncorrectAuthority,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ProgramError {}
+impl core::error::Error for ProgramError {}
 
 impl fmt::Display for ProgramError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/pubkey/Cargo.toml
+++ b/pubkey/Cargo.toml
@@ -3,6 +3,7 @@ name = "solana-pubkey"
 description = "Solana account addresses"
 documentation = "https://docs.rs/solana-pubkey"
 version = "2.4.0"
+rust-version = "1.81.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/pubkey/src/lib.rs
+++ b/pubkey/src/lib.rs
@@ -103,8 +103,7 @@ impl FromPrimitive for PubkeyError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for PubkeyError {}
+impl core::error::Error for PubkeyError {}
 
 impl fmt::Display for PubkeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -368,8 +367,7 @@ impl FromPrimitive for ParsePubkeyError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ParsePubkeyError {}
+impl core::error::Error for ParsePubkeyError {}
 
 impl fmt::Display for ParsePubkeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/quic-definitions/Cargo.toml
+++ b/quic-definitions/Cargo.toml
@@ -3,6 +3,7 @@ name = "solana-quic-definitions"
 description = "Definitions related to Solana over QUIC."
 documentation = "https://docs.rs/solana-quic-definitions"
 version = "2.3.1"
+rust-version = "1.81.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/quic-definitions/src/lib.rs
+++ b/quic-definitions/src/lib.rs
@@ -56,5 +56,5 @@ pub const QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO: u64 = 128;
 pub const QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO: u64 = 512;
 
 pub trait NotifyKeyUpdate {
-    fn update_key(&self, key: &Keypair) -> Result<(), Box<dyn std::error::Error>>;
+    fn update_key(&self, key: &Keypair) -> Result<(), Box<dyn core::error::Error>>;
 }

--- a/sanitize/Cargo.toml
+++ b/sanitize/Cargo.toml
@@ -2,6 +2,7 @@
 name = "solana-sanitize"
 description = "Solana Message Sanitization"
 documentation = "https://docs.rs/solana-sanitize"
+rust-version = "1.81.0"
 version = "2.2.1"
 authors = { workspace = true }
 repository = { workspace = true }

--- a/sanitize/src/lib.rs
+++ b/sanitize/src/lib.rs
@@ -1,6 +1,6 @@
 //! A trait for sanitizing values and members of over the wire messages.
 
-use {core::fmt, std::error::Error};
+use {core::error::Error, core::fmt};
 
 #[derive(PartialEq, Debug, Eq, Clone)]
 pub enum SanitizeError {

--- a/sanitize/src/lib.rs
+++ b/sanitize/src/lib.rs
@@ -1,6 +1,6 @@
 //! A trait for sanitizing values and members of over the wire messages.
 
-use {core::error::Error, core::fmt};
+use core::{error::Error, fmt};
 
 #[derive(PartialEq, Debug, Eq, Clone)]
 pub enum SanitizeError {

--- a/secp256r1-program/Cargo.toml
+++ b/secp256r1-program/Cargo.toml
@@ -3,6 +3,7 @@ name = "solana-secp256r1-program"
 description = "Precompile implementation for the secp256r1 elliptic curve."
 documentation = "https://docs.rs/solana-secp256r1"
 version = "2.2.4"
+rust-version = "1.81.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/secp256r1-program/src/lib.rs
+++ b/secp256r1-program/src/lib.rs
@@ -78,7 +78,7 @@ mod target_arch {
     pub fn sign_message(
         message: &[u8],
         priv_key_bytes_der: &[u8],
-    ) -> Result<[u8; SIGNATURE_SERIALIZED_SIZE], Box<dyn std::error::Error>> {
+    ) -> Result<[u8; SIGNATURE_SERIALIZED_SIZE], Box<dyn core::error::Error>> {
         let signing_key = EcKey::private_key_from_der(priv_key_bytes_der)?;
         if signing_key.group().curve_name() != Some(Nid::X9_62_PRIME256V1) {
             return Err(("Signing key must be on the secp256r1 curve".to_string()).into());

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -3,6 +3,7 @@ name = "solana-signature"
 description = "Solana 64-byte signature type"
 documentation = "https://docs.rs/solana-signature"
 version = "2.3.0"
+rust-version = "1.81.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/signature/src/error.rs
+++ b/signature/src/error.rs
@@ -1,7 +1,7 @@
 //! Signature error copied directly from
 //! [RustCrypto's opaque signature error](https://github.com/RustCrypto/traits/tree/master/signature)
 
-#[cfg(all(feature = "std", feature = "alloc"))]
+#[cfg(feature = "alloc")]
 use alloc::boxed::Box;
 use core::fmt::{self, Debug, Display};
 
@@ -12,10 +12,10 @@ use core::fmt::{self, Debug, Display};
 /// (e.g. [BB'06]).
 ///
 /// When the `std` feature is enabled, it impls
-/// [`std::error::Error`](https://doc.rust-lang.org/std/error/trait.Error.html).
+/// [`core::error::Error`](https://doc.rust-lang.org/core/error/trait.Error.html).
 ///
 /// When the `alloc` feature is enabled, it supports an optional
-/// [`std::error::Error::source`](https://doc.rust-lang.org/std/error/trait.Error.html#method.source),
+/// [`core::error::Error::source`](https://doc.rust-lang.org/core/error/trait.Error.html#method.source),
 /// which can be used by things like remote signers (e.g. HSM, KMS) to report
 /// I/O or auth errors.
 ///
@@ -24,8 +24,8 @@ use core::fmt::{self, Debug, Display};
 #[non_exhaustive]
 pub struct Error {
     /// Source of the error (if applicable).
-    #[cfg(all(feature = "std", feature = "alloc"))]
-    source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    #[cfg(feature = "alloc")]
+    source: Option<Box<dyn core::error::Error + Send + Sync + 'static>>,
 }
 
 impl Error {
@@ -35,9 +35,9 @@ impl Error {
     /// errors e.g. signature parsing or verification errors. The intended use
     /// cases are for propagating errors related to external signers, e.g.
     /// communication/authentication errors with HSMs, KMS, etc.
-    #[cfg(all(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     pub fn from_source(
-        source: impl Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+        source: impl Into<Box<dyn core::error::Error + Send + Sync + 'static>>,
     ) -> Self {
         Self {
             source: Some(source.into()),
@@ -46,12 +46,12 @@ impl Error {
 }
 
 impl Debug for Error {
-    #[cfg(not(all(feature = "std", feature = "alloc")))]
+    #[cfg(not(feature = "alloc"))]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("signature::Error {}")
     }
 
-    #[cfg(all(feature = "std", feature = "alloc"))]
+    #[cfg(feature = "alloc")]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("signature::Error { source: ")?;
 
@@ -71,18 +71,24 @@ impl Display for Error {
     }
 }
 
-#[cfg(all(feature = "std", feature = "alloc"))]
-impl From<Box<dyn std::error::Error + Send + Sync + 'static>> for Error {
-    fn from(source: Box<dyn std::error::Error + Send + Sync + 'static>) -> Error {
+#[cfg(feature = "alloc")]
+impl From<Box<dyn core::error::Error + Send + Sync + 'static>> for Error {
+    fn from(source: Box<dyn core::error::Error + Send + Sync + 'static>) -> Error {
         Self::from_source(source)
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        self.source
-            .as_ref()
-            .map(|source| source.as_ref() as &(dyn std::error::Error + 'static))
+impl core::error::Error for Error {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        #[cfg(feature = "alloc")]
+        {
+            self.source()
+                .as_ref()
+                .map(|source| source.as_ref() as &(dyn core::error::Error + 'static))
+        }
+	#[cfg(not(feature = "alloc"))]
+	{
+	    None
+	}
     }
 }

--- a/signature/src/error.rs
+++ b/signature/src/error.rs
@@ -82,13 +82,13 @@ impl core::error::Error for Error {
     fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         #[cfg(feature = "alloc")]
         {
-            self.source()
+            self.source
                 .as_ref()
                 .map(|source| source.as_ref() as &(dyn core::error::Error + 'static))
         }
-	#[cfg(not(feature = "alloc"))]
-	{
-	    None
-	}
+        #[cfg(not(feature = "alloc"))]
+        {
+            None
+        }
     }
 }

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -12,8 +12,9 @@ use core::{
 extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
+use core::error::Error;
 #[cfg(feature = "std")]
-use std::{error::Error, vec::Vec};
+use std::vec::Vec;
 #[cfg(feature = "serde")]
 use {
     serde_big_array::BigArray,
@@ -139,7 +140,6 @@ pub enum ParseSignatureError {
     Invalid,
 }
 
-#[cfg(feature = "std")]
 impl Error for ParseSignatureError {}
 
 impl fmt::Display for ParseSignatureError {

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -3,6 +3,7 @@ name = "solana-signer"
 description = "Abstractions for Solana transaction signers. See `solana-keypair` for a concrete implementation."
 documentation = "https://docs.rs/solana-signer"
 version = "2.2.1"
+rust-version = "1.81.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -22,7 +22,7 @@ pub enum PresignerError {
     VerificationFailure,
 }
 
-impl std::error::Error for PresignerError {}
+impl core::error::Error for PresignerError {}
 
 impl fmt::Display for PresignerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -49,8 +49,8 @@ pub enum SignerError {
     TooManySigners,
 }
 
-impl std::error::Error for SignerError {
-    fn source(&self) -> ::core::option::Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for SignerError {
+    fn source(&self) -> ::core::option::Option<&(dyn core::error::Error + 'static)> {
         match self {
             Self::KeypairPubkeyMismatch => None,
             Self::NotEnoughSigners => None,

--- a/transaction-error/Cargo.toml
+++ b/transaction-error/Cargo.toml
@@ -3,6 +3,7 @@ name = "solana-transaction-error"
 description = "Solana TransactionError type"
 documentation = "https://docs.rs/solana-transaction-error"
 version = "2.2.1"
+rust-version = "1.81.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/transaction-error/src/lib.rs
+++ b/transaction-error/src/lib.rs
@@ -142,7 +142,7 @@ pub enum TransactionError {
     CommitCancelled,
 }
 
-impl std::error::Error for TransactionError {}
+impl core::error::Error for TransactionError {}
 
 impl fmt::Display for TransactionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -268,7 +268,7 @@ pub enum AddressLoaderError {
 }
 
 #[cfg(not(target_os = "solana"))]
-impl std::error::Error for AddressLoaderError {}
+impl core::error::Error for AddressLoaderError {}
 
 #[cfg(not(target_os = "solana"))]
 impl fmt::Display for AddressLoaderError {
@@ -314,8 +314,8 @@ pub enum SanitizeMessageError {
 }
 
 #[cfg(not(target_os = "solana"))]
-impl std::error::Error for SanitizeMessageError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for SanitizeMessageError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
             Self::IndexOutOfBounds => None,
             Self::ValueOutOfBounds => None,
@@ -365,8 +365,8 @@ pub enum TransportError {
 }
 
 #[cfg(not(target_os = "solana"))]
-impl std::error::Error for TransportError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for TransportError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
             TransportError::IoError(e) => Some(e),
             TransportError::TransactionError(e) => Some(e),

--- a/vote-interface/Cargo.toml
+++ b/vote-interface/Cargo.toml
@@ -3,6 +3,7 @@ name = "solana-vote-interface"
 description = "Solana vote interface."
 documentation = "https://docs.rs/solana-vote-interface"
 version = "2.2.5"
+rust-version = "1.81.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/vote-interface/src/error.rs
+++ b/vote-interface/src/error.rs
@@ -32,7 +32,7 @@ pub enum VoteError {
     AssertionFailed,
 }
 
-impl std::error::Error for VoteError {}
+impl core::error::Error for VoteError {}
 
 impl fmt::Display for VoteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
This PR simply replaces instances of `std::error::Error` with `core::error::Error`. It fixes #81, but as mentioned in the issue, it should probably be merged after #115.

Regards,

Divya.