### PR TITLE
rust: Bump nightly to 2025-04-01

### DIFF
--- a/file-download/src/lib.rs
+++ b/file-download/src/lib.rs
@@ -179,10 +179,7 @@ pub fn download_file<'a, 'b>(
             if let Some(callback) = self.callback {
                 if to_update_progress && !callback(&progress_record) {
                     info!("Download is aborted by the caller");
-                    return Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        "Download is aborted by the caller",
-                    ));
+                    return Err(io::Error::other("Download is aborted by the caller"));
                 }
             }
 

--- a/genesis-config/src/lib.rs
+++ b/genesis-config/src/lib.rs
@@ -161,37 +161,23 @@ impl GenesisConfig {
             .read(true)
             .open(&filename)
             .map_err(|err| {
-                std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("Unable to open {filename:?}: {err:?}"),
-                )
+                std::io::Error::other(format!("Unable to open {filename:?}: {err:?}"))
             })?;
 
         //UNSAFE: Required to create a Mmap
-        let mem = unsafe { Mmap::map(&file) }.map_err(|err| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("Unable to map {filename:?}: {err:?}"),
-            )
-        })?;
+        let mem = unsafe { Mmap::map(&file) }
+            .map_err(|err| std::io::Error::other(format!("Unable to map {filename:?}: {err:?}")))?;
 
         let genesis_config = deserialize(&mem).map_err(|err| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("Unable to deserialize {filename:?}: {err:?}"),
-            )
+            std::io::Error::other(format!("Unable to deserialize {filename:?}: {err:?}"))
         })?;
         Ok(genesis_config)
     }
 
     #[cfg(feature = "serde")]
     pub fn write(&self, ledger_path: &Path) -> Result<(), std::io::Error> {
-        let serialized = serialize(&self).map_err(|err| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("Unable to serialize: {err:?}"),
-            )
-        })?;
+        let serialized = serialize(&self)
+            .map_err(|err| std::io::Error::other(format!("Unable to serialize: {err:?}")))?;
 
         std::fs::create_dir_all(ledger_path)?;
 

--- a/keypair/src/lib.rs
+++ b/keypair/src/lib.rs
@@ -245,8 +245,7 @@ pub fn read_keypair<R: Read>(reader: &mut R) -> Result<Keypair, Box<dyn error::E
         let parsed: u8 = element.parse()?;
         out[idx] = parsed;
     }
-    Keypair::try_from(&out[..])
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()).into())
+    Keypair::try_from(&out[..]).map_err(|e| std::io::Error::other(e.to_string()).into())
 }
 
 /// Reads a `Keypair` from a file

--- a/loader-v3-interface/src/instruction.rs
+++ b/loader-v3-interface/src/instruction.rs
@@ -153,7 +153,7 @@ pub enum UpgradeableLoaderInstruction {
     ///   2. `[]` System program (`solana_sdk::system_program::id()`), optional, used to transfer
     ///      lamports from the payer to the ProgramData account.
     ///   3. `[writable, signer]` The payer account, optional, that will pay
-    ///       necessary rent exemption costs for the increased storage size.
+    ///      necessary rent exemption costs for the increased storage size.
     ExtendProgram {
         /// Number of bytes to extend the program data.
         additional_bytes: u32,

--- a/precompiles/src/lib.rs
+++ b/precompiles/src/lib.rs
@@ -34,7 +34,7 @@ impl Precompile {
         F: Fn(&Pubkey) -> bool,
     {
         self.feature
-            .map_or(true, |ref feature_id| is_enabled(feature_id))
+            .is_none_or(|ref feature_id| is_enabled(feature_id))
             && self.program_id == *program_id
     }
     /// Verify this precompiled program

--- a/scripts/rust-version.sh
+++ b/scripts/rust-version.sh
@@ -27,7 +27,7 @@ fi
 if [[ -n $RUST_NIGHTLY_VERSION ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2024-11-22
+  nightly_version=2025-04-01
 fi
 
 export rust_stable="$stable_version"

--- a/serde-varint/src/lib.rs
+++ b/serde-varint/src/lib.rs
@@ -56,7 +56,7 @@ where
     T: VarInt,
 {
     deserializer.deserialize_tuple(
-        (std::mem::size_of::<T>() * 8 + 6) / 7,
+        (std::mem::size_of::<T>() * 8).div_ceil(7),
         VarIntVisitor {
             phantom: PhantomData,
         },
@@ -100,7 +100,7 @@ macro_rules! impl_var_int {
                 S: Serializer,
             {
                 let bits = <$type>::BITS - self.leading_zeros();
-                let num_bytes = ((bits + 6) / 7).max(1) as usize;
+                let num_bytes = bits.div_ceil(7).max(1) as usize;
                 let mut seq = serializer.serialize_tuple(num_bytes)?;
                 while self >= 0x80 {
                     let byte = ((self & 0x7F) | 0x80) as u8;
@@ -138,8 +138,8 @@ mod tests {
 
     #[test]
     fn test_serde_varint() {
-        assert_eq!((std::mem::size_of::<u32>() * 8 + 6) / 7, 5);
-        assert_eq!((std::mem::size_of::<u64>() * 8 + 6) / 7, 10);
+        assert_eq!((std::mem::size_of::<u32>() * 8).div_ceil(7), 5);
+        assert_eq!((std::mem::size_of::<u64>() * 8).div_ceil(7), 10);
         let dummy = Dummy {
             a: 698,
             b: 370,

--- a/transaction/src/lib.rs
+++ b/transaction/src/lib.rs
@@ -554,7 +554,7 @@ impl Transaction {
     ///
     /// * `from_keypairs` - The keys used to sign the transaction.
     /// * `keys` - The keys for the transaction.  These are the program state
-    ///    instances or lamport recipient keys.
+    ///   instances or lamport recipient keys.
     /// * `recent_blockhash` - The PoH hash.
     /// * `program_ids` - The keys that identify programs used in the `instruction` vector.
     /// * `instructions` - Instructions that will be executed atomically.


### PR DESCRIPTION
#### Problem

The stable toolchain was bumped to 1.85.1, but the nightly toolchain is still behind.

#### Summary of changes

Update the nightly version to 2025-04-01 and fix issues that come up.

* io::Error::new(io::ErrorKind::Other ...) -> io::Error::other
* map_or(true, ...) -> is_none_or
* identation fixes
* using div_ceil

I wasn't sure what version Agave would land on, so let me konw if I should use another one.