### PR TITLE
instruction: Add syscalls helpers

### DIFF
--- a/instruction/Cargo.toml
+++ b/instruction/Cargo.toml
@@ -46,6 +46,7 @@ serde = [
     "solana-pubkey/serde",
 ]
 std = []
+syscalls = ["std"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]

--- a/instruction/src/lib.rs
+++ b/instruction/src/lib.rs
@@ -24,7 +24,7 @@ pub mod account_meta;
 #[cfg(feature = "std")]
 pub use account_meta::AccountMeta;
 pub mod error;
-#[cfg(target_os = "solana")]
+#[cfg(feature = "syscalls")]
 pub mod syscalls;
 #[cfg(all(feature = "std", target_arch = "wasm32"))]
 pub mod wasm;

--- a/instruction/src/lib.rs
+++ b/instruction/src/lib.rs
@@ -24,7 +24,7 @@ pub mod account_meta;
 #[cfg(feature = "std")]
 pub use account_meta::AccountMeta;
 pub mod error;
-#[cfg(feature = "syscalls")]
+#[cfg(any(feature = "syscalls", target_os = "solana"))]
 pub mod syscalls;
 #[cfg(all(feature = "std", target_arch = "wasm32"))]
 pub mod wasm;

--- a/instruction/src/syscalls.rs
+++ b/instruction/src/syscalls.rs
@@ -1,8 +1,80 @@
-pub use solana_define_syscall::definitions::sol_get_stack_height;
-use {
+use crate::Instruction;
+#[cfg(target_os = "solana")]
+pub use {
     crate::{AccountMeta, ProcessedSiblingInstruction},
-    solana_define_syscall::define_syscall,
+    solana_define_syscall::{define_syscall, definitions::sol_get_stack_height},
     solana_pubkey::Pubkey,
 };
 
+#[cfg(target_os = "solana")]
 define_syscall!(fn sol_get_processed_sibling_instruction(index: u64, meta: *mut ProcessedSiblingInstruction, program_id: *mut Pubkey, data: *mut u8, accounts: *mut AccountMeta) -> u64);
+
+/// Returns a sibling instruction from the processed sibling instruction list.
+///
+/// The processed sibling instruction list is a reverse-ordered list of
+/// successfully processed sibling instructions. For example, given the call flow:
+///
+/// A
+/// B -> C -> D
+/// B -> E
+/// B -> F
+///
+/// Then B's processed sibling instruction list is: `[A]`
+/// Then F's processed sibling instruction list is: `[E, C]`
+pub fn get_processed_sibling_instruction(index: usize) -> Option<Instruction> {
+    #[cfg(target_os = "solana")]
+    {
+        let mut meta = ProcessedSiblingInstruction::default();
+        let mut program_id = solana_pubkey::Pubkey::default();
+
+        if 1 == unsafe {
+            sol_get_processed_sibling_instruction(
+                index as u64,
+                &mut meta,
+                &mut program_id,
+                &mut u8::default(),
+                &mut AccountMeta::default(),
+            )
+        } {
+            let mut data = std::vec::Vec::new();
+            let mut accounts = std::vec::Vec::new();
+            data.resize_with(meta.data_len as usize, u8::default);
+            accounts.resize_with(meta.accounts_len as usize, AccountMeta::default);
+
+            let _ = unsafe {
+                sol_get_processed_sibling_instruction(
+                    index as u64,
+                    &mut meta,
+                    &mut program_id,
+                    data.as_mut_ptr(),
+                    accounts.as_mut_ptr(),
+                )
+            };
+
+            Some(Instruction::new_with_bytes(program_id, &data, accounts))
+        } else {
+            None
+        }
+    }
+
+    #[cfg(not(target_os = "solana"))]
+    {
+        core::hint::black_box(index);
+        None
+    }
+}
+
+/// Get the current stack height.
+///
+/// Transaction-level instructions are height [`TRANSACTION_LEVEL_STACK_HEIGHT`]`,
+/// fist invoked inner instruction is height `TRANSACTION_LEVEL_STACK_HEIGHT + 1`,
+/// and so forth.
+pub fn get_stack_height() -> usize {
+    #[cfg(target_os = "solana")]
+    unsafe {
+        sol_get_stack_height() as usize
+    }
+
+    #[cfg(not(target_os = "solana"))]
+    0
+}

--- a/instruction/src/syscalls.rs
+++ b/instruction/src/syscalls.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "syscalls")]
 use crate::Instruction;
 #[cfg(target_os = "solana")]
 pub use {
@@ -21,6 +22,7 @@ define_syscall!(fn sol_get_processed_sibling_instruction(index: u64, meta: *mut 
 ///
 /// Then B's processed sibling instruction list is: `[A]`
 /// Then F's processed sibling instruction list is: `[E, C]`
+#[cfg(feature = "syscalls")]
 pub fn get_processed_sibling_instruction(index: usize) -> Option<Instruction> {
     #[cfg(target_os = "solana")]
     {
@@ -70,6 +72,7 @@ pub fn get_processed_sibling_instruction(index: usize) -> Option<Instruction> {
 /// Transaction-level instructions are height [`TRANSACTION_LEVEL_STACK_HEIGHT`]`,
 /// fist invoked inner instruction is height `TRANSACTION_LEVEL_STACK_HEIGHT + 1`,
 /// and so forth.
+#[cfg(feature = "syscalls")]
 pub fn get_stack_height() -> usize {
     #[cfg(target_os = "solana")]
     unsafe {

--- a/instruction/src/syscalls.rs
+++ b/instruction/src/syscalls.rs
@@ -60,6 +60,7 @@ pub fn get_processed_sibling_instruction(index: usize) -> Option<Instruction> {
     #[cfg(not(target_os = "solana"))]
     {
         core::hint::black_box(index);
+        // Same value used in `solana_sysvar::program_stubs`.
         None
     }
 }
@@ -76,5 +77,6 @@ pub fn get_stack_height() -> usize {
     }
 
     #[cfg(not(target_os = "solana"))]
+    // Same value used in `solana_sysvar::program_stubs`.
     0
 }

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -52,6 +52,7 @@ solana-instruction = { workspace = true, default-features = false, features = [
     "bincode",
     "serde",
     "std",
+    "syscalls",
 ] }
 solana-instructions-sysvar = { workspace = true }
 solana-keccak-hasher = { workspace = true, features = ["sha3"] }

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -1,11 +1,49 @@
 pub use {
     crate::message::compiled_instruction::CompiledInstruction,
     solana_instruction::{
-        error::InstructionError,
-        syscalls::{get_processed_sibling_instruction, get_stack_height},
-        AccountMeta, Instruction, ProcessedSiblingInstruction, TRANSACTION_LEVEL_STACK_HEIGHT,
+        error::InstructionError, AccountMeta, Instruction, ProcessedSiblingInstruction,
+        TRANSACTION_LEVEL_STACK_HEIGHT,
     },
 };
+
+/// Returns a sibling instruction from the processed sibling instruction list.
+///
+/// The processed sibling instruction list is a reverse-ordered list of
+/// successfully processed sibling instructions. For example, given the call flow:
+///
+/// A
+/// B -> C -> D
+/// B -> E
+/// B -> F
+///
+/// Then B's processed sibling instruction list is: `[A]`
+/// Then F's processed sibling instruction list is: `[E, C]`
+pub fn get_processed_sibling_instruction(index: usize) -> Option<Instruction> {
+    #[cfg(target_os = "solana")]
+    {
+        solana_instruction::syscalls::get_processed_sibling_instruction(index)
+    }
+
+    #[cfg(not(target_os = "solana"))]
+    {
+        crate::program_stubs::sol_get_processed_sibling_instruction(index)
+    }
+}
+
+/// Get the current stack height, transaction-level instructions are height
+/// TRANSACTION_LEVEL_STACK_HEIGHT, fist invoked inner instruction is height
+/// TRANSACTION_LEVEL_STACK_HEIGHT + 1, etc...
+pub fn get_stack_height() -> usize {
+    #[cfg(target_os = "solana")]
+    unsafe {
+        solana_instruction::syscalls::get_stack_height()
+    }
+
+    #[cfg(not(target_os = "solana"))]
+    {
+        crate::program_stubs::sol_get_stack_height() as usize
+    }
+}
 
 // TODO: remove this.
 /// Addition that returns [`InstructionError::InsufficientFunds`] on overflow.

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -1,77 +1,11 @@
 pub use {
     crate::message::compiled_instruction::CompiledInstruction,
     solana_instruction::{
-        error::InstructionError, AccountMeta, Instruction, ProcessedSiblingInstruction,
-        TRANSACTION_LEVEL_STACK_HEIGHT,
+        error::InstructionError,
+        syscalls::{get_processed_sibling_instruction, get_stack_height},
+        AccountMeta, Instruction, ProcessedSiblingInstruction, TRANSACTION_LEVEL_STACK_HEIGHT,
     },
 };
-
-/// Returns a sibling instruction from the processed sibling instruction list.
-///
-/// The processed sibling instruction list is a reverse-ordered list of
-/// successfully processed sibling instructions. For example, given the call flow:
-///
-/// A
-/// B -> C -> D
-/// B -> E
-/// B -> F
-///
-/// Then B's processed sibling instruction list is: `[A]`
-/// Then F's processed sibling instruction list is: `[E, C]`
-pub fn get_processed_sibling_instruction(index: usize) -> Option<Instruction> {
-    #[cfg(target_os = "solana")]
-    {
-        let mut meta = ProcessedSiblingInstruction::default();
-        let mut program_id = solana_pubkey::Pubkey::default();
-
-        if 1 == unsafe {
-            solana_instruction::syscalls::sol_get_processed_sibling_instruction(
-                index as u64,
-                &mut meta,
-                &mut program_id,
-                &mut u8::default(),
-                &mut AccountMeta::default(),
-            )
-        } {
-            let mut data = Vec::new();
-            let mut accounts = Vec::new();
-            data.resize_with(meta.data_len as usize, u8::default);
-            accounts.resize_with(meta.accounts_len as usize, AccountMeta::default);
-
-            let _ = unsafe {
-                solana_instruction::syscalls::sol_get_processed_sibling_instruction(
-                    index as u64,
-                    &mut meta,
-                    &mut program_id,
-                    data.as_mut_ptr(),
-                    accounts.as_mut_ptr(),
-                )
-            };
-
-            Some(Instruction::new_with_bytes(program_id, &data, accounts))
-        } else {
-            None
-        }
-    }
-
-    #[cfg(not(target_os = "solana"))]
-    crate::program_stubs::sol_get_processed_sibling_instruction(index)
-}
-
-/// Get the current stack height, transaction-level instructions are height
-/// TRANSACTION_LEVEL_STACK_HEIGHT, fist invoked inner instruction is height
-/// TRANSACTION_LEVEL_STACK_HEIGHT + 1, etc...
-pub fn get_stack_height() -> usize {
-    #[cfg(target_os = "solana")]
-    unsafe {
-        solana_instruction::syscalls::sol_get_stack_height() as usize
-    }
-
-    #[cfg(not(target_os = "solana"))]
-    {
-        crate::program_stubs::sol_get_stack_height() as usize
-    }
-}
 
 // TODO: remove this.
 /// Addition that returns [`InstructionError::InsufficientFunds`] on overflow.


### PR DESCRIPTION
### Problem

Currently the syscalls module on the `instruction` crate is behind a `#[cfg(target_os = "solana")]` attribute. Therefore, they are not "visible" on non-solana environment. This makes it difficult to write code that depends on them. Additionally, the crate does not include helpers to wrap the syscalls into friendlier functions.

### Solution

Add a `syscalls` feature to the crate to conditionally include the syscalls module and add wrapper functions for the syscalls. This PR also update the `solana-program` crate to use these helpers to avoid duplication of logic.