### PR TITLE
frozen-abi: Add `AbiExample` implementation for `bytes::Bytes`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,9 +493,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cast"
@@ -2949,6 +2949,7 @@ dependencies = [
  "bitflags 2.8.0",
  "bs58",
  "bv",
+ "bytes",
  "im",
  "log",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,6 +153,7 @@ bs58 = { version = "0.5.1", default-features = false }
 bv = "0.11.1"
 bytemuck = "1.21.0"
 bytemuck_derive = "1.8.1"
+bytes = "1.10.0"
 cfg_eval = "0.1.2"
 chrono = { version = "0.4.39", default-features = false }
 console = "0.15.10"

--- a/frozen-abi/Cargo.toml
+++ b/frozen-abi/Cargo.toml
@@ -12,6 +12,7 @@ edition = { workspace = true }
 [dependencies]
 bs58 = { workspace = true, features = ["alloc"] }
 bv = { workspace = true, features = ["serde"] }
+bytes = { workspace = true }
 log = { workspace = true, features = ["std"] }
 serde = { workspace = true, features = ["rc"] }
 serde_derive = { workspace = true }

--- a/frozen-abi/src/abi_example.rs
+++ b/frozen-abi/src/abi_example.rs
@@ -195,6 +195,8 @@ example_impls! { String, String::new() }
 example_impls! { std::time::Duration, std::time::Duration::from_secs(0) }
 example_impls! { std::sync::Once, std::sync::Once::new() }
 
+example_impls! { bytes::Bytes, bytes::Bytes::new() }
+
 use std::sync::atomic::*;
 
 // Source: https://github.com/rust-lang/rust/blob/ba18875557aabffe386a2534a1aa6118efb6ab88/src/libcore/sync/atomic.rs#L1199


### PR DESCRIPTION
Currently it's impossible to use `Bytes` in ABI-stable types. Allow that by adding the necessary `AbiExample` implementation.