### PR TITLE
mark net::DEFAULT_TPU_COALESCE deprecated

### DIFF
--- a/sdk/src/net.rs
+++ b/sdk/src/net.rs
@@ -1,3 +1,4 @@
 use std::time::Duration;
 
+#[deprecated(since = "2.2.3", note = "This symbol is now private interface.")]
 pub const DEFAULT_TPU_COALESCE: Duration = Duration::from_millis(5);


### PR DESCRIPTION
this never should have been public interface in the first place