### PR TITLE
sol_to_lamports(): convert negative and NaN to 0, clip positive value…

### DIFF
--- a/native-token/src/lib.rs
+++ b/native-token/src/lib.rs
@@ -4,15 +4,25 @@
 
 /// There are 10^9 lamports in one SOL
 pub const LAMPORTS_PER_SOL: u64 = 1_000_000_000;
+const LAMPORTS_PER_SOL_F64: f64 = LAMPORTS_PER_SOL as f64;
 
 /// Approximately convert fractional native tokens (lamports) into native tokens (SOL)
 pub fn lamports_to_sol(lamports: u64) -> f64 {
-    lamports as f64 / LAMPORTS_PER_SOL as f64
+    lamports as f64 / LAMPORTS_PER_SOL_F64
 }
 
 /// Approximately convert native tokens (SOL) into fractional native tokens (lamports)
 pub fn sol_to_lamports(sol: f64) -> u64 {
-    (sol * LAMPORTS_PER_SOL as f64) as u64
+    const U64_MAX_PLUS_1: f64 = 18446744073709551616.; // 0x1p64
+    let lamports = (sol * LAMPORTS_PER_SOL_F64).round();
+    if lamports <= 0.0 {
+        0
+    } else if lamports >= U64_MAX_PLUS_1 {
+        u64::MAX
+    } else {
+        // NaNs fallthrough to here and cast to zero
+        lamports as u64
+    }
 }
 
 use std::fmt::{Debug, Display, Formatter, Result};
@@ -38,5 +48,76 @@ impl Display for Sol {
 impl Debug for Sol {
     fn fmt(&self, f: &mut Formatter) -> Result {
         self.write_in_sol(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lamports_to_sol() {
+        assert_eq!(0.0, lamports_to_sol(0));
+        assert_eq!(0.000000001, lamports_to_sol(1));
+        assert_eq!(0.00000001, lamports_to_sol(10));
+        assert_eq!(0.0000001, lamports_to_sol(100));
+        assert_eq!(0.000001, lamports_to_sol(1000));
+        assert_eq!(0.00001, lamports_to_sol(10000));
+        assert_eq!(0.0001, lamports_to_sol(100000));
+        assert_eq!(0.001, lamports_to_sol(1000000));
+        assert_eq!(0.01, lamports_to_sol(10000000));
+        assert_eq!(0.1, lamports_to_sol(100000000));
+        assert_eq!(1., lamports_to_sol(1000000000));
+        assert_eq!(4.1, lamports_to_sol(4_100_000_000));
+        assert_eq!(8.2, lamports_to_sol(8_200_000_000));
+        assert_eq!(8.50228288, lamports_to_sol(8_502_282_880));
+        assert_eq!(18446744073.70955276489257812500, lamports_to_sol(u64::MAX));
+        assert_eq!(
+            18446744073.70955276489257812500,
+            lamports_to_sol(u64::MAX - 1023)
+        );
+        assert_eq!(
+            18446744073.70954895019531250000,
+            lamports_to_sol(u64::MAX - 1024)
+        );
+        assert_eq!(
+            18446744073.70954895019531250000,
+            lamports_to_sol(u64::MAX - 5119)
+        );
+        assert_eq!(
+            18446744073.70954513549804687500,
+            lamports_to_sol(u64::MAX - 5120)
+        );
+    }
+
+    #[test]
+    fn test_sol_to_lamports() {
+        assert_eq!(0, sol_to_lamports(0.0));
+        assert_eq!(1, sol_to_lamports(0.000000001));
+        assert_eq!(10, sol_to_lamports(0.00000001));
+        assert_eq!(100, sol_to_lamports(0.0000001));
+        assert_eq!(1000, sol_to_lamports(0.000001));
+        assert_eq!(10000, sol_to_lamports(0.00001));
+        assert_eq!(100000, sol_to_lamports(0.0001));
+        assert_eq!(1000000, sol_to_lamports(0.001));
+        assert_eq!(10000000, sol_to_lamports(0.01));
+        assert_eq!(100000000, sol_to_lamports(0.1));
+        assert_eq!(1000000000, sol_to_lamports(1.));
+        assert_eq!(4_100_000_000, sol_to_lamports(4.1));
+        assert_eq!(8_200_000_000, sol_to_lamports(8.2));
+        assert_eq!(8_502_282_880, sol_to_lamports(8.50228288));
+        assert_eq!(0, sol_to_lamports(-1.0));
+        assert_eq!(0, sol_to_lamports(f64::NEG_INFINITY));
+        assert_eq!(0, sol_to_lamports(f64::NAN));
+        assert_eq!(u64::MAX, sol_to_lamports(f64::INFINITY));
+        assert_eq!(u64::MAX, sol_to_lamports(18446744073.70955276489257812500));
+        assert_eq!(
+            u64::MAX - 2047,
+            sol_to_lamports(18446744073.70954895019531250000)
+        );
+        assert_eq!(
+            u64::MAX - 6143,
+            sol_to_lamports(18446744073.70954513549804687500)
+        );
     }
 }

--- a/native-token/src/lib.rs
+++ b/native-token/src/lib.rs
@@ -13,16 +13,9 @@ pub fn lamports_to_sol(lamports: u64) -> f64 {
 
 /// Approximately convert native tokens (SOL) into fractional native tokens (lamports)
 pub fn sol_to_lamports(sol: f64) -> u64 {
-    const U64_MAX_PLUS_1: f64 = 18446744073709551616.; // 0x1p64
-    let lamports = (sol * LAMPORTS_PER_SOL_F64).round();
-    if lamports <= 0.0 {
-        0
-    } else if lamports >= U64_MAX_PLUS_1 {
-        u64::MAX
-    } else {
-        // NaNs fallthrough to here and cast to zero
-        lamports as u64
-    }
+    // NaNs return zero, negative values saturate to u64::MIN (i.e. zero), positive values saturate to u64::MAX
+    // https://doc.rust-lang.org/reference/expressions/operator-expr.html#r-expr.as.numeric.float-as-int
+    (sol * LAMPORTS_PER_SOL_F64).round() as u64
 }
 
 use std::fmt::{Debug, Display, Formatter, Result};
@@ -56,6 +49,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(clippy::excessive_precision)]
     fn test_lamports_to_sol() {
         assert_eq!(0.0, lamports_to_sol(0));
         assert_eq!(0.000000001, lamports_to_sol(1));
@@ -91,6 +85,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::excessive_precision)]
     fn test_sol_to_lamports() {
         assert_eq!(0, sol_to_lamports(0.0));
         assert_eq!(1, sol_to_lamports(0.000000001));


### PR DESCRIPTION
Handle NaNs, negative and large SOL values safely.
Round lamports to integer rather than truncate.
Add test cases.
Addresses issue #148.