### PR TITLE
build: Add `js` Cargo feature flag for WASM builds

### DIFF
--- a/hash/Cargo.toml
+++ b/hash/Cargo.toml
@@ -20,6 +20,7 @@ bs58 = { workspace = true, default-features = false }
 bytemuck = { workspace = true, optional = true }
 bytemuck_derive = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
+js-sys = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 solana-atomic-u64 = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
@@ -29,6 +30,7 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
 solana-sanitize = { workspace = true }
+wasm-bindgen = { workspace = true, optional = true }
 
 [dev-dependencies]
 solana-hash = { path = ".", features = ["dev-context-only-utils"] }
@@ -47,6 +49,7 @@ frozen-abi = [
     "dep:solana-frozen-abi-macro",
     "std"
 ]
+js = ["dep:wasm-bindgen", "dep:js-sys"]
 serde = ["dep:serde", "dep:serde_derive"]
 std = []
 

--- a/hash/src/lib.rs
+++ b/hash/src/lib.rs
@@ -19,7 +19,7 @@ use {
     },
     solana_sanitize::Sanitize,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "js")]
 use {
     js_sys::{Array, Uint8Array},
     std::{boxed::Box, format, string::String, vec},
@@ -38,7 +38,7 @@ pub const MAX_BASE58_LEN: usize = 44;
 ///
 /// [SHA-256]: https://en.wikipedia.org/wiki/SHA-2
 /// [blake3]: https://github.com/BLAKE3-team/BLAKE3
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[cfg_attr(
     feature = "borsh",
@@ -151,7 +151,7 @@ impl Hash {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "js")]
 #[allow(non_snake_case)]
 #[wasm_bindgen]
 impl Hash {

--- a/instruction/Cargo.toml
+++ b/instruction/Cargo.toml
@@ -12,20 +12,18 @@ edition = { workspace = true }
 [dependencies]
 bincode = { workspace = true, optional = true }
 borsh = { workspace = true, optional = true }
+getrandom = { workspace = true, optional = true, features = ["js", "wasm-bindgen"] }
+js-sys = { workspace = true, optional = true }
 num-traits = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-pubkey = { workspace = true, default-features = false }
+wasm-bindgen = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "solana")'.dependencies]
 solana-define-syscall = { workspace = true }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { workspace = true, features = ["js", "wasm-bindgen"] }
-js-sys = { workspace = true }
-wasm-bindgen = { workspace = true }
 
 [dev-dependencies]
 solana-instruction = { path = ".", features = ["borsh"] }
@@ -40,6 +38,7 @@ frozen-abi = [
     "serde",
     "std",
 ]
+js = ["dep:getrandom", "dep:wasm-bindgen", "dep:js-sys"]
 serde = [
     "dep:serde",
     "dep:serde_derive",

--- a/instruction/src/lib.rs
+++ b/instruction/src/lib.rs
@@ -26,7 +26,7 @@ pub use account_meta::AccountMeta;
 pub mod error;
 #[cfg(target_os = "solana")]
 pub mod syscalls;
-#[cfg(all(feature = "std", target_arch = "wasm32"))]
+#[cfg(all(feature = "std", feature = "js"))]
 pub mod wasm;
 
 /// A directive for a single invocation of a Solana program.
@@ -88,7 +88,7 @@ pub mod wasm;
 /// Programs may require signatures from some accounts, in which case they
 /// should be specified as signers during `Instruction` construction. The
 /// program must still validate during execution that the account is a signer.
-#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
+#[cfg(all(feature = "std", not(feature = "js")))]
 #[cfg_attr(
     feature = "serde",
     derive(serde_derive::Serialize, serde_derive::Deserialize)
@@ -106,7 +106,7 @@ pub struct Instruction {
 /// wasm-bindgen version of the Instruction struct.
 /// This duplication is required until https://github.com/rustwasm/wasm-bindgen/issues/3671
 /// is fixed. This must not diverge from the regular non-wasm Instruction struct.
-#[cfg(all(feature = "std", target_arch = "wasm32"))]
+#[cfg(all(feature = "std", feature = "js"))]
 #[wasm_bindgen::prelude::wasm_bindgen]
 #[cfg_attr(
     feature = "serde",

--- a/keypair/Cargo.toml
+++ b/keypair/Cargo.toml
@@ -20,9 +20,7 @@ solana-seed-derivable = { workspace = true, optional = true }
 solana-seed-phrase = { workspace = true }
 solana-signature = { workspace = true, features = ["std", "verify"] }
 solana-signer = { workspace = true }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = { workspace = true }
+wasm-bindgen = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
@@ -30,6 +28,7 @@ static_assertions = { workspace = true }
 tiny-bip39 = { workspace = true }
 
 [features]
+js = ["dep:wasm-bindgen"]
 seed-derivable = ["dep:solana-derivation-path", "dep:solana-seed-derivable", "dep:ed25519-dalek-bip32"]
 
 [package.metadata.docs.rs]

--- a/keypair/src/lib.rs
+++ b/keypair/src/lib.rs
@@ -1,6 +1,6 @@
 //! Concrete implementation of a Solana `Signer` from raw bytes
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::*;
 use {
     ed25519_dalek::Signer as DalekSigner,
@@ -21,7 +21,7 @@ pub mod seed_derivable;
 pub mod signable;
 
 /// A vanilla Ed25519 key pair
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[derive(Debug)]
 pub struct Keypair(ed25519_dalek::Keypair);
 
@@ -119,7 +119,7 @@ impl TryFrom<&[u8]> for Keypair {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "js")]
 #[allow(non_snake_case)]
 #[wasm_bindgen]
 impl Keypair {

--- a/message/Cargo.toml
+++ b/message/Cargo.toml
@@ -29,9 +29,7 @@ solana-system-interface = { workspace = true, optional = true, features = [
     "bincode",
 ] }
 solana-transaction-error = { workspace = true }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = { workspace = true }
+wasm-bindgen = { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -62,6 +60,7 @@ frozen-abi = [
     "solana-hash/frozen-abi",
     "solana-pubkey/frozen-abi",
 ]
+js = ["dep:wasm-bindgen"]
 serde = [
     "dep:serde",
     "dep:serde_derive",

--- a/message/src/legacy.rs
+++ b/message/src/legacy.rs
@@ -17,7 +17,7 @@ pub use builtins::{BUILTIN_PROGRAMS_KEYS, MAYBE_BUILTIN_KEY_OR_SYSVAR};
 use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::{frozen_abi, AbiExample};
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::wasm_bindgen;
 use {
     crate::{
@@ -146,7 +146,7 @@ fn compile_instructions(ixs: &[Instruction], keys: &[Pubkey]) -> Vec<CompiledIns
 /// redundantly specifying the fee-payer is not strictly required.
 // NOTE: Serialization-related changes must be paired with the custom serialization
 // for versioned messages in the `RemainingLegacyMessage` struct.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(feature = "js"))]
 #[cfg_attr(
     feature = "frozen-abi",
     frozen_abi(digest = "2THeaWnXSGDTsiadKytJTcbjrk4KjfMww9arRLZcwGnw"),
@@ -179,7 +179,7 @@ pub struct Message {
 /// wasm-bindgen version of the Message struct.
 /// This duplication is required until https://github.com/rustwasm/wasm-bindgen/issues/3671
 /// is fixed. This must not diverge from the regular non-wasm Message struct.
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "js")]
 #[wasm_bindgen]
 #[cfg_attr(
     feature = "frozen-abi",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -19,6 +19,7 @@ borsh = { workspace = true, optional = true }
 borsh0-10 = { workspace = true, optional = true }
 bs58 = { workspace = true, features = ["alloc"] }
 bytemuck = { workspace = true }
+getrandom = { workspace = true, optional = true, features = ["js", "wasm-bindgen"] }
 lazy_static = { workspace = true }
 log = { workspace = true }
 memoffset = { workspace = true }
@@ -87,6 +88,7 @@ solana-sysvar = { workspace = true, features = ["bincode", "bytemuck"] }
 solana-sysvar-id = { workspace = true }
 solana-vote-interface = { workspace = true, features = ["bincode"] }
 thiserror = { workspace = true }
+wasm-bindgen = { workspace = true, optional = true }
 
 # This is currently needed to build on-chain programs reliably.
 # Borsh 0.10 may pull in hashbrown 0.13, which uses ahash 0.8, which uses
@@ -157,6 +159,7 @@ frozen-abi = [
     "solana-stake-interface/frozen-abi",
     "solana-sysvar/frozen-abi"
 ]
+js = ["dep:getrandom", "dep:wasm-bindgen"]
 
 [lints]
 workspace = true

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -567,7 +567,7 @@ pub use solana_stable_layout as stable_layout;
 pub use solana_sysvar::program_stubs;
 #[deprecated(since = "2.2.0", note = "Use `solana-vote-interface` crate instead")]
 pub use solana_vote_interface as vote;
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "js")]
 pub use wasm_bindgen::prelude::wasm_bindgen;
 pub use {
     solana_account_info::{self as account_info, debug_account_data},

--- a/program/src/wasm/mod.rs
+++ b/program/src/wasm/mod.rs
@@ -1,5 +1,5 @@
 //! solana-program Javascript interface
-#![cfg(target_arch = "wasm32")]
+#![cfg(feature = "js")]
 #[deprecated(since = "2.2.0", note = "Use solana_instruction::wasm instead.")]
 pub use solana_instruction::wasm as instructions;
 use wasm_bindgen::prelude::*;

--- a/pubkey/Cargo.toml
+++ b/pubkey/Cargo.toml
@@ -18,6 +18,8 @@ bytemuck = { workspace = true, optional = true }
 bytemuck_derive = { workspace = true, optional = true }
 five8_const = { workspace = true }
 num-traits = { workspace = true }
+getrandom = { workspace = true, optional = true, features = ["js", "wasm-bindgen"] }
+js-sys = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
@@ -30,6 +32,7 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
 solana-sanitize = { workspace = true }
+wasm-bindgen = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "solana")'.dependencies]
 solana-define-syscall = { workspace = true }
@@ -38,11 +41,6 @@ solana-sha256-hasher = { workspace = true }
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 curve25519-dalek = { workspace = true, optional = true }
 solana-sha256-hasher = { workspace = true, optional = true }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { workspace = true, features = ["js", "wasm-bindgen"] }
-js-sys = { workspace = true }
-wasm-bindgen = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -71,6 +69,7 @@ frozen-abi = [
     "dep:solana-frozen-abi-macro",
     "std",
 ]
+js = ["dep:getrandom", "dep:wasm-bindgen", "dep:js-sys"]
 rand = ["dep:rand", "std"]
 serde = ["dep:serde", "dep:serde_derive"]
 sha2 = ["dep:solana-sha256-hasher", "solana-sha256-hasher/sha2"]

--- a/pubkey/src/lib.rs
+++ b/pubkey/src/lib.rs
@@ -31,7 +31,7 @@ use {
     num_traits::{FromPrimitive, ToPrimitive},
     solana_decode_error::DecodeError,
 };
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "js")]
 use {
     js_sys::{Array, Uint8Array},
     wasm_bindgen::{prelude::wasm_bindgen, JsCast, JsValue},
@@ -149,7 +149,7 @@ impl From<u64> for PubkeyError {
 /// [ed25519]: https://ed25519.cr.yp.to/
 /// [pdas]: https://solana.com/docs/core/cpi#program-derived-addresses
 /// [`Keypair`]: https://docs.rs/solana-sdk/latest/solana_sdk/signer/keypair/struct.Keypair.html
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(feature = "js", wasm_bindgen)]
 #[repr(transparent)]
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[cfg_attr(
@@ -1079,7 +1079,7 @@ macro_rules! impl_borsh_serialize {
 #[cfg(feature = "borsh")]
 impl_borsh_serialize!(borsh0_10);
 
-#[cfg(all(target_arch = "wasm32", feature = "curve25519"))]
+#[cfg(all(feature = "js", feature = "curve25519"))]
 fn js_value_to_seeds_vec(array_of_uint8_arrays: &[JsValue]) -> Result<Vec<Vec<u8>>, JsValue> {
     let vec_vec_u8 = array_of_uint8_arrays
         .iter()
@@ -1097,12 +1097,12 @@ fn js_value_to_seeds_vec(array_of_uint8_arrays: &[JsValue]) -> Result<Vec<Vec<u8
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "js")]
 fn display_to_jsvalue<T: fmt::Display>(display: T) -> JsValue {
     std::string::ToString::to_string(&display).into()
 }
 
-#[allow(non_snake_case)]
+#[cfg(feature = "js")]
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
 impl Pubkey {

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -19,7 +19,7 @@ program = []
 
 default = [
     "borsh",
-    "full",  # functionality that is not compatible or needed for on-chain programs
+    "full", # functionality that is not compatible or needed for on-chain programs
 ]
 full = [
     "serde_json",
@@ -85,6 +85,8 @@ openssl-vendored = ["solana-precompiles/openssl-vendored"]
 [dependencies]
 bincode = { workspace = true }
 bs58 = { workspace = true }
+getrandom = { version = "0.1.1", optional = true, features = ["wasm-bindgen"] }
+js-sys = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
 solana-account = { workspace = true, features = ["bincode"] }
@@ -173,11 +175,7 @@ solana-transaction-error = { workspace = true, features = [
 ], optional = true }
 solana-validator-exit = { workspace = true }
 thiserror = { workspace = true }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.1.1", features = ["wasm-bindgen"] }
-js-sys = { workspace = true }
-wasm-bindgen = { workspace = true }
+wasm-bindgen = { workspace = true, optional = true }
 
 [dev-dependencies]
 curve25519-dalek = { workspace = true }
@@ -190,6 +188,9 @@ serde_with = { workspace = true, features = ["macros"] }
 solana-instructions-sysvar = { workspace = true, features = ["dev-context-only-utils"] }
 solana-program = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk = { path = ".", features = ["dev-context-only-utils"] }
+
+[feature]
+js = ["dep:getrandom", "dep:wasm-bindgen", "dep:js-sys"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -42,7 +42,7 @@ pub use solana_program::program_stubs;
 // confusing duplication in the docs due to a rustdoc bug. #26211
 #[allow(deprecated)]
 pub use solana_program::sdk_ids;
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "js")]
 pub use solana_program::wasm_bindgen;
 pub use solana_program::{
     account_info, address_lookup_table, big_mod_exp, blake3, bpf_loader, bpf_loader_deprecated,

--- a/sdk/src/wasm/mod.rs
+++ b/sdk/src/wasm/mod.rs
@@ -1,5 +1,5 @@
 //! solana-sdk Javascript interface
-#![cfg(target_arch = "wasm32")]
+#![cfg(feature = "js")]
 
 pub mod keypair;
 pub mod transaction;

--- a/transaction/Cargo.toml
+++ b/transaction/Cargo.toml
@@ -19,6 +19,7 @@ solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
+solana-keypair = { workspace = true, optional = true }
 solana-logger = { workspace = true, optional = true }
 solana-message = { workspace = true }
 solana-precompiles = { workspace = true, optional = true }
@@ -30,10 +31,7 @@ solana-signature = { workspace = true }
 solana-signer = { workspace = true, optional = true }
 solana-system-interface = { workspace = true, optional = true, features = ["bincode"] }
 solana-transaction-error = { workspace = true }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-solana-keypair = { workspace = true }
-wasm-bindgen = { workspace = true }
+wasm-bindgen = { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -71,6 +69,7 @@ frozen-abi = [
     "dep:solana-frozen-abi-macro",
     "dep:solana-logger",
 ]
+js = ["dep:wasm-bindgen", "dep:solana-keypair"]
 precompiles = ["dep:solana-feature-set", "dep:solana-precompiles"]
 serde = [
     "dep:serde",

--- a/transaction/src/lib.rs
+++ b/transaction/src/lib.rs
@@ -110,7 +110,7 @@
 //! # Ok::<(), anyhow::Error>(())
 //! ```
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "js")]
 use wasm_bindgen::prelude::wasm_bindgen;
 #[cfg(feature = "serde")]
 use {
@@ -182,7 +182,7 @@ const PACKET_DATA_SIZE: usize = 1280 - 40 - 8;
 /// if the caller has knowledge that the first account of the constructed
 /// transaction's `Message` is both a signer and the expected fee-payer, then
 /// redundantly specifying the fee-payer is not strictly required.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(feature = "js"))]
 #[cfg_attr(
     feature = "frozen-abi",
     derive(solana_frozen_abi_macro::AbiExample),
@@ -210,7 +210,7 @@ pub struct Transaction {
 /// wasm-bindgen version of the Transaction struct.
 /// This duplication is required until https://github.com/rustwasm/wasm-bindgen/issues/3671
 /// is fixed. This must not diverge from the regular non-wasm Transaction struct.
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "js")]
 #[wasm_bindgen]
 #[cfg_attr(
     feature = "frozen-abi",

--- a/transaction/src/wasm.rs
+++ b/transaction/src/wasm.rs
@@ -1,5 +1,5 @@
 //! `Transaction` Javascript interface
-#![cfg(target_arch = "wasm32")]
+#![cfg(feature = "js")]
 #![allow(non_snake_case)]
 use {
     crate::Transaction, solana_hash::Hash, solana_instruction::wasm::Instructions,


### PR DESCRIPTION
Previously, the wasm32 target implicitly assumed a browser environment, which caused issues when building for non-browser WASM environments due to the unconditional inclusion of `wasm-bindgen`.

This commit introduces an explicit `js` feature flag, making `wasm-bindgen` and `js-sys` conditional dependencies. This allows greater flexibility for different WASM execution environments.

Related to #117