### PR TITLE
deny warnings in check-doc.sh

### DIFF
--- a/scripts/check-doc.sh
+++ b/scripts/check-doc.sh
@@ -5,4 +5,5 @@ here="$(dirname "$0")"
 src_root="$(readlink -f "${here}/..")"
 cd "${src_root}"
 
+export RUSTDOCFLAGS="-D warnings"
 ./cargo nightly hack doc --all-features


### PR DESCRIPTION
I noticed check-doc.sh generates some warnings. We probably want to fail on those. Making this a draft since the warnings need to be fixed first