### PR TITLE
CI: Add minimum supported rust version check

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -16,6 +16,9 @@ inputs:
   nightly-toolchain:
     description: Install nightly toolchain if `true`. Defaults to `false`.
     required: false
+  minimum-toolchain:
+    description: Install minimum toolchain if `true`. Defaults to `false`.
+    required: false
   clippy:
     description: Install Clippy if `true`. Defaults to `false`.
     required: false
@@ -66,6 +69,7 @@ runs:
       run: |
         source ./scripts/rust-version.sh
         echo "RUST_STABLE=${rust_stable}" >> $GITHUB_ENV
+        echo "RUST_MINIMUM=${rust_minimum}" >> $GITHUB_ENV
         echo "RUST_NIGHTLY=${rust_nightly}" >> $GITHUB_ENV
 
     - name: Install stable toolchain
@@ -73,6 +77,12 @@ runs:
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ env.RUST_STABLE }}
+
+    - name: Install minimum toolchain
+      if: ${{ inputs.minimum-toolchain == 'true' }}
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ env.RUST_MINIMUM }}
 
     - name: Install nightly toolchain
       if: ${{ inputs.nightly-toolchain == 'true' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -232,6 +232,24 @@ jobs:
       - name: Check feature powerset
         run: ./scripts/check-powerset.sh
 
+  msrv:
+    name: Check minimum supported Rust version
+    runs-on: ubuntu-latest
+    needs: [sanity]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          minimum-toolchain: true
+          cargo-cache-key: cargo-minimum-check
+          cargo-cache-fallback-key: cargo-minimum
+
+      - name: Run check
+        run: ./scripts/check-msrv.sh
+
   minimal-versions:
     name: Check minimal-versions
     runs-on: ubuntu-latest

--- a/cargo
+++ b/cargo
@@ -11,6 +11,12 @@ case "$1" in
     toolchain="$rust_stable"
     shift
     ;;
+  minimum)
+    source "${here}"/scripts/rust-version.sh minimum
+    # shellcheck disable=SC2054 # rust_stable is sourced from rust-version.sh
+    toolchain="$rust_minimum"
+    shift
+    ;;
   nightly)
     source "${here}"/scripts/rust-version.sh nightly
     # shellcheck disable=SC2054 # rust_nightly is sourced from rust-version.sh

--- a/pubkey/src/lib.rs
+++ b/pubkey/src/lib.rs
@@ -212,7 +212,8 @@ mod hasher {
                 "This hasher is intended to be used with pubkeys and nothing else"
             );
             // This slice/unwrap can never panic since offset is < PUBKEY_BYTES - mem::size_of::<u64>()
-            let chunk: &[u8; mem::size_of::<u64>()] = bytes[self.offset..self.offset + mem::size_of::<u64>()]
+            let chunk: &[u8; mem::size_of::<u64>()] = bytes
+                [self.offset..self.offset + mem::size_of::<u64>()]
                 .try_into()
                 .unwrap();
             self.state = u64::from_ne_bytes(*chunk);

--- a/pubkey/src/lib.rs
+++ b/pubkey/src/lib.rs
@@ -25,7 +25,7 @@ use {
         convert::{Infallible, TryFrom},
         fmt,
         hash::{Hash, Hasher},
-        mem::{self, size_of},
+        mem,
         str::{from_utf8, FromStr},
     },
     num_traits::{FromPrimitive, ToPrimitive},
@@ -181,6 +181,7 @@ mod hasher {
         core::{
             cell::Cell,
             hash::{BuildHasher, Hasher},
+            mem,
         },
         rand::{thread_rng, Rng},
     };
@@ -210,8 +211,8 @@ mod hasher {
                 PUBKEY_BYTES,
                 "This hasher is intended to be used with pubkeys and nothing else"
             );
-            // This slice/unwrap can never panic since offset is < PUBKEY_BYTES - size_of::<u64>()
-            let chunk: &[u8; size_of::<u64>()] = bytes[self.offset..self.offset + size_of::<u64>()]
+            // This slice/unwrap can never panic since offset is < PUBKEY_BYTES - mem::size_of::<u64>()
+            let chunk: &[u8; mem::size_of::<u64>()] = bytes[self.offset..self.offset + mem::size_of::<u64>()]
                 .try_into()
                 .unwrap();
             self.state = u64::from_ne_bytes(*chunk);
@@ -241,12 +242,12 @@ mod hasher {
         fn default() -> Self {
             std::thread_local!(static OFFSET: Cell<usize>  = {
                 let mut rng = thread_rng();
-                Cell::new(rng.gen_range(0..PUBKEY_BYTES - size_of::<u64>()))
+                Cell::new(rng.gen_range(0..PUBKEY_BYTES - mem::size_of::<u64>()))
             });
 
             let offset = OFFSET.with(|offset| {
                 let mut next_offset = offset.get() + 1;
-                if next_offset > PUBKEY_BYTES - size_of::<u64>() {
+                if next_offset > PUBKEY_BYTES - mem::size_of::<u64>() {
                     next_offset = 0;
                 }
                 offset.set(next_offset);
@@ -479,7 +480,7 @@ impl Pubkey {
         use solana_atomic_u64::AtomicU64;
         static I: AtomicU64 = AtomicU64::new(1);
         type T = u32;
-        const COUNTER_BYTES: usize = size_of::<T>();
+        const COUNTER_BYTES: usize = mem::size_of::<T>();
         let mut b = [0u8; PUBKEY_BYTES];
         #[cfg(any(feature = "std", target_arch = "wasm32"))]
         let mut i = I.fetch_add(1) as T;

--- a/scripts/check-msrv.sh
+++ b/scripts/check-msrv.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+here="$(dirname "$0")"
+src_root="$(readlink -f "${here}/..")"
+cd "${src_root}"/program
+
+../cargo minimum check

--- a/scripts/rust-version.sh
+++ b/scripts/rust-version.sh
@@ -24,6 +24,17 @@ else
   stable_version=$(readCargoVariable channel "$base/../rust-toolchain.toml")
 fi
 
+if [[ -n $RUST_MINIMUM_VERSION ]]; then
+  minimum_version="$RUST_MINIMUM_VERSION"
+else
+  # read MSRV from program/Cargo.toml file
+  base="$(dirname "${BASH_SOURCE[0]}")"
+  # pacify shellcheck: cannot follow dynamic path
+  # shellcheck disable=SC1090,SC1091
+  source "$base/read-cargo-variable.sh"
+  minimum_version=$(readCargoVariable rust-version "$base/../program/Cargo.toml")
+fi
+
 if [[ -n $RUST_NIGHTLY_VERSION ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
@@ -31,6 +42,7 @@ else
 fi
 
 export rust_stable="$stable_version"
+export rust_minimum="$minimum_version"
 export rust_nightly=nightly-"$nightly_version"
 
 [[ -z $1 ]] || (
@@ -49,11 +61,15 @@ export rust_nightly=nightly-"$nightly_version"
   stable)
      rustup_install "$rust_stable"
      ;;
+  minimum)
+     rustup_install "$rust_minimum"
+    ;;
   nightly)
      rustup_install "$rust_nightly"
     ;;
   all)
      rustup_install "$rust_stable"
+     rustup_install "$rust_minimum"
      rustup_install "$rust_nightly"
     ;;
   *)

--- a/signature/src/error.rs
+++ b/signature/src/error.rs
@@ -78,9 +78,9 @@ impl From<Box<dyn std::error::Error + Send + Sync + 'static>> for Error {
 
 #[cfg(feature = "std")]
 impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         self.source
             .as_ref()
-            .map(|source| source.as_ref() as &(dyn core::error::Error + 'static))
+            .map(|source| source.as_ref() as &(dyn std::error::Error + 'static))
     }
 }


### PR DESCRIPTION
#### Problem

We broke pubkey by assuming that `size_of` was included in the prelude, which was added after 1.79, the minimum supported rust version for solana-program. This happened because we're not explicitly testing the minimum supported rust version in crates that expose it.

More info at #124

#### Summary of changes

Add a "minimum" toolchain in the repo, and add a CI step + script to check that `cargo check` passes for this toolchain.

While working on this, I found a few more places that were broken, so fix those up.