### PR TITLE
Marks the authority in `extend_program_checked()` as signer

### DIFF
--- a/loader-v3-interface/src/instruction.rs
+++ b/loader-v3-interface/src/instruction.rs
@@ -501,7 +501,7 @@ pub fn extend_program_checked(
     let mut metas = vec![
         AccountMeta::new(program_data_address, false),
         AccountMeta::new(*program_address, false),
-        AccountMeta::new(*authority_address, false),
+        AccountMeta::new(*authority_address, true),
     ];
     if let Some(payer_address) = payer_address {
         metas.push(AccountMeta::new_readonly(


### PR DESCRIPTION
Ironically #155 missed the vital part: The authority being a signer.