### PR TITLE
chore: Update `openssl` to 0.10.72 and `openssl-sys` to 0.9.107

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1821,9 +1821,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.70"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags 2.8.0",
  "cfg-if",
@@ -1856,9 +1856,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.105"
+version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ num-bigint = "0.4.6"
 num-derive = "0.4"
 num-traits = "0.2.18"
 num_enum = "0.7.3"
-openssl = "0.10.39"
+openssl = "0.10.72"
 parking_lot = "0.12"
 pbkdf2 = { version = "0.11.0", default-features = false }
 proc-macro2 = "1.0.93"


### PR DESCRIPTION
This update addresses the advisory:
https://rustsec.org/advisories/RUSTSEC-2025-0022