### PR TITLE
Deprecate re-exports more loudly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4013,7 +4013,6 @@ dependencies = [
  "solana-packet",
  "solana-precompiles",
  "solana-presigner",
- "solana-program",
  "solana-pubkey",
  "solana-sanitize",
  "solana-sdk",
@@ -4025,6 +4024,7 @@ dependencies = [
  "solana-system-interface",
  "solana-transaction",
  "solana-transaction-error",
+ "solana-vote-interface",
  "static_assertions",
  "wasm-bindgen",
 ]

--- a/decode-error/src/lib.rs
+++ b/decode-error/src/lib.rs
@@ -21,6 +21,7 @@ use num_traits::FromPrimitive;
 /// [`ProgramError`]: https://docs.rs/solana-program-error/latest/solana_program_error/enum.ProgramError.html
 /// [`ProgramError::Custom`]: https://docs.rs/solana-program-error/latest/solana_program_error/enum.ProgramError.html#variant.Custom
 /// [`ToPrimitive`]: num_traits::ToPrimitive
+#[deprecated(since = "2.3.0", note = "Use `num_traits::FromPrimitive` instead")]
 pub trait DecodeError<E> {
     fn decode_custom_error_to_enum(custom: u32) -> Option<E>
     where
@@ -32,6 +33,7 @@ pub trait DecodeError<E> {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use {super::*, num_derive::FromPrimitive};
 

--- a/precompile-error/src/lib.rs
+++ b/precompile-error/src/lib.rs
@@ -1,5 +1,5 @@
 /// Precompile errors
-use {core::fmt, solana_decode_error::DecodeError};
+use core::fmt;
 
 /// Precompile errors
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -69,7 +69,8 @@ impl fmt::Display for PrecompileError {
     }
 }
 
-impl<T> DecodeError<T> for PrecompileError {
+#[allow(deprecated)]
+impl<T> solana_decode_error::DecodeError<T> for PrecompileError {
     fn type_of() -> &'static str {
         "PrecompileError"
     }

--- a/program-error/src/lib.rs
+++ b/program-error/src/lib.rs
@@ -9,7 +9,6 @@ use serde_derive::{Deserialize, Serialize};
 use {
     core::fmt,
     num_traits::FromPrimitive,
-    solana_decode_error::DecodeError,
     solana_instruction::error::{
         InstructionError, ACCOUNT_ALREADY_INITIALIZED, ACCOUNT_BORROW_FAILED,
         ACCOUNT_DATA_TOO_SMALL, ACCOUNT_NOT_RENT_EXEMPT, ARITHMETIC_OVERFLOW, BORSH_IO_ERROR,
@@ -126,17 +125,26 @@ impl fmt::Display for ProgramError {
     since = "2.2.2",
     note = "Use `ToStr` instead with `solana_msg::msg!` or any other logging"
 )]
+#[allow(deprecated)]
 pub trait PrintProgramError {
     fn print<E>(&self)
     where
-        E: 'static + std::error::Error + DecodeError<E> + PrintProgramError + FromPrimitive;
+        E: 'static
+            + std::error::Error
+            + solana_decode_error::DecodeError<E>
+            + PrintProgramError
+            + FromPrimitive;
 }
 
 #[allow(deprecated)]
 impl PrintProgramError for ProgramError {
     fn print<E>(&self)
     where
-        E: 'static + std::error::Error + DecodeError<E> + PrintProgramError + FromPrimitive,
+        E: 'static
+            + std::error::Error
+            + solana_decode_error::DecodeError<E>
+            + PrintProgramError
+            + FromPrimitive,
     {
         match self {
             Self::Custom(error) => {

--- a/program/src/address_lookup_table.rs
+++ b/program/src/address_lookup_table.rs
@@ -1,6 +1,9 @@
-#[deprecated(
-    since = "2.2.0",
-    note = "Use solana-address-lookup-table interface instead"
+#![deprecated(
+    since = "2.3.0",
+    note = "Use solana-address-lookup-table-interface and solana-message instead"
 )]
-pub use solana_address_lookup_table_interface::{error, instruction, program, state};
-pub use solana_message::AddressLookupTableAccount;
+
+pub use {
+    solana_address_lookup_table_interface::{error, instruction, program, state},
+    solana_message::AddressLookupTableAccount,
+};

--- a/program/src/bpf_loader_upgradeable.rs
+++ b/program/src/bpf_loader_upgradeable.rs
@@ -1,4 +1,5 @@
-#[deprecated(since = "2.2.0", note = "Use solana-loader-v3-interface instead")]
+#![deprecated(since = "2.3.0", note = "Use solana-loader-v3-interface instead")]
+
 #[allow(deprecated)]
 pub use solana_loader_v3_interface::{
     get_program_data_address,

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -502,6 +502,10 @@ pub mod log;
 pub mod nonce;
 pub mod program;
 pub mod program_error;
+#[deprecated(
+    since = "2.3.0",
+    note = "Use `solana_bincode::limited_deserialize` instead"
+)]
 pub mod program_utils;
 pub mod secp256k1_program;
 pub mod slot_hashes;

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -483,19 +483,19 @@ pub mod hash;
 pub mod incinerator;
 pub mod instruction;
 pub mod lamports;
+#[deprecated(
+    since = "2.3.0",
+    note = "Use solana_loader_v3_interface::instruction instead"
+)]
 pub mod loader_upgradeable_instruction {
-    #[deprecated(
-        since = "2.2.0",
-        note = "Use solana_loader_v3_interface::instruction instead"
-    )]
     pub use solana_loader_v3_interface::instruction::UpgradeableLoaderInstruction;
 }
 pub mod loader_v4;
+#[deprecated(
+    since = "2.3.0",
+    note = "Use solana_loader_v4_interface::instruction instead"
+)]
 pub mod loader_v4_instruction {
-    #[deprecated(
-        since = "2.2.0",
-        note = "Use solana_loader_v4_interface::instruction instead"
-    )]
     pub use solana_loader_v4_interface::instruction::LoaderV4Instruction;
 }
 pub mod log;
@@ -530,10 +530,12 @@ pub use solana_borsh::v1 as borsh1;
 #[deprecated(since = "2.1.0", note = "Use `solana-epoch-rewards` crate instead")]
 pub use solana_epoch_rewards as epoch_rewards;
 #[deprecated(
-    since = "2.2.0",
+    since = "2.3.0",
     note = "Use `solana-feature-gate-interface` crate instead"
 )]
-pub use solana_feature_gate_interface as feature;
+pub mod feature {
+    pub use solana_feature_gate_interface::*;
+}
 #[deprecated(since = "2.1.0", note = "Use `solana-fee-calculator` crate instead")]
 pub use solana_fee_calculator as fee_calculator;
 #[deprecated(since = "2.2.0", note = "Use `solana-keccak-hasher` crate instead")]
@@ -541,18 +543,24 @@ pub use solana_keccak_hasher as keccak;
 #[deprecated(since = "2.1.0", note = "Use `solana-last-restart-slot` crate instead")]
 pub use solana_last_restart_slot as last_restart_slot;
 #[deprecated(
-    since = "2.2.0",
+    since = "2.3.0",
     note = "Use `solana-loader-v2-interface` crate instead"
 )]
-pub use solana_loader_v2_interface as loader_instruction;
-#[deprecated(since = "2.2.0", note = "Use `solana-message` crate instead")]
-pub use solana_message as message;
+pub mod loader_instruction {
+    pub use solana_loader_v2_interface::*;
+}
+#[deprecated(since = "2.3.0", note = "Use `solana-message` crate instead")]
+pub mod message {
+    pub use solana_message::*;
+}
 #[deprecated(since = "2.1.0", note = "Use `solana-program-memory` crate instead")]
 pub use solana_program_memory as program_memory;
 #[deprecated(since = "2.1.0", note = "Use `solana-program-pack` crate instead")]
 pub use solana_program_pack as program_pack;
-#[deprecated(since = "2.1.0", note = "Use `solana-sanitize` crate instead")]
-pub use solana_sanitize as sanitize;
+#[deprecated(since = "2.3.0", note = "Use `solana-sanitize` crate instead")]
+pub mod sanitize {
+    pub use solana_sanitize::*;
+}
 #[deprecated(since = "2.1.0", note = "Use `solana-secp256k1-recover` crate instead")]
 pub use solana_secp256k1_recover as secp256k1_recover;
 #[deprecated(since = "2.1.0", note = "Use `solana-serde-varint` crate instead")]
@@ -565,8 +573,10 @@ pub use solana_short_vec as short_vec;
 pub use solana_stable_layout as stable_layout;
 #[cfg(not(target_os = "solana"))]
 pub use solana_sysvar::program_stubs;
-#[deprecated(since = "2.2.0", note = "Use `solana-vote-interface` crate instead")]
-pub use solana_vote_interface as vote;
+#[deprecated(since = "2.3.0", note = "Use `solana-vote-interface` crate instead")]
+pub mod vote {
+    pub use solana_vote_interface::*;
+}
 #[cfg(target_arch = "wasm32")]
 pub use wasm_bindgen::prelude::wasm_bindgen;
 pub use {
@@ -632,8 +642,10 @@ pub mod sdk_ids {
     }
 }
 
-#[deprecated(since = "2.1.0", note = "Use `solana-decode-error` crate instead")]
-pub use solana_decode_error as decode_error;
+#[deprecated(since = "2.3.0", note = "Use `num_traits::FromPrimitive` instead")]
+pub mod decode_error {
+    pub use solana_decode_error::*;
+}
 pub use solana_pubkey::{declare_deprecated_id, declare_id, pubkey};
 #[deprecated(since = "2.1.0", note = "Use `solana-sysvar-id` crate instead")]
 pub use solana_sysvar_id::{declare_deprecated_sysvar_id, declare_sysvar_id};

--- a/program/src/loader_v4.rs
+++ b/program/src/loader_v4.rs
@@ -1,14 +1,14 @@
-#[deprecated(since = "2.2.0", note = "Use solana-loader-v4-interface instead")]
-pub use solana_loader_v4_interface::{
-    instruction::{
-        create_buffer, deploy, deploy_from_source, finalize, is_deploy_instruction,
-        is_finalize_instruction, is_retract_instruction, is_set_program_length_instruction,
-        is_set_program_length_instruction as is_truncate_instruction,
-        is_transfer_authority_instruction, is_write_instruction, retract,
-        set_program_length as truncate, set_program_length as truncate_uninitialized,
-        set_program_length, transfer_authority, write,
+#![deprecated(since = "2.3.0", note = "Use solana-loader-v4-interface instead")]
+pub use {
+    solana_loader_v4_interface::{
+        instruction::{
+            create_buffer, deploy, deploy_from_source, finalize, is_deploy_instruction,
+            is_finalize_instruction, is_retract_instruction, is_set_program_length_instruction,
+            is_transfer_authority_instruction, is_write_instruction, retract,
+            set_program_length as truncate, transfer_authority, write,
+        },
+        state::{LoaderV4State, LoaderV4Status},
+        DEPLOYMENT_COOLDOWN_IN_SLOTS,
     },
-    state::{LoaderV4State, LoaderV4Status},
-    DEPLOYMENT_COOLDOWN_IN_SLOTS,
+    solana_sdk_ids::loader_v4::{check_id, id, ID},
 };
-pub use solana_sdk_ids::loader_v4::{check_id, id, ID};

--- a/program/src/nonce.rs
+++ b/program/src/nonce.rs
@@ -1,3 +1,5 @@
+#![deprecated(since = "2.3.0", note = "Use solana_nonce instead")]
+
 pub use solana_nonce::{state::State, NONCED_TX_MARKER_IX_INDEX};
 pub mod state {
     pub use solana_nonce::{

--- a/program/src/stake.rs
+++ b/program/src/stake.rs
@@ -1,10 +1,9 @@
-#[deprecated(since = "2.2.0", note = "Use solana-stake-interface instead")]
+#![deprecated(since = "2.3.0", note = "Use solana-stake-interface instead")]
 pub use solana_stake_interface::{
     config, stake_flags, state, tools, MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION,
 };
 
 pub mod instruction {
-    #[deprecated(since = "2.2.0", note = "Use solana-stake-interface instead")]
     pub use solana_stake_interface::{error::StakeError, instruction::*};
 }
 

--- a/program/src/stake_history.rs
+++ b/program/src/stake_history.rs
@@ -1,3 +1,4 @@
+#![deprecated(since = "2.3.0", note = "Use `solana-stake-interface` crate instead")]
 pub use {
     crate::sysvar::stake_history::{
         StakeHistory, StakeHistoryEntry, StakeHistoryGetEntry, MAX_ENTRIES,

--- a/program/src/system_instruction.rs
+++ b/program/src/system_instruction.rs
@@ -1,4 +1,5 @@
-#[deprecated(since = "2.2.0", note = "Use `solana_system_interface` crate instead")]
+#![deprecated(since = "2.3.0", note = "Use `solana_system_interface` crate instead")]
+
 pub use solana_system_interface::{
     error::SystemError,
     instruction::{

--- a/program/src/system_program.rs
+++ b/program/src/system_program.rs
@@ -1,3 +1,4 @@
+#![deprecated(since = "2.3.0", note = "Use `solana_sdk_ids::system_program` instead")]
 //! The [system native program][np].
 //!
 //! [np]: https://docs.solanalabs.com/runtime/programs#system-program

--- a/pubkey/src/lib.rs
+++ b/pubkey/src/lib.rs
@@ -29,7 +29,6 @@ use {
         str::{from_utf8, FromStr},
     },
     num_traits::{FromPrimitive, ToPrimitive},
-    solana_decode_error::DecodeError,
 };
 #[cfg(target_arch = "wasm32")]
 use {
@@ -120,7 +119,8 @@ impl fmt::Display for PubkeyError {
     }
 }
 
-impl<T> DecodeError<T> for PubkeyError {
+#[allow(deprecated)]
+impl<T> solana_decode_error::DecodeError<T> for PubkeyError {
     fn type_of() -> &'static str {
         "PubkeyError"
     }
@@ -381,7 +381,8 @@ impl From<Infallible> for ParsePubkeyError {
     }
 }
 
-impl<T> DecodeError<T> for ParsePubkeyError {
+#[allow(deprecated)]
+impl<T> solana_decode_error::DecodeError<T> for ParsePubkeyError {
     fn type_of() -> &'static str {
         "ParsePubkeyError"
     }

--- a/sdk/src/feature.rs
+++ b/sdk/src/feature.rs
@@ -1,1 +1,2 @@
+#[allow(deprecated)]
 pub use solana_program::feature::*;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -35,26 +35,107 @@
 extern crate self as solana_sdk;
 
 #[cfg(feature = "full")]
-pub use solana_commitment_config as commitment_config;
+#[deprecated(since = "2.3.0", note = "Use `solana-commitment-config` crate instead")]
+pub mod commitment_config {
+    pub use solana_commitment_config::*;
+}
 #[cfg(not(target_os = "solana"))]
 pub use solana_program::program_stubs;
-// These solana_program imports could be *-imported, but that causes a bunch of
-// confusing duplication in the docs due to a rustdoc bug. #26211
-#[allow(deprecated)]
-pub use solana_program::sdk_ids;
 #[cfg(target_arch = "wasm32")]
 pub use solana_program::wasm_bindgen;
 pub use solana_program::{
-    account_info, address_lookup_table, big_mod_exp, blake3, bpf_loader, bpf_loader_deprecated,
-    bpf_loader_upgradeable, clock, config, custom_heap_default, custom_panic_default,
-    debug_account_data, declare_deprecated_sysvar_id, declare_sysvar_id, ed25519_program,
-    epoch_rewards, epoch_schedule, fee_calculator, impl_sysvar_get, incinerator, instruction,
-    keccak, lamports, loader_instruction, loader_upgradeable_instruction, loader_v4,
-    loader_v4_instruction, message, msg, native_token, nonce, program, program_error,
-    program_option, program_pack, rent, secp256k1_program, serialize_utils, slot_hashes,
-    slot_history, stable_layout, stake, stake_history, syscalls, system_instruction,
-    system_program, sysvar, unchecked_div_by_const, vote,
+    account_info, big_mod_exp, blake3, bpf_loader, bpf_loader_deprecated, clock, config,
+    custom_heap_default, custom_panic_default, debug_account_data, declare_deprecated_sysvar_id,
+    declare_sysvar_id, ed25519_program, epoch_rewards, epoch_schedule, fee_calculator,
+    impl_sysvar_get, incinerator, instruction, keccak, lamports, msg, native_token, program,
+    program_error, program_option, program_pack, rent, secp256k1_program, serialize_utils,
+    slot_hashes, slot_history, stable_layout, syscalls, sysvar, unchecked_div_by_const,
 };
+#[deprecated(
+    since = "2.3.0",
+    note = "Use `solana-address-lookup-table-interface` crate instead"
+)]
+pub mod address_lookup_table {
+    #[allow(deprecated)]
+    pub use solana_program::address_lookup_table::*;
+}
+#[deprecated(
+    since = "2.3.0",
+    note = "Use `solana-loader-v3-interface` crate instead"
+)]
+pub mod bpf_loader_upgradeable {
+    #[allow(deprecated)]
+    pub use solana_program::bpf_loader_upgradeable::*;
+}
+#[deprecated(
+    since = "2.3.0",
+    note = "Use `solana-loader-v2-interface` crate instead"
+)]
+pub mod loader_instruction {
+    #[allow(deprecated)]
+    pub use solana_program::loader_instruction::*;
+}
+#[deprecated(
+    since = "2.3.0",
+    note = "Use solana_loader_v3_interface::instruction instead"
+)]
+pub mod loader_upgradeable_instruction {
+    #[allow(deprecated)]
+    pub use solana_program::loader_upgradeable_instruction::*;
+}
+#[deprecated(since = "2.3.0", note = "Use solana-loader-v4-interface instead")]
+pub mod loader_v4 {
+    #[allow(deprecated)]
+    pub use solana_program::loader_v4::*;
+}
+#[deprecated(
+    since = "2.3.0",
+    note = "Use solana_loader_v4_interface::instruction instead"
+)]
+pub mod loader_v4_instruction {
+    #[allow(deprecated)]
+    pub use solana_program::loader_v4_instruction::*;
+}
+#[deprecated(since = "2.2.0", note = "Use `solana-message` crate instead")]
+pub use solana_message as message;
+#[deprecated(since = "2.3.0", note = "Use `solana-nonce` crate instead")]
+pub mod nonce {
+    #[allow(deprecated)]
+    pub use solana_program::nonce::*;
+}
+#[deprecated(since = "2.3.0", note = "Use `solana-sdk-ids` crate instead")]
+pub mod sdk_ids {
+    #[allow(deprecated)]
+    pub use solana_program::sdk_ids::*;
+}
+#[deprecated(since = "2.3.0", note = "Use `solana-stake-interface` instead")]
+pub mod stake {
+    #[allow(deprecated)]
+    pub use solana_program::stake::*;
+}
+#[deprecated(
+    since = "2.3.0",
+    note = "Use `solana_stake_interface::stake_history` instead"
+)]
+pub mod stake_history {
+    #[allow(deprecated)]
+    pub use solana_program::stake_history::*;
+}
+#[deprecated(since = "2.3.0", note = "Use `solana_system_interface` crate instead")]
+pub mod system_instruction {
+    #[allow(deprecated)]
+    pub use solana_program::system_instruction::*;
+}
+#[deprecated(since = "2.3.0", note = "Use `solana_sdk_ids::system_program` instead")]
+pub mod system_program {
+    #[allow(deprecated)]
+    pub use solana_program::system_program::*;
+}
+#[deprecated(since = "2.3.0", note = "Use `solana_vote_interface` crate instead")]
+pub mod vote {
+    #[allow(deprecated)]
+    pub use solana_program::vote::*;
+}
 #[cfg(feature = "borsh")]
 pub use solana_program::{borsh, borsh0_10, borsh1};
 #[cfg(feature = "full")]
@@ -63,13 +144,21 @@ pub use solana_signer::signers;
 pub mod entrypoint;
 pub mod entrypoint_deprecated;
 pub mod example_mocks;
+#[deprecated(
+    since = "2.2.0",
+    note = "Use `solana-feature-gate-interface` crate instead"
+)]
 pub mod feature;
 #[cfg(feature = "full")]
-#[deprecated(since = "2.2.0", note = "Use `solana-genesis-config` crate instead")]
-pub use solana_genesis_config as genesis_config;
+#[deprecated(since = "2.3.0", note = "Use `solana-genesis-config` crate instead")]
+pub mod genesis_config {
+    pub use solana_genesis_config::*;
+}
 #[cfg(feature = "full")]
-#[deprecated(since = "2.2.0", note = "Use `solana-hard-forks` crate instead")]
-pub use solana_hard_forks as hard_forks;
+#[deprecated(since = "2.3.0", note = "Use `solana-hard-forks` crate instead")]
+pub mod hard_forks {
+    pub use solana_hard_forks::*;
+}
 pub mod hash;
 pub mod log;
 pub mod native_loader;
@@ -79,8 +168,10 @@ pub mod precompiles;
 pub mod program_utils;
 pub mod pubkey;
 #[cfg(feature = "full")]
-#[deprecated(since = "2.2.0", note = "Use `solana_rent_collector` crate instead")]
-pub use solana_rent_collector as rent_collector;
+#[deprecated(since = "2.3.0", note = "Use `solana_rent_collector` crate instead")]
+pub mod rent_collector {
+    pub use solana_rent_collector::*;
+}
 #[deprecated(since = "2.2.0", note = "Use `solana-reward-info` crate instead")]
 pub mod reward_info {
     pub use solana_reward_info::RewardInfo;
@@ -106,24 +197,36 @@ pub use solana_account as account;
     note = "Use `solana_account::state_traits` crate instead"
 )]
 pub use solana_account::state_traits as account_utils;
-#[deprecated(since = "2.1.0", note = "Use `solana-bn254` crate instead")]
-pub use solana_bn254 as alt_bn128;
+#[deprecated(since = "2.3.0", note = "Use `solana-bn254` crate instead")]
+pub mod alt_bn128 {
+    pub use solana_bn254::*;
+}
 #[cfg(feature = "full")]
-#[deprecated(since = "2.2.0", note = "Use `solana-client-traits` crate instead")]
-pub use solana_client_traits as client;
+#[deprecated(since = "2.3.0", note = "Use `solana-client-traits` crate instead")]
+pub mod client {
+    pub use solana_client_traits::*;
+}
 #[deprecated(
-    since = "2.2.0",
+    since = "2.3.0",
     note = "Use `solana-compute-budget-interface` crate instead"
 )]
 #[cfg(feature = "full")]
-pub use solana_compute_budget_interface as compute_budget;
-#[deprecated(since = "2.1.0", note = "Use `solana-decode-error` crate instead")]
-pub use solana_decode_error as decode_error;
-#[deprecated(since = "2.1.0", note = "Use `solana-derivation-path` crate instead")]
-pub use solana_derivation_path as derivation_path;
+pub mod compute_budget {
+    pub use solana_compute_budget_interface::*;
+}
+#[deprecated(since = "2.3.0", note = "Use `solana-decode-error` crate instead")]
+pub mod decode_error {
+    pub use solana_decode_error::*;
+}
+#[deprecated(since = "2.3.0", note = "Use `solana-derivation-path` crate instead")]
+pub mod derivation_path {
+    pub use solana_derivation_path::*;
+}
 #[cfg(feature = "full")]
-#[deprecated(since = "2.2.0", note = "Use `solana-ed25519-program` crate instead")]
-pub use solana_ed25519_program as ed25519_instruction;
+#[deprecated(since = "2.3.0", note = "Use `solana-ed25519-program` crate instead")]
+pub mod ed25519_instruction {
+    pub use solana_ed25519_program::*;
+}
 #[deprecated(since = "2.2.0", note = "Use `solana-epoch-info` crate instead")]
 pub use solana_epoch_info as epoch_info;
 #[deprecated(
@@ -145,15 +248,21 @@ pub use solana_inflation as inflation;
     note = "Use `solana_message::inner_instruction` instead"
 )]
 pub use solana_message::inner_instruction;
-#[deprecated(since = "2.2.0", note = "Use `solana-nonce-account` crate instead")]
-pub use solana_nonce_account as nonce_account;
+#[deprecated(since = "2.3.0", note = "Use `solana-nonce-account` crate instead")]
+pub mod nonce_account {
+    pub use solana_nonce_account::*;
+}
 #[cfg(feature = "full")]
 #[deprecated(since = "2.2.0", note = "Use `solana-offchain-message` crate instead")]
 pub use solana_offchain_message as offchain_message;
-#[deprecated(since = "2.1.0", note = "Use `solana-packet` crate instead")]
-pub use solana_packet as packet;
-#[deprecated(since = "2.2.0", note = "Use `solana-poh-config` crate instead")]
-pub use solana_poh_config as poh_config;
+#[deprecated(since = "2.3.0", note = "Use `solana-packet` crate instead")]
+pub mod packet {
+    pub use solana_packet::*;
+}
+#[deprecated(since = "2.3.0", note = "Use `solana-poh-config` crate instead")]
+pub mod poh_config {
+    pub use solana_poh_config::*;
+}
 #[deprecated(since = "2.1.0", note = "Use `solana-program-memory` crate instead")]
 pub use solana_program_memory as program_memory;
 #[deprecated(since = "2.1.0", note = "Use `solana_pubkey::pubkey` instead")]
@@ -174,10 +283,14 @@ pub use solana_program_memory as program_memory;
 /// ```
 pub use solana_pubkey::pubkey;
 #[cfg(feature = "full")]
-#[deprecated(since = "2.2.0", note = "Use `solana-quic-definitions` crate instead")]
-pub use solana_quic_definitions as quic;
-#[deprecated(since = "2.2.0", note = "Use `solana-rent-debits` crate instead")]
-pub use solana_rent_debits as rent_debits;
+#[deprecated(since = "2.3.0", note = "Use `solana-quic-definitions` crate instead")]
+pub mod quic {
+    pub use solana_quic_definitions::*;
+}
+#[deprecated(since = "2.3.0", note = "Use `solana-rent-debits` crate instead")]
+pub mod rent_debits {
+    pub use solana_rent_debits::*;
+}
 #[cfg(feature = "full")]
 #[deprecated(
     since = "2.2.2",
@@ -215,11 +328,15 @@ pub use solana_sdk_macro::declare_deprecated_id;
 pub use solana_sdk_macro::declare_id;
 /// Convenience macro to define multiple static public keys.
 pub use solana_sdk_macro::pubkeys;
-#[deprecated(since = "2.2.0", note = "Use `solana-secp256k1-program` crate instead")]
+#[deprecated(since = "2.3.0", note = "Use `solana-secp256k1-program` crate instead")]
 #[cfg(feature = "full")]
-pub use solana_secp256k1_program as secp256k1_instruction;
-#[deprecated(since = "2.1.0", note = "Use `solana-secp256k1-recover` crate instead")]
-pub use solana_secp256k1_recover as secp256k1_recover;
+pub mod secp256k1_instruction {
+    pub use solana_secp256k1_program::*;
+}
+#[deprecated(since = "2.3.0", note = "Use `solana-secp256k1-recover` crate instead")]
+pub mod secp256k1_recover {
+    pub use solana_secp256k1_recover::*;
+}
 #[deprecated(since = "2.2.0", note = "Use `solana-serde` crate instead")]
 pub use solana_serde as deserialize_utils;
 #[deprecated(since = "2.1.0", note = "Use `solana-serde-varint` crate instead")]
@@ -228,10 +345,12 @@ pub use solana_serde_varint as serde_varint;
 pub use solana_short_vec as short_vec;
 #[cfg(feature = "full")]
 #[deprecated(
-    since = "2.2.0",
+    since = "2.3.0",
     note = "Use `solana-system-transaction` crate instead"
 )]
-pub use solana_system_transaction as system_transaction;
+pub mod system_transaction {
+    pub use solana_system_transaction::*;
+}
 #[deprecated(since = "2.2.0", note = "Use `solana-time-utils` crate instead")]
 pub use solana_time_utils as timing;
 #[cfg(feature = "full")]
@@ -247,8 +366,10 @@ pub use solana_transaction::simple_vote_transaction_checker;
 pub mod transaction_context {
     pub use solana_transaction_context::*;
 }
-#[deprecated(since = "2.2.0", note = "Use `solana-validator-exit` crate instead")]
-pub use solana_validator_exit as exit;
+#[deprecated(since = "2.3.0", note = "Use `solana-validator-exit` crate instead")]
+pub mod exit {
+    pub use solana_validator_exit::*;
+}
 
 /// Convenience macro for `AddAssign` with saturating arithmetic.
 /// Replace by `std::num::Saturating` once stable

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -126,7 +126,10 @@ pub mod system_instruction {
     #[allow(deprecated)]
     pub use solana_program::system_instruction::*;
 }
-#[deprecated(since = "2.3.0", note = "Use `solana_sdk_ids::system_program` instead")]
+#[deprecated(
+    since = "2.3.0",
+    note = "Use `solana_system_interface::program` instead"
+)]
 pub mod system_program {
     #[allow(deprecated)]
     pub use solana_program::system_program::*;
@@ -372,7 +375,7 @@ pub mod exit {
 }
 
 /// Convenience macro for `AddAssign` with saturating arithmetic.
-/// Replace by `std::num::Saturating` once stable
+#[deprecated(since = "2.3.0", note = "Use `std::num::Saturating` instead")]
 #[macro_export]
 macro_rules! saturating_add_assign {
     ($i:expr, $v:expr) => {{
@@ -383,6 +386,7 @@ macro_rules! saturating_add_assign {
 pub extern crate bs58;
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     #[test]
     fn test_saturating_add_assign() {

--- a/sdk/src/program_utils.rs
+++ b/sdk/src/program_utils.rs
@@ -6,6 +6,10 @@ use crate::instruction::InstructionError;
 
 /// Deserialize with a limit based the maximum amount of data a program can expect to get.
 /// This function should be used in place of direct deserialization to help prevent OOM errors
+#[deprecated(
+    since = "2.3.0",
+    note = "Use `solana_bincode::limited_deserialize` instead"
+)]
 pub fn limited_deserialize<T>(instruction_data: &[u8]) -> Result<T, InstructionError>
 where
     T: serde::de::DeserializeOwned,
@@ -17,6 +21,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 pub mod tests {
     use super::*;
 

--- a/sdk/src/rpc_port.rs
+++ b/sdk/src/rpc_port.rs
@@ -1,3 +1,4 @@
+#![deprecated(since = "2.3.0", note = "Use `solana_rpc_client_api::port` instead")]
 //! RPC default port numbers.
 
 /// Default port number for JSON RPC API

--- a/transaction/Cargo.toml
+++ b/transaction/Cargo.toml
@@ -45,11 +45,11 @@ solana-keypair = { workspace = true }
 solana-nonce = { workspace = true }
 solana-packet = { workspace = true }
 solana-presigner = { workspace = true }
-solana-program = { workspace = true, default-features = false }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-sdk = { path = "../sdk" }
 solana-sha256-hasher = { workspace = true }
 solana-transaction = { path = ".", features = ["dev-context-only-utils"] }
+solana-vote-interface = { workspace = true }
 static_assertions = { workspace = true }
 
 [features]

--- a/transaction/src/sanitized.rs
+++ b/transaction/src/sanitized.rs
@@ -344,8 +344,8 @@ mod tests {
         super::*,
         solana_keypair::Keypair,
         solana_message::{MessageHeader, SimpleAddressLoader},
-        solana_program::vote::{self, state::Vote},
         solana_signer::Signer,
+        solana_vote_interface::{instruction, state::Vote},
     };
 
     #[test]
@@ -357,8 +357,7 @@ mod tests {
         let node_keypair = Keypair::new();
         let auth_keypair = Keypair::new();
         let votes = Vote::new(vec![1, 2, 3], bank_hash);
-        let vote_ix =
-            vote::instruction::vote(&vote_keypair.pubkey(), &auth_keypair.pubkey(), votes);
+        let vote_ix = instruction::vote(&vote_keypair.pubkey(), &auth_keypair.pubkey(), votes);
         let mut vote_tx = Transaction::new_with_payer(&[vote_ix], Some(&node_keypair.pubkey()));
         vote_tx.partial_sign(&[&node_keypair], block_hash);
         vote_tx.partial_sign(&[&auth_keypair], block_hash);

--- a/vote-interface/src/error.rs
+++ b/vote-interface/src/error.rs
@@ -3,7 +3,6 @@
 use {
     core::fmt,
     num_derive::{FromPrimitive, ToPrimitive},
-    solana_decode_error::DecodeError,
 };
 
 /// Reasons the vote might have had an error
@@ -73,7 +72,8 @@ impl fmt::Display for VoteError {
     }
 }
 
-impl<E> DecodeError<E> for VoteError {
+#[allow(deprecated)]
+impl<E> solana_decode_error::DecodeError<E> for VoteError {
     fn type_of() -> &'static str {
         "VoteError"
     }
@@ -86,9 +86,10 @@ mod tests {
     #[test]
     fn test_custom_error_decode() {
         use num_traits::FromPrimitive;
+        #[allow(deprecated)]
         fn pretty_err<T>(err: InstructionError) -> String
         where
-            T: 'static + std::error::Error + DecodeError<T> + FromPrimitive,
+            T: 'static + std::error::Error + solana_decode_error::DecodeError<T> + FromPrimitive,
         {
             if let InstructionError::Custom(code) = err {
                 let specific_error: T = T::decode_custom_error_to_enum(code).unwrap();


### PR DESCRIPTION
#### Problem

There are many different crates and types that we would like to remove from the sdk, but they are still re-exported from solana-sdk and solana-program. The re-exports have a `#[deprecated(...)]` attribute, but they aren't flagged to downstream users.

#### Summary of changes

Make the re-export deprecations louder by creating a deprecated module and re-exporting from in there.

These are the types affected

* `DecodeError`: this trait isn't all that useful, and is set to be removed entirely with #104, so deprecate it here

These are the crates to no longer re-export from solana-program because they will be moved to program-specific repos:

* `address_lookup_table` -> `solana_address_lookup_table_interface`
* `bpf_loader_upgradeable` -> `solana_loader_v3_interface`
* `loader_upgradeable_instruction` -> `solana_loader_v3_interface::instruction`
* `loader_v4` -> `solana_loader_v4_interface`
* `loader_v4_instruction` -> `solana_loader_v4_interface::instruction`
* `nonce` -> `solana_nonce`
* `feature` -> `solana_feature_gate_interface`
* `loader_instruction` -> `solana_loader_v2_interface`
* `vote` -> `solana_vote_interface`
* `stake` -> `solana_stake_interface`
* `stake_history` -> `solana_stake_interface::stake_history`
* `system_instruction` -> `solana_system_interface`
* `system_program` -> `solana_sdk_ids::system_program` (not sure about this one)

Separately, `solana_message` and `solana_sanitize` are no longer re-exported. They never quite fit in `solana_program`, and caused more annoyance than anything else. The re-exports remain in `solana_sdk`.

`solana-decode-error` will be removed entirely, so its deprecation is louder too.

For `solana-sdk`, there are many types that just don't belong, so stop re-exporting these:

* `commitment_config` -> `solana_commitment_config`
* `genesis_config` -> `solana_genesis_config`
* `hard_forks` -> `solana_hard_forks`
* `rent_collector` -> `solana_rent_collector`
* `alt_bn128` -> `solana_bn254`
* `client` -> `solana_client_traits`
* `compute_budget` -> `solana_compute_budget_interface`
* `derivation_path` -> `solana_derivation_path`
* `ed25519_instruction` -> `solana_ed25519_program`
* `nonce_account` -> `solana_nonce_account`
* `packet` -> `solana_packet`
* `poh_config` -> `solana_poh_config`
* `quic` -> `solana_quic_definitions`
* `rent_debits` -> `solana_rent_debits`
* `secp256k1_instruction` -> `solana_secp256k1_program`
* `secp256k1_recover` -> `solana_secp256k1_recover`
* `system_transaction` -> `solana_system_transaction`
* `exit` -> `solana_validator_exit`

I ran this branch against agave, and there won't be too many changes required. Let me know if you want to add or remove any other re-exports, these seemed like the most sensible.