### PR TITLE
ci: Add build-sbf step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -353,6 +353,34 @@ jobs:
       - name: Check dev-context-only-utils declarations
         run: ./scripts/check-dev-context-only-utils.sh
 
+  build-sbf:
+    name: Check build-sbf
+    runs-on: ubuntu-latest
+    needs: [sanity]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          stable-toolchain: true
+
+      - name: Determine Solana CLI version
+        run: |
+          source "./scripts/read-cargo-variable.sh"
+          solana_version=$(readCargoVariable solana "./Cargo.toml")
+          echo "SOLANA_VERSION=$solana_version" >> $GITHUB_ENV
+
+      - name: Install Solana CLI
+        uses: solana-program/actions/install-solana@v1
+        with:
+          version: ${{ env.SOLANA_VERSION }}
+          cache: true
+
+      - name: Run cargo-build-sbf
+        run: ./scripts/check-build-sbf.sh
+
   miri:
     name: Test miri
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -379,7 +379,7 @@ jobs:
           cache: true
 
       - name: Run cargo-build-sbf
-        run: ./scripts/check-build-sbf.sh
+        run: ./scripts/build-sbf.sh
 
   miri:
     name: Test miri

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ tag-message = "Publish {{crate_name}} v{{version}}"
 consolidate-commits = false
 
 [workspace.metadata.cli]
-solana = "2.2.0"
+solana = "2.2.7"
 
 [workspace.dependencies]
 ahash = "0.8.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,9 @@ pre-release-commit-message = "Publish {{crate_name}} v{{version}}"
 tag-message = "Publish {{crate_name}} v{{version}}"
 consolidate-commits = false
 
+[workspace.metadata.cli]
+solana = "2.2.0"
+
 [workspace.dependencies]
 ahash = "0.8.11"
 anyhow = "1.0.96"

--- a/scripts/build-sbf.sh
+++ b/scripts/build-sbf.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+here="$(dirname "$0")"
+src_root="$(readlink -f "${here}/..")"
+cd "${src_root}"
+
+exclude_list=(
+  ".github"
+  "scripts"
+  "client-traits"
+  "ed25519-program"
+  "example-mocks"
+  "feature-set"
+  "feature-set-interface"
+  "file-download"
+  "genesis-config"
+  "keypair"
+  "logger"
+  "offchain-message"
+  "precompiles"
+  "presigner"
+  "quic-definitions"
+  "rent-collector"
+  "reserved-account-keys"
+  "secp256k1-program"
+  "secp256r1-program"
+  "system-transaction"
+  "transaction"
+)
+
+for dir in $(git ls-tree -d --name-only HEAD .); do
+  if [[ ! " ${exclude_list[*]} " =~ [[:space:]]${dir}[[:space:]] ]]; then
+    (cd $dir && cargo build-sbf)
+  fi
+done

--- a/scripts/build-sbf.sh
+++ b/scripts/build-sbf.sh
@@ -31,6 +31,6 @@ exclude_list=(
 
 for dir in $(git ls-tree -d --name-only HEAD .); do
   if [[ ! " ${exclude_list[*]} " =~ [[:space:]]${dir}[[:space:]] ]]; then
-    (cd $dir && cargo build-sbf)
+    (cd "$dir" && cargo build-sbf)
   fi
 done

--- a/scripts/check-build-sbf.sh
+++ b/scripts/check-build-sbf.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+here="$(dirname "$0")"
+src_root="$(readlink -f "${here}/..")"
+cd "${src_root}"
+
+./cargo build-sbf

--- a/scripts/check-build-sbf.sh
+++ b/scripts/check-build-sbf.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -eo pipefail
-here="$(dirname "$0")"
-src_root="$(readlink -f "${here}/..")"
-cd "${src_root}"
-
-./cargo build-sbf


### PR DESCRIPTION
### Problem

In general, the workspace rust toolchain has a different (newer) version than the built-in one used by `build-sbf`. This could potentially lead to compilation problems not currently detected by the CI when using crates in a program context – e.g., #124.

### Solution

Add a "check-build-sbf" step to the CI to build crates using `cargo build-sbf`.

Fixes #70 