### PR TITLE
Use only rlib as crate type

### DIFF
--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -127,7 +127,7 @@ all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["rlib"]
 
 [features]
 default = ["borsh"]

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -94,16 +94,21 @@
 //!
 //! ```toml
 //! [lib]
-//! crate-type = ["cdylib", "rlib"]
+//! crate-type = ["cdylib"]
 //!
 //! [features]
 //! no-entrypoint = []
 //! ```
 //!
-//! Note that a Solana program must specify its crate-type as "cdylib", and
-//! "cdylib" crates will automatically be discovered and built by the `cargo
-//! build-bpf` command. Solana programs also often have crate-type "rlib" so
-//! they can be linked to other Rust crates.
+//! Note that a Solana program must specify its crate-type as "cdylib", to
+//! be discovered and built by the `cargo-build-sbf` command as a deployable program.
+//! Solana programs also often have crate-type "rlib" so they can be linked to other Rust crates.
+//! Avoid using "rlib" and "cdylib" crates together, since their combined usage precludes
+//! compiler optimizations that may decrease program size and CU usage.
+//!
+//! Prefer writing a separate package if it is supposed to be used as a library for other Solana
+//! programs (i.e. a "rlib" only crate). When created a Rust project intended to be a program
+//! ready for deployment, ues only the "cdylib" crate type.
 //!
 //! # On-chain vs. off-chain compilation targets
 //!

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -197,7 +197,7 @@ all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["rlib"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
**Problem**

We cannot run LTO natively for the SBF target, since the Rust compiler complains that dependencies are declared as both cdylib and rlib crate types.

**Summary of changes**

1. Rewrite documentation to mention the fact that we should use different crate types depending on the Rust package intended usage.
2. Set the crate type as rlib for SDK and `program`, since they are not supposed to be programs for deployment, but instead libraries to be imported.