### PR TITLE
[bls] Add `serde`, `bytemuck` and `frozen-abi` features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2785,6 +2785,7 @@ dependencies = [
 name = "solana-bls"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "bincode",
  "blst",
  "blstrs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,6 +2789,7 @@ dependencies = [
  "blst",
  "blstrs",
  "bytemuck",
+ "cfg_eval",
  "ff",
  "group",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2794,6 +2794,8 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_with",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
  "solana-keypair",
  "solana-signature",
  "solana-signer",

--- a/bls/Cargo.toml
+++ b/bls/Cargo.toml
@@ -11,8 +11,8 @@ edition = { workspace = true }
 
 [dependencies]
 bytemuck = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
-serde_with = { workspace = true, features = ["macros"] }
+serde = { workspace = true, features = ["derive"], optional = true }
+serde_with = { workspace = true, features = ["macros"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 blst = { workspace = true }
@@ -30,6 +30,7 @@ bincode = { workspace = true }
 solana-keypair = { workspace = true }
 
 [features]
+serde = ["dep:serde", "dep:serde_with"]
 solana-signer-derive = [
     "dep:solana-signer",
     "dep:solana-signature",

--- a/bls/Cargo.toml
+++ b/bls/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+base64 = { workspace = true }
 bytemuck = { workspace = true, optional = true }
 cfg_eval = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }

--- a/bls/Cargo.toml
+++ b/bls/Cargo.toml
@@ -11,6 +11,7 @@ edition = { workspace = true }
 
 [dependencies]
 bytemuck = { workspace = true, optional = true }
+cfg_eval = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 serde_with = { workspace = true, features = ["macros"], optional = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
@@ -38,7 +39,7 @@ solana-keypair = { workspace = true }
 [features]
 bytemuck = ["dep:bytemuck"]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
-serde = ["dep:serde", "dep:serde_with"]
+serde = ["dep:cfg_eval", "dep:serde", "dep:serde_with"]
 solana-signer-derive = [
     "dep:solana-signer",
     "dep:solana-signature",

--- a/bls/Cargo.toml
+++ b/bls/Cargo.toml
@@ -13,6 +13,12 @@ edition = { workspace = true }
 bytemuck = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 serde_with = { workspace = true, features = ["macros"], optional = true }
+solana-frozen-abi = { workspace = true, optional = true, features = [
+    "frozen-abi",
+] }
+solana-frozen-abi-macro = { workspace = true, optional = true, features = [
+    "frozen-abi",
+] }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 blst = { workspace = true }
@@ -31,6 +37,7 @@ solana-keypair = { workspace = true }
 
 [features]
 bytemuck = ["dep:bytemuck"]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 serde = ["dep:serde", "dep:serde_with"]
 solana-signer-derive = [
     "dep:solana-signer",

--- a/bls/Cargo.toml
+++ b/bls/Cargo.toml
@@ -21,6 +21,7 @@ solana-frozen-abi = { workspace = true, optional = true, features = [
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
+thiserror = { workspace = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 blst = { workspace = true }
@@ -31,7 +32,6 @@ rand = { workspace = true }
 solana-signature = { workspace = true, optional = true }
 solana-signer = { workspace = true, optional = true }
 subtle = { workspace = true, optional = true }
-thiserror = { workspace = true }
 
 [dev-dependencies]
 bincode = { workspace = true }

--- a/bls/Cargo.toml
+++ b/bls/Cargo.toml
@@ -10,7 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-bytemuck = { workspace = true }
+bytemuck = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 serde_with = { workspace = true, features = ["macros"], optional = true }
 
@@ -30,6 +30,7 @@ bincode = { workspace = true }
 solana-keypair = { workspace = true }
 
 [features]
+bytemuck = ["dep:bytemuck"]
 serde = ["dep:serde", "dep:serde_with"]
 solana-signer-derive = [
     "dep:solana-signer",

--- a/bls/src/error.rs
+++ b/bls/src/error.rs
@@ -10,4 +10,6 @@ pub enum BlsError {
     KeyDerivation,
     #[error("Point representation conversion failed")]
     PointConversion, // TODO: could be more specific here
+    #[error("Failed to parse from string")]
+    ParseFromString, // TODO: update after more precise error handling
 }

--- a/bls/src/lib.rs
+++ b/bls/src/lib.rs
@@ -22,7 +22,6 @@ use {
 // TODO: add conversion between compressed and uncompressed representation of
 // signatures, pubkeys, and proof of possessions
 
-#[cfg(not(target_os = "solana"))]
 pub mod error;
 #[cfg(not(target_os = "solana"))]
 pub mod keypair;

--- a/bls/src/lib.rs
+++ b/bls/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
+
 pub use crate::pod::{
     ProofOfPossession, ProofOfPossessionCompressed, Pubkey, PubkeyCompressed, Signature,
     SignatureCompressed, BLS_PROOF_OF_POSSESSION_AFFINE_SIZE,

--- a/bls/src/pod.rs
+++ b/bls/src/pod.rs
@@ -13,8 +13,14 @@ use {
 /// Size of a BLS signature in a compressed point representation
 pub const BLS_SIGNATURE_COMPRESSED_SIZE: usize = 96;
 
+/// Size of a BLS signature in a compressed point representation in base64
+pub const BLS_SIGNATURE_COMPRESSED_BASE64_SIZE: usize = 128;
+
 /// Size of a BLS signature in an affine point representation
 pub const BLS_SIGNATURE_AFFINE_SIZE: usize = 192;
+
+/// Size of a BLS signature in an affine point representation in base64
+pub const BLS_SIGNATURE_AFFINE_BASE64_SIZE: usize = 256;
 
 /// A serialized BLS signature in a compressed point representation
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
@@ -42,7 +48,7 @@ impl fmt::Display for SignatureCompressed {
 impl_from_str!(
     TYPE = SignatureCompressed,
     BYTES_LEN = BLS_SIGNATURE_COMPRESSED_SIZE,
-    BASE64_LEN = 128
+    BASE64_LEN = BLS_SIGNATURE_COMPRESSED_BASE64_SIZE
 );
 
 /// A serialized BLS signature in an affine point representation
@@ -71,14 +77,20 @@ impl fmt::Display for Signature {
 impl_from_str!(
     TYPE = Signature,
     BYTES_LEN = BLS_SIGNATURE_AFFINE_SIZE,
-    BASE64_LEN = 256
+    BASE64_LEN = BLS_SIGNATURE_AFFINE_BASE64_SIZE
 );
 
 /// Size of a BLS proof of possession in a compressed point representation
 pub const BLS_PROOF_OF_POSSESSION_COMPRESSED_SIZE: usize = 96;
 
+/// Size of a BLS proof of possession in a compressed point representation in base64
+pub const BLS_PROOF_OF_POSSESSION_COMPRESSED_BASE64_SIZE: usize = 128;
+
 /// Size of a BLS proof of possession in an affine point representation
 pub const BLS_PROOF_OF_POSSESSION_AFFINE_SIZE: usize = 192;
+
+/// Size of a BLS proof of possession in an affine point representation in base64
+pub const BLS_PROOF_OF_POSSESSKON_AFFINE_BASE64_SIZE: usize = 256;
 
 /// A serialized BLS signature in a compressed point representation
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
@@ -109,7 +121,7 @@ impl fmt::Display for ProofOfPossessionCompressed {
 impl_from_str!(
     TYPE = ProofOfPossessionCompressed,
     BYTES_LEN = BLS_PROOF_OF_POSSESSION_COMPRESSED_SIZE,
-    BASE64_LEN = 128
+    BASE64_LEN = BLS_PROOF_OF_POSSESSION_COMPRESSED_BASE64_SIZE
 );
 
 /// A serialized BLS signature in an affine point representation
@@ -141,14 +153,20 @@ impl fmt::Display for ProofOfPossession {
 impl_from_str!(
     TYPE = ProofOfPossession,
     BYTES_LEN = BLS_PROOF_OF_POSSESSION_AFFINE_SIZE,
-    BASE64_LEN = 256
+    BASE64_LEN = BLS_PROOF_OF_POSSESSKON_AFFINE_BASE64_SIZE
 );
 
 /// Size of a BLS public key in a compressed point representation
 pub const BLS_PUBLIC_KEY_COMPRESSED_SIZE: usize = 48;
 
+/// Size of a BLS public key in a compressed point representation in base64
+pub const BLS_PUBLIC_KEY_COMPRESSED_BASE64_SIZE: usize = 128;
+
 /// Size of a BLS public key in an affine point representation
 pub const BLS_PUBLIC_KEY_AFFINE_SIZE: usize = 96;
+
+/// Size of a BLS public key in an affine point representation in base64
+pub const BLS_PUBLIC_KEY_AFFINE_BASE64_SIZE: usize = 256;
 
 /// A serialized BLS public key in a compressed point representation
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
@@ -179,7 +197,7 @@ impl fmt::Display for PubkeyCompressed {
 impl_from_str!(
     TYPE = PubkeyCompressed,
     BYTES_LEN = BLS_PUBLIC_KEY_COMPRESSED_SIZE,
-    BASE64_LEN = 64
+    BASE64_LEN = BLS_PUBLIC_KEY_COMPRESSED_BASE64_SIZE
 );
 
 /// A serialized BLS public key in an affine point representation
@@ -208,7 +226,7 @@ impl fmt::Display for Pubkey {
 impl_from_str!(
     TYPE = Pubkey,
     BYTES_LEN = BLS_PUBLIC_KEY_AFFINE_SIZE,
-    BASE64_LEN = 128
+    BASE64_LEN = BLS_PUBLIC_KEY_AFFINE_BASE64_SIZE
 );
 
 // Byte arrays are both `Pod` and `Zeraoble`, but the traits `bytemuck::Pod` and

--- a/bls/src/pod.rs
+++ b/bls/src/pod.rs
@@ -14,7 +14,8 @@ pub const BLS_SIGNATURE_AFFINE_SIZE: usize = 192;
 
 /// A serialized BLS signature in a compressed point representation
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
-#[cfg_attr(feature = "serde", serde_as, derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_as)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct SignatureCompressed(
@@ -30,7 +31,8 @@ impl Default for SignatureCompressed {
 
 /// A serialized BLS signature in an affine point representation
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
-#[cfg_attr(feature = "serde", serde_as, derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_as)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct Signature(
@@ -52,7 +54,8 @@ pub const BLS_PROOF_OF_POSSESSION_AFFINE_SIZE: usize = 192;
 
 /// A serialized BLS signature in a compressed point representation
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
-#[cfg_attr(feature = "serde", serde_as, derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_as)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct ProofOfPossessionCompressed(
@@ -71,7 +74,8 @@ impl Default for ProofOfPossessionCompressed {
 
 /// A serialized BLS signature in an affine point representation
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
-#[cfg_attr(feature = "serde", serde_as, derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_as)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct ProofOfPossession(
@@ -96,7 +100,8 @@ pub const BLS_PUBLIC_KEY_AFFINE_SIZE: usize = 96;
 
 /// A serialized BLS public key in a compressed point representation
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
-#[cfg_attr(feature = "serde", serde_as, derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_as)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[repr(transparent)]
 pub struct PubkeyCompressed(
@@ -115,7 +120,8 @@ impl Default for PubkeyCompressed {
 
 /// A serialized BLS public key in an affine point representation
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
-#[cfg_attr(feature = "serde", serde_as, derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_as)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(transparent)]
 pub struct Pubkey(

--- a/bls/src/pod.rs
+++ b/bls/src/pod.rs
@@ -1,5 +1,5 @@
+#[cfg(feature = "bytemuck")]
 use bytemuck::{Pod, PodInOption, Zeroable, ZeroableInOption};
-
 #[cfg(feature = "serde")]
 use {
     serde::{Deserialize, Serialize},
@@ -127,35 +127,39 @@ impl Default for Pubkey {
 // `bytemuck::Zeroable` can only be derived for power-of-two length byte arrays.
 // Directly implement these traits for types that are simple wrappers around
 // byte arrays.
-unsafe impl Zeroable for PubkeyCompressed {}
-unsafe impl Pod for PubkeyCompressed {}
-unsafe impl ZeroableInOption for PubkeyCompressed {}
-unsafe impl PodInOption for PubkeyCompressed {}
+#[cfg(feature = "bytemuck")]
+mod bytemuck_impls {
+    use super::*;
+    unsafe impl Zeroable for PubkeyCompressed {}
+    unsafe impl Pod for PubkeyCompressed {}
+    unsafe impl ZeroableInOption for PubkeyCompressed {}
+    unsafe impl PodInOption for PubkeyCompressed {}
 
-unsafe impl Zeroable for Pubkey {}
-unsafe impl Pod for Pubkey {}
-unsafe impl ZeroableInOption for Pubkey {}
-unsafe impl PodInOption for Pubkey {}
+    unsafe impl Zeroable for Pubkey {}
+    unsafe impl Pod for Pubkey {}
+    unsafe impl ZeroableInOption for Pubkey {}
+    unsafe impl PodInOption for Pubkey {}
 
-unsafe impl Zeroable for Signature {}
-unsafe impl Pod for Signature {}
-unsafe impl ZeroableInOption for Signature {}
-unsafe impl PodInOption for Signature {}
+    unsafe impl Zeroable for Signature {}
+    unsafe impl Pod for Signature {}
+    unsafe impl ZeroableInOption for Signature {}
+    unsafe impl PodInOption for Signature {}
 
-unsafe impl Zeroable for SignatureCompressed {}
-unsafe impl Pod for SignatureCompressed {}
-unsafe impl ZeroableInOption for SignatureCompressed {}
-unsafe impl PodInOption for SignatureCompressed {}
+    unsafe impl Zeroable for SignatureCompressed {}
+    unsafe impl Pod for SignatureCompressed {}
+    unsafe impl ZeroableInOption for SignatureCompressed {}
+    unsafe impl PodInOption for SignatureCompressed {}
 
-unsafe impl Zeroable for ProofOfPossessionCompressed {}
-unsafe impl Pod for ProofOfPossessionCompressed {}
-unsafe impl ZeroableInOption for ProofOfPossessionCompressed {}
-unsafe impl PodInOption for ProofOfPossessionCompressed {}
+    unsafe impl Zeroable for ProofOfPossessionCompressed {}
+    unsafe impl Pod for ProofOfPossessionCompressed {}
+    unsafe impl ZeroableInOption for ProofOfPossessionCompressed {}
+    unsafe impl PodInOption for ProofOfPossessionCompressed {}
 
-unsafe impl Zeroable for ProofOfPossession {}
-unsafe impl Pod for ProofOfPossession {}
-unsafe impl ZeroableInOption for ProofOfPossession {}
-unsafe impl PodInOption for ProofOfPossession {}
+    unsafe impl Zeroable for ProofOfPossession {}
+    unsafe impl Pod for ProofOfPossession {}
+    unsafe impl ZeroableInOption for ProofOfPossession {}
+    unsafe impl PodInOption for ProofOfPossession {}
+}
 
 #[cfg(test)]
 mod tests {

--- a/bls/src/pod.rs
+++ b/bls/src/pod.rs
@@ -16,7 +16,7 @@ pub const BLS_SIGNATURE_AFFINE_SIZE: usize = 192;
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_as)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(transparent)]
 pub struct SignatureCompressed(
     #[cfg_attr(feature = "serde", serde_as(as = "[_; BLS_SIGNATURE_COMPRESSED_SIZE]"))]
@@ -33,7 +33,7 @@ impl Default for SignatureCompressed {
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_as)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(transparent)]
 pub struct Signature(
     #[cfg_attr(feature = "serde", serde_as(as = "[_; BLS_SIGNATURE_AFFINE_SIZE]"))]
@@ -56,7 +56,7 @@ pub const BLS_PROOF_OF_POSSESSION_AFFINE_SIZE: usize = 192;
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_as)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(transparent)]
 pub struct ProofOfPossessionCompressed(
     #[cfg_attr(
@@ -76,7 +76,7 @@ impl Default for ProofOfPossessionCompressed {
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_as)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(transparent)]
 pub struct ProofOfPossession(
     #[cfg_attr(

--- a/bls/src/pod.rs
+++ b/bls/src/pod.rs
@@ -13,6 +13,7 @@ pub const BLS_SIGNATURE_COMPRESSED_SIZE: usize = 96;
 pub const BLS_SIGNATURE_AFFINE_SIZE: usize = 192;
 
 /// A serialized BLS signature in a compressed point representation
+#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[cfg_attr(feature = "serde", serde_as, derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(transparent)]
@@ -28,6 +29,7 @@ impl Default for SignatureCompressed {
 }
 
 /// A serialized BLS signature in an affine point representation
+#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[cfg_attr(feature = "serde", serde_as, derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(transparent)]
@@ -49,6 +51,7 @@ pub const BLS_PROOF_OF_POSSESSION_COMPRESSED_SIZE: usize = 96;
 pub const BLS_PROOF_OF_POSSESSION_AFFINE_SIZE: usize = 192;
 
 /// A serialized BLS signature in a compressed point representation
+#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[cfg_attr(feature = "serde", serde_as, derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(transparent)]
@@ -67,6 +70,7 @@ impl Default for ProofOfPossessionCompressed {
 }
 
 /// A serialized BLS signature in an affine point representation
+#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[cfg_attr(feature = "serde", serde_as, derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(transparent)]
@@ -91,6 +95,7 @@ pub const BLS_PUBLIC_KEY_COMPRESSED_SIZE: usize = 48;
 pub const BLS_PUBLIC_KEY_AFFINE_SIZE: usize = 96;
 
 /// A serialized BLS public key in a compressed point representation
+#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[cfg_attr(feature = "serde", serde_as, derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[repr(transparent)]
@@ -109,6 +114,7 @@ impl Default for PubkeyCompressed {
 }
 
 /// A serialized BLS public key in an affine point representation
+#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[cfg_attr(feature = "serde", serde_as, derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(transparent)]

--- a/bls/src/pod.rs
+++ b/bls/src/pod.rs
@@ -82,7 +82,7 @@ pub const BLS_PUBLIC_KEY_AFFINE_SIZE: usize = 96;
 
 /// A serialized BLS public key in a compressed point representation
 #[serde_as]
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 #[repr(transparent)]
 pub struct PubkeyCompressed(
     #[serde_as(as = "[_; BLS_PUBLIC_KEY_COMPRESSED_SIZE]")] pub [u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
@@ -96,7 +96,7 @@ impl Default for PubkeyCompressed {
 
 /// A serialized BLS public key in an affine point representation
 #[serde_as]
-#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 #[repr(transparent)]
 pub struct Pubkey(
     #[serde_as(as = "[_; BLS_PUBLIC_KEY_AFFINE_SIZE]")] pub [u8; BLS_PUBLIC_KEY_AFFINE_SIZE],

--- a/bls/src/pod.rs
+++ b/bls/src/pod.rs
@@ -1,5 +1,7 @@
+use bytemuck::{Pod, PodInOption, Zeroable, ZeroableInOption};
+
+#[cfg(feature = "serde")]
 use {
-    bytemuck::{Pod, PodInOption, Zeroable, ZeroableInOption},
     serde::{Deserialize, Serialize},
     serde_with::serde_as,
 };
@@ -11,11 +13,12 @@ pub const BLS_SIGNATURE_COMPRESSED_SIZE: usize = 96;
 pub const BLS_SIGNATURE_AFFINE_SIZE: usize = 192;
 
 /// A serialized BLS signature in a compressed point representation
-#[serde_with::serde_as]
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "serde", serde_as, derive(Deserialize, Serialize))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct SignatureCompressed(
-    #[serde_as(as = "[_; BLS_SIGNATURE_COMPRESSED_SIZE]")] pub [u8; BLS_SIGNATURE_COMPRESSED_SIZE],
+    #[cfg_attr(feature = "serde", serde_as(as = "[_; BLS_SIGNATURE_COMPRESSED_SIZE]"))]
+    pub  [u8; BLS_SIGNATURE_COMPRESSED_SIZE],
 );
 
 impl Default for SignatureCompressed {
@@ -25,11 +28,12 @@ impl Default for SignatureCompressed {
 }
 
 /// A serialized BLS signature in an affine point representation
-#[serde_with::serde_as]
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "serde", serde_as, derive(Deserialize, Serialize))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct Signature(
-    #[serde_as(as = "[_; BLS_SIGNATURE_AFFINE_SIZE]")] pub [u8; BLS_SIGNATURE_AFFINE_SIZE],
+    #[cfg_attr(feature = "serde", serde_as(as = "[_; BLS_SIGNATURE_AFFINE_SIZE]"))]
+    pub  [u8; BLS_SIGNATURE_AFFINE_SIZE],
 );
 
 impl Default for Signature {
@@ -45,12 +49,15 @@ pub const BLS_PROOF_OF_POSSESSION_COMPRESSED_SIZE: usize = 96;
 pub const BLS_PROOF_OF_POSSESSION_AFFINE_SIZE: usize = 192;
 
 /// A serialized BLS signature in a compressed point representation
-#[serde_as]
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "serde", serde_as, derive(Deserialize, Serialize))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct ProofOfPossessionCompressed(
-    #[serde_as(as = "[_; BLS_PROOF_OF_POSSESSION_COMPRESSED_SIZE]")]
-    pub  [u8; BLS_PROOF_OF_POSSESSION_COMPRESSED_SIZE],
+    #[cfg_attr(
+        feature = "serde",
+        serde_as(as = "[_; BLS_PROOF_OF_POSSESSION_COMPRESSED_SIZE]")
+    )]
+    pub [u8; BLS_PROOF_OF_POSSESSION_COMPRESSED_SIZE],
 );
 
 impl Default for ProofOfPossessionCompressed {
@@ -60,12 +67,15 @@ impl Default for ProofOfPossessionCompressed {
 }
 
 /// A serialized BLS signature in an affine point representation
-#[serde_as]
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "serde", serde_as, derive(Deserialize, Serialize))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct ProofOfPossession(
-    #[serde_as(as = "[_; BLS_PROOF_OF_POSSESSION_AFFINE_SIZE]")]
-    pub  [u8; BLS_PROOF_OF_POSSESSION_AFFINE_SIZE],
+    #[cfg_attr(
+        feature = "serde",
+        serde_as(as = "[_; BLS_PROOF_OF_POSSESSION_AFFINE_SIZE]")
+    )]
+    pub [u8; BLS_PROOF_OF_POSSESSION_AFFINE_SIZE],
 );
 
 impl Default for ProofOfPossession {
@@ -81,11 +91,15 @@ pub const BLS_PUBLIC_KEY_COMPRESSED_SIZE: usize = 48;
 pub const BLS_PUBLIC_KEY_AFFINE_SIZE: usize = 96;
 
 /// A serialized BLS public key in a compressed point representation
-#[serde_as]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[cfg_attr(feature = "serde", serde_as, derive(Deserialize, Serialize))]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[repr(transparent)]
 pub struct PubkeyCompressed(
-    #[serde_as(as = "[_; BLS_PUBLIC_KEY_COMPRESSED_SIZE]")] pub [u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
+    #[cfg_attr(
+        feature = "serde",
+        serde_as(as = "[_; BLS_PUBLIC_KEY_COMPRESSED_SIZE]")
+    )]
+    pub [u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
 );
 
 impl Default for PubkeyCompressed {
@@ -95,11 +109,12 @@ impl Default for PubkeyCompressed {
 }
 
 /// A serialized BLS public key in an affine point representation
-#[serde_as]
-#[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[cfg_attr(feature = "serde", serde_as, derive(Deserialize, Serialize))]
+#[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(transparent)]
 pub struct Pubkey(
-    #[serde_as(as = "[_; BLS_PUBLIC_KEY_AFFINE_SIZE]")] pub [u8; BLS_PUBLIC_KEY_AFFINE_SIZE],
+    #[cfg_attr(feature = "serde", serde_as(as = "[_; BLS_PUBLIC_KEY_AFFINE_SIZE]"))]
+    pub  [u8; BLS_PUBLIC_KEY_AFFINE_SIZE],
 );
 
 impl Default for Pubkey {
@@ -144,8 +159,10 @@ unsafe impl PodInOption for ProofOfPossession {}
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "serde")]
     use super::*;
 
+    #[cfg(feature = "serde")]
     #[test]
     fn serialize_and_deserialize_pubkey() {
         let original = Pubkey::default();
@@ -159,6 +176,7 @@ mod tests {
         assert_eq!(original, deserialized);
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn serialize_and_deserialize_pubkey_compressed() {
         let original = PubkeyCompressed::default();
@@ -172,6 +190,7 @@ mod tests {
         assert_eq!(original, deserialized);
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn serialize_and_deserialize_signature() {
         let original = Signature::default();
@@ -185,6 +204,7 @@ mod tests {
         assert_eq!(original, deserialized);
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn serialize_and_deserialize_signature_compressed() {
         let original = SignatureCompressed::default();
@@ -198,6 +218,7 @@ mod tests {
         assert_eq!(original, deserialized);
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn serialize_and_deserialize_proof_of_possession() {
         let original = ProofOfPossession::default();
@@ -211,6 +232,7 @@ mod tests {
         assert_eq!(original, deserialized);
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn serialize_and_deserialize_proof_of_possession_compressed() {
         let original = ProofOfPossessionCompressed::default();


### PR DESCRIPTION
Just reorganizing some trait implementations for BLS pod types
- Derived `Ord` and `PartialOrd` for all the pod types
- Created serde feature and made the serde serialization/deserialization optional
- Created bytemuck feature and made the bytemuck implementation optional
- Created `frozen-abi` feature and implemented the `AbiExample` traits for the bls pod types
- Implemented `Display` and `FromStr` for bls pod types