### PR TITLE
use saturating_sub in is_writable_index() - fix #150

### DIFF
--- a/message/src/legacy.rs
+++ b/message/src/legacy.rs
@@ -1044,7 +1044,7 @@ mod tests {
         };
         assert!(!message1.is_writable_index(0));
 
-        // Matching issue #150 PoC 2 concept - num_readonly_unsigned_accounts > account_keys.len()
+        // Matching issue #150 PoC 2 - num_readonly_unsigned_accounts > account_keys.len()
         let key_for_poc2 = Pubkey::new_unique();
         let message2 = Message {
             header: MessageHeader {

--- a/message/src/legacy.rs
+++ b/message/src/legacy.rs
@@ -646,11 +646,13 @@ impl Message {
     /// Returns true if the account at the specified index was requested to be
     /// writable. This method should not be used directly.
     pub(super) fn is_writable_index(&self, i: usize) -> bool {
-        i < (self.header.num_required_signatures - self.header.num_readonly_signed_accounts)
-            as usize
+        i < (self.header.num_required_signatures as usize)
+            .saturating_sub(self.header.num_readonly_signed_accounts as usize)
             || (i >= self.header.num_required_signatures as usize
-                && i < self.account_keys.len()
-                    - self.header.num_readonly_unsigned_accounts as usize)
+                && i < self
+                    .account_keys
+                    .len()
+                    .saturating_sub(self.header.num_readonly_unsigned_accounts as usize))
     }
 
     /// Returns true if the account at the specified index is writable by the

--- a/message/src/legacy.rs
+++ b/message/src/legacy.rs
@@ -1025,4 +1025,81 @@ mod tests {
     fn test_inline_all_ids() {
         assert_eq!(solana_sysvar::ALL_IDS.to_vec(), ALL_IDS.to_vec());
     }
+
+    #[test]
+    fn test_is_writable_index_saturating_behavior() {
+        // Directly matching issue #150 PoC 1:
+        // num_readonly_signed_accounts > num_required_signatures
+        // This now results in the first part of the OR condition in is_writable_index effectively becoming `i < 0`.
+        let key0 = Pubkey::new_unique();
+        let message1 = Message {
+            header: MessageHeader {
+                num_required_signatures: 1,
+                num_readonly_signed_accounts: 2, // 2 > 1
+                num_readonly_unsigned_accounts: 0,
+            },
+            account_keys: vec![key0],
+            recent_blockhash: Hash::default(),
+            instructions: vec![],
+        };
+        assert!(!message1.is_writable_index(0));
+
+        // Matching issue #150 PoC 2 concept - num_readonly_unsigned_accounts > account_keys.len()
+        let key_for_poc2 = Pubkey::new_unique();
+        let message2 = Message {
+            header: MessageHeader {
+                num_required_signatures: 0,
+                num_readonly_signed_accounts: 0,
+                num_readonly_unsigned_accounts: 2, // 2 > account_keys.len() (1)
+            },
+            account_keys: vec![key_for_poc2],
+            recent_blockhash: Hash::default(),
+            instructions: vec![],
+        };
+        assert!(!message2.is_writable_index(0));
+
+        // Scenario 3: num_readonly_unsigned_accounts > account_keys.len() with writable signed account
+        // This should result in the first condition being true for the signed account
+        let message3 = Message {
+            header: MessageHeader {
+                num_required_signatures: 1, // Writable range starts before index 1
+                num_readonly_signed_accounts: 0,
+                num_readonly_unsigned_accounts: 2, // 2 > account_keys.len() (1)
+            },
+            account_keys: vec![key0],
+            recent_blockhash: Hash::default(),
+            instructions: vec![],
+        };
+        assert!(message3.is_writable_index(0));
+
+        // Scenario 4: Both conditions, and testing an index that would rely on the second part of OR
+        let key1 = Pubkey::new_unique();
+        let message4 = Message {
+            header: MessageHeader {
+                num_required_signatures: 1, // Writable range starts before index 1 for signed accounts
+                num_readonly_signed_accounts: 0,
+                num_readonly_unsigned_accounts: 3, // 3 > account_keys.len() (2)
+            },
+            account_keys: vec![key0, key1],
+            recent_blockhash: Hash::default(),
+            instructions: vec![],
+        };
+        assert!(message4.is_writable_index(0));
+        assert!(!message4.is_writable_index(1));
+
+        // Scenario 5: num_required_signatures is 0 due to saturating_sub
+        // and num_readonly_unsigned_accounts makes the second range empty
+        let message5 = Message {
+            header: MessageHeader {
+                num_required_signatures: 1,
+                num_readonly_signed_accounts: 2, // 1.saturating_sub(2) = 0
+                num_readonly_unsigned_accounts: 3, // account_keys.len().saturating_sub(3) potentially 0
+            },
+            account_keys: vec![key0, key1], // len is 2
+            recent_blockhash: Hash::default(),
+            instructions: vec![],
+        };
+        assert!(!message5.is_writable_index(0));
+        assert!(!message5.is_writable_index(1));
+    }
 }


### PR DESCRIPTION
legacy: use saturating_sub in is_writable_index()

Fixes #150.

Problem
-------
`is_writable_index()` subtracts two u8 header counters.  
If the caller skips `Message::sanitize()` the subtraction can underflow, panicking in debug builds or silently wrapping to 255 in release, making ≈all accounts appear writable.

Options considered
------------------
* wrapping_sub  
  + Zero-cost.  
  - Fail-open: an unchecked message marks many indices writable.

* saturating_sub (chosen)  
  + Matches the [v0-message implementation](https://github.com/anza-xyz/solana-sdk/blob/0f9989d0f2f6aa5328124084e20f587446bda79b/message/src/versions/v0/loaded.rs#L116-L136).  
  + Fail-closed: underflow clamps to 0, no extra accounts are writable.  
  - Adds a micro-op, but this should cause no performance impact.

Change
------
Replace both unchecked subtractions with `saturating_sub`.
Add a unit test covering scenarios including those demonstrated in the original PoC.

Result
------
Now immune to underflow; behavior of legacy messages here aligns with behavior of v0 messages.