### PR TITLE
program-memory: Add missing unsafe

### DIFF
--- a/account-info/src/lib.rs
+++ b/account-info/src/lib.rs
@@ -178,7 +178,7 @@ impl<'a> AccountInfo<'a> {
         if zero_init {
             let len_increase = new_len.saturating_sub(old_len);
             if len_increase > 0 {
-                sol_memset(&mut data[old_len..], 0, len_increase);
+                unsafe { sol_memset(&mut data[old_len..], 0, len_increase) };
             }
         }
 

--- a/program-memory/src/lib.rs
+++ b/program-memory/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 //! Basic low-level memory operations.
 //!
 //! Within the SBF environment, these are implemented as syscalls and executed by
@@ -10,6 +12,7 @@ pub mod syscalls {
     };
 }
 
+#[cfg(not(target_os = "solana"))]
 /// Check that two regions do not overlap.
 fn is_nonoverlapping(src: usize, src_len: usize, dst: usize, dst_len: usize) -> bool {
     // If the absolute distance between the ptrs is at least as big as the size of the other,
@@ -32,11 +35,11 @@ pub mod stubs {
             is_nonoverlapping(src as usize, n, dst as usize, n),
             "memcpy does not support overlapping regions"
         );
-        std::ptr::copy_nonoverlapping(src, dst, n);
+        core::ptr::copy_nonoverlapping(src, dst, n);
     }
     /// # Safety
     pub unsafe fn sol_memmove(dst: *mut u8, src: *const u8, n: usize) {
-        std::ptr::copy(src, dst, n);
+        core::ptr::copy(src, dst, n);
     }
     /// # Safety
     pub unsafe fn sol_memcmp(s1: *const u8, s2: *const u8, n: usize, result: *mut i32) {
@@ -54,7 +57,7 @@ pub mod stubs {
     }
     /// # Safety
     pub unsafe fn sol_memset(s: *mut u8, c: u8, n: usize) {
-        let s = std::slice::from_raw_parts_mut(s, n);
+        let s = core::slice::from_raw_parts_mut(s, n);
         for val in s.iter_mut().take(n) {
             *val = c;
         }
@@ -120,7 +123,7 @@ pub fn sol_memcpy(dst: &mut [u8], src: &[u8], n: usize) {
 ///
 /// The same safety rules apply as in [`ptr::copy`].
 ///
-/// [`ptr::copy`]: https://doc.rust-lang.org/std/ptr/fn.copy.html
+/// [`ptr::copy`]: https://doc.rust-lang.org/core/ptr/fn.copy.html
 #[inline]
 pub unsafe fn sol_memmove(dst: *mut u8, src: *const u8, n: usize) {
     #[cfg(target_os = "solana")]

--- a/program-memory/src/lib.rs
+++ b/program-memory/src/lib.rs
@@ -5,6 +5,8 @@
 //! Within the SBF environment, these are implemented as syscalls and executed by
 //! the runtime in native code.
 
+use core::mem::MaybeUninit;
+
 #[cfg(target_os = "solana")]
 pub mod syscalls {
     pub use solana_define_syscall::definitions::{
@@ -84,8 +86,6 @@ pub mod stubs {
 ///
 /// # Safety
 ///
-/// __This function is incorrectly missing an `unsafe` declaration.__
-///
 /// This function does not verify that `n` is less than or equal to the
 /// lengths of the `dst` and `src` slices passed to it &mdash; it will copy
 /// bytes to and from beyond the slices.
@@ -93,16 +93,12 @@ pub mod stubs {
 /// Specifying an `n` greater than either the length of `dst` or `src` will
 /// likely introduce undefined behavior.
 #[inline]
-pub fn sol_memcpy(dst: &mut [u8], src: &[u8], n: usize) {
+pub unsafe fn sol_memcpy(dst: &mut [u8], src: &[u8], n: usize) {
     #[cfg(target_os = "solana")]
-    unsafe {
-        syscalls::sol_memcpy_(dst.as_mut_ptr(), src.as_ptr(), n as u64);
-    }
+    syscalls::sol_memcpy_(dst.as_mut_ptr(), src.as_ptr(), n as u64);
 
     #[cfg(not(target_os = "solana"))]
-    unsafe {
-        stubs::sol_memcpy(dst.as_mut_ptr(), src.as_ptr(), n);
-    }
+    stubs::sol_memcpy(dst.as_mut_ptr(), src.as_ptr(), n);
 }
 
 /// Like C `memmove`.
@@ -149,8 +145,6 @@ pub unsafe fn sol_memmove(dst: *mut u8, src: *const u8, n: usize) {
 ///
 /// # Safety
 ///
-/// __This function is incorrectly missing an `unsafe` declaration.__
-///
 /// It does not verify that `n` is less than or equal to the lengths of the
 /// `dst` and `src` slices passed to it &mdash; it will read bytes beyond the
 /// slices.
@@ -158,20 +152,16 @@ pub unsafe fn sol_memmove(dst: *mut u8, src: *const u8, n: usize) {
 /// Specifying an `n` greater than either the length of `dst` or `src` will
 /// likely introduce undefined behavior.
 #[inline]
-pub fn sol_memcmp(s1: &[u8], s2: &[u8], n: usize) -> i32 {
-    let mut result = 0;
+pub unsafe fn sol_memcmp(s1: &[u8], s2: &[u8], n: usize) -> i32 {
+    let mut result: MaybeUninit<i32> = MaybeUninit::uninit();
 
     #[cfg(target_os = "solana")]
-    unsafe {
-        syscalls::sol_memcmp_(s1.as_ptr(), s2.as_ptr(), n as u64, &mut result as *mut i32);
-    }
+    syscalls::sol_memcmp_(s1.as_ptr(), s2.as_ptr(), n as u64, result.as_mut_ptr());
 
     #[cfg(not(target_os = "solana"))]
-    unsafe {
-        stubs::sol_memcmp(s1.as_ptr(), s2.as_ptr(), n, &mut result as *mut i32);
-    }
+    stubs::sol_memcmp(s1.as_ptr(), s2.as_ptr(), n, result.as_mut_ptr());
 
-    result
+    result.assume_init()
 }
 
 /// Like C `memset`.
@@ -190,8 +180,6 @@ pub fn sol_memcmp(s1: &[u8], s2: &[u8], n: usize) -> i32 {
 ///
 /// # Safety
 ///
-/// __This function is incorrectly missing an `unsafe` declaration.__
-///
 /// This function does not verify that `n` is less than or equal to the length
 /// of the `s` slice passed to it &mdash; it will write bytes beyond the
 /// slice.
@@ -199,16 +187,12 @@ pub fn sol_memcmp(s1: &[u8], s2: &[u8], n: usize) -> i32 {
 /// Specifying an `n` greater than the length of `s` will likely introduce
 /// undefined behavior.
 #[inline]
-pub fn sol_memset(s: &mut [u8], c: u8, n: usize) {
+pub unsafe fn sol_memset(s: &mut [u8], c: u8, n: usize) {
     #[cfg(target_os = "solana")]
-    unsafe {
-        syscalls::sol_memset_(s.as_mut_ptr(), c, n as u64);
-    }
+    syscalls::sol_memset_(s.as_mut_ptr(), c, n as u64);
 
     #[cfg(not(target_os = "solana"))]
-    unsafe {
-        stubs::sol_memset(s.as_mut_ptr(), c, n);
-    }
+    stubs::sol_memset(s.as_mut_ptr(), c, n);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Program

Currently there are a few functions on `program-memory` crate that are missing the "unsafe" qualifier.

### Solution

Add the missing "unsafe". This PR also adds the `no_std` attribute to the crate since it is already a `no_std` "friendly" crate.