### PR TITLE
retire updated hashes consts

### DIFF
--- a/clock/src/lib.rs
+++ b/clock/src/lib.rs
@@ -44,45 +44,49 @@ pub const MS_PER_TICK: u64 = 1000 / DEFAULT_TICKS_PER_SECOND;
 // every 400 ms. A fast voting cadence ensures faster finality and convergence
 pub const DEFAULT_TICKS_PER_SLOT: u64 = 64;
 
-// GCP n1-standard hardware and also a xeon e5-2520 v4 are about this rate of hashes/s
-pub const DEFAULT_HASHES_PER_SECOND: u64 = 2_000_000;
+pub const DEFAULT_HASHES_PER_SECOND: u64 = 10_000_000;
 
 // Empirical sampling of mainnet validator hash rate showed the following stake
 // percentages can exceed the designated hash rates as of July 2023:
 // 97.6%
+#[deprecated(since = "2.2.2", note = "Use 'DEFAULT_HASHES_PER_SECOND' instead")]
 pub const UPDATED_HASHES_PER_SECOND_2: u64 = 2_800_000;
 // 96.2%
+#[deprecated(since = "2.2.2", note = "Use 'DEFAULT_HASHES_PER_SECOND' instead")]
 pub const UPDATED_HASHES_PER_SECOND_3: u64 = 4_400_000;
 // 96.2%
+#[deprecated(since = "2.2.2", note = "Use 'DEFAULT_HASHES_PER_SECOND' instead")]
 pub const UPDATED_HASHES_PER_SECOND_4: u64 = 7_600_000;
 // 96.2%
+#[deprecated(since = "2.2.2", note = "Use 'DEFAULT_HASHES_PER_SECOND' instead")]
 pub const UPDATED_HASHES_PER_SECOND_5: u64 = 9_200_000;
 // 96.2%
+#[deprecated(since = "2.2.2", note = "Use 'DEFAULT_HASHES_PER_SECOND' instead")]
 pub const UPDATED_HASHES_PER_SECOND_6: u64 = 10_000_000;
 
 #[cfg(test)]
-static_assertions::const_assert_eq!(DEFAULT_HASHES_PER_TICK, 12_500);
+static_assertions::const_assert_eq!(DEFAULT_HASHES_PER_TICK, 62_500);
 pub const DEFAULT_HASHES_PER_TICK: u64 = DEFAULT_HASHES_PER_SECOND / DEFAULT_TICKS_PER_SECOND;
 
 #[cfg(test)]
-static_assertions::const_assert_eq!(UPDATED_HASHES_PER_TICK2, 17_500);
-pub const UPDATED_HASHES_PER_TICK2: u64 = UPDATED_HASHES_PER_SECOND_2 / DEFAULT_TICKS_PER_SECOND;
+#[deprecated(since = "2.2.2", note = "Use 'DEFAULT_HASHES_PER_TICK' instead")]
+pub const UPDATED_HASHES_PER_TICK2: u64 = DEFAULT_HASHES_PER_SECOND / DEFAULT_TICKS_PER_SECOND;
 
 #[cfg(test)]
-static_assertions::const_assert_eq!(UPDATED_HASHES_PER_TICK3, 27_500);
-pub const UPDATED_HASHES_PER_TICK3: u64 = UPDATED_HASHES_PER_SECOND_3 / DEFAULT_TICKS_PER_SECOND;
+#[deprecated(since = "2.2.2", note = "Use 'DEFAULT_HASHES_PER_TICK' instead")]
+pub const UPDATED_HASHES_PER_TICK3: u64 = DEFAULT_HASHES_PER_SECOND / DEFAULT_TICKS_PER_SECOND;
 
 #[cfg(test)]
-static_assertions::const_assert_eq!(UPDATED_HASHES_PER_TICK4, 47_500);
-pub const UPDATED_HASHES_PER_TICK4: u64 = UPDATED_HASHES_PER_SECOND_4 / DEFAULT_TICKS_PER_SECOND;
+#[deprecated(since = "2.2.2", note = "Use 'DEFAULT_HASHES_PER_TICK' instead")]
+pub const UPDATED_HASHES_PER_TICK4: u64 = DEFAULT_HASHES_PER_SECOND / DEFAULT_TICKS_PER_SECOND;
 
 #[cfg(test)]
-static_assertions::const_assert_eq!(UPDATED_HASHES_PER_TICK5, 57_500);
-pub const UPDATED_HASHES_PER_TICK5: u64 = UPDATED_HASHES_PER_SECOND_5 / DEFAULT_TICKS_PER_SECOND;
+#[deprecated(since = "2.2.2", note = "Use 'DEFAULT_HASHES_PER_TICK' instead")]
+pub const UPDATED_HASHES_PER_TICK5: u64 = DEFAULT_HASHES_PER_SECOND / DEFAULT_TICKS_PER_SECOND;
 
 #[cfg(test)]
-static_assertions::const_assert_eq!(UPDATED_HASHES_PER_TICK6, 62_500);
-pub const UPDATED_HASHES_PER_TICK6: u64 = UPDATED_HASHES_PER_SECOND_6 / DEFAULT_TICKS_PER_SECOND;
+#[deprecated(since = "2.2.2", note = "Use 'DEFAULT_HASHES_PER_TICK' instead")]
+pub const UPDATED_HASHES_PER_TICK6: u64 = DEFAULT_HASHES_PER_SECOND / DEFAULT_TICKS_PER_SECOND;
 
 // 1 Dev Epoch = 400 ms * 8192 ~= 55 minutes
 pub const DEFAULT_DEV_SLOTS_PER_EPOCH: u64 = 8192;


### PR DESCRIPTION
Mainnet activated the feature to use the `UPDATED_HASHES_PER_SECOND_6` and `UPDATED_HASHES_PER_TICK6` values to control hashing a long time ago. We're past due to deprecate these old values and make the `DEFAULT*` values match the ones we actually use in mainnet/testnet/etc.