### PR TITLE
define-syscall: Add `no_std` attribute

### DIFF
--- a/define-syscall/src/lib.rs
+++ b/define-syscall/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 pub mod definitions;
 
 #[cfg(target_feature = "static-syscalls")]


### PR DESCRIPTION
### Problem

Currently the define-syscall crate is `no_std` "friendly" but does not have the crate attribute. This indirectly brings the `std` at link stage when trying to compile `no_std` programs:
```
error[E0152]: found duplicate lang item `panic_impl`
 --> src/lib.rs:9:1
  |
9 | pinocchio::nostd_panic_handler!();
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: the lang item is first defined in crate `std` (which `solana_define_syscall` depends on)
```

### Solution

Add the `#![no_std]` attribute to the crate.