### PR TITLE
Re-export signature and pubkey types

### DIFF
--- a/client-traits/src/lib.rs
+++ b/client-traits/src/lib.rs
@@ -23,6 +23,12 @@ use {
     solana_transaction_error::{TransactionResult, TransportResult as Result},
 };
 
+pub use {
+    solana_commitment_config::CommitmentConfig,
+    solana_pubkey::Pubkey,
+    solana_signature::Signature
+};
+
 pub trait Client: SyncClient + AsyncClient {
     fn tpu_addr(&self) -> String;
 }

--- a/keypair/Cargo.toml
+++ b/keypair/Cargo.toml
@@ -31,6 +31,7 @@ tiny-bip39 = { workspace = true }
 
 [features]
 seed-derivable = ["dep:solana-derivation-path", "dep:solana-seed-derivable", "dep:ed25519-dalek-bip32"]
+signer = []
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]

--- a/keypair/src/lib.rs
+++ b/keypair/src/lib.rs
@@ -5,15 +5,20 @@ use wasm_bindgen::prelude::*;
 use {
     ed25519_dalek::Signer as DalekSigner,
     rand0_7::{rngs::OsRng, CryptoRng, RngCore},
-    solana_pubkey::Pubkey,
     solana_seed_phrase::generate_seed_from_seed_phrase_and_passphrase,
-    solana_signature::{error::Error as SignatureError, Signature},
+    solana_signature::{error::Error as SignatureError},
     solana_signer::{EncodableKey, EncodableKeypair, Signer, SignerError},
     std::{
         error,
         io::{Read, Write},
         path::Path,
     },
+};
+
+#[cfg(feature = "signer")]
+pub use {
+    solana_pubkey::Pubkey,
+    solana_signature::Signature
 };
 
 #[cfg(feature = "seed-derivable")]
@@ -159,6 +164,7 @@ impl From<ed25519_dalek::Keypair> for Keypair {
 #[cfg(test)]
 static_assertions::const_assert_eq!(Keypair::SECRET_KEY_LENGTH, ed25519_dalek::SECRET_KEY_LENGTH);
 
+#[cfg(feature = "signer")]
 impl Signer for Keypair {
     #[inline]
     fn pubkey(&self) -> Pubkey {

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -2,8 +2,6 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 use {
     core::fmt,
-    solana_pubkey::Pubkey,
-    solana_signature::Signature,
     solana_transaction_error::TransactionError,
     std::{
         error,
@@ -12,6 +10,11 @@ use {
         ops::Deref,
         path::Path,
     },
+};
+
+pub use {
+    solana_pubkey::Pubkey,
+    solana_signature::Signature,
 };
 
 pub mod null_signer;


### PR DESCRIPTION
This exports certain types from crates that are used again and again, so by exporting one can use those types directly without having to repeatedly import those crates.

It aims to resolve #106. 