### PR TITLE
instructions-sysvar: refactor #162 to be non-breaking

### DIFF
--- a/program/src/sysvar.rs
+++ b/program/src/sysvar.rs
@@ -24,6 +24,7 @@ pub mod instructions {
     #[deprecated(since = "2.2.0", note = "Use solana-instructions-sysvar crate instead")]
     pub use solana_instructions_sysvar::{deserialize_instruction, load_instruction_at};
     #[deprecated(since = "2.2.0", note = "Use solana-instructions-sysvar crate instead")]
+    #[allow(deprecated)]
     pub use solana_instructions_sysvar::{
         get_instruction_relative, load_current_index_checked, load_instruction_at_checked,
         store_current_index, Instructions,


### PR DESCRIPTION
Whoopsie, changes #162 to be non-breaking so we can just cut a patch version. We can still make Agave use the new, non-deprecated method.