### PR TITLE
pubkey: fix compile error by importing size_of

### DIFF
--- a/pubkey/src/lib.rs
+++ b/pubkey/src/lib.rs
@@ -25,7 +25,7 @@ use {
         convert::{Infallible, TryFrom},
         fmt,
         hash::{Hash, Hasher},
-        mem,
+        mem::{self, size_of},
         str::{from_utf8, FromStr},
     },
     num_traits::{FromPrimitive, ToPrimitive},
@@ -36,6 +36,7 @@ use {
     js_sys::{Array, Uint8Array},
     wasm_bindgen::{prelude::wasm_bindgen, JsCast, JsValue},
 };
+
 #[cfg(target_os = "solana")]
 pub mod syscalls;
 


### PR DESCRIPTION
Resolves https://github.com/anza-xyz/solana-sdk/issues/124

The crate misses core::mem::size_of (or std) causing build failures when other dependencies require it. Add import to resolve, opting for `core` as opposed to `std` such that it works with existing `#![no_std]` declaration.

As part of upgrading to anchor 0.31.0 and solana 2.x