### PR TITLE
CI: Fix miri job to actually run tests

### DIFF
--- a/scripts/test-miri.sh
+++ b/scripts/test-miri.sh
@@ -5,4 +5,4 @@ here="$(dirname "$0")"
 src_root="$(readlink -f "${here}/..")"
 cd "${src_root}"
 # miri is very slow; so only run very few of selective tests!
-./cargo nightly miri test -p solana-program -- hash:: account_info::
+./cargo nightly miri test -p solana-hash -p solana-account-info


### PR DESCRIPTION
#### Problem

The miri job is assuming that the `hash` module and the `account_info` module in `solana-program` have tests, but those were moved into `solana-hash` and `solana-account-info` awhile ago.

#### Summary of changes

Specify the correct packages to test.