### PR TITLE
scripts: Fix downstream patch script

### DIFF
--- a/scripts/patch-crates-functions.sh
+++ b/scripts/patch-crates-functions.sh
@@ -103,7 +103,6 @@ crate_dirs=(
   target
   time-utils
   transaction
-  transaction-context
   transaction-error
   validator-exit
   vote-interface


### PR DESCRIPTION
#### Problem

As noted in #121, the patching script in this repo doesn't work on Agave v2.2, because solana-transaction-context was moved back into the Agave repo, but the script is still trying to patch it.

#### Summary of changes

Remove transaction-context from one of the scripts to patch. This is one part of fixing the issue.