### PR TITLE
Deprecates `AccountInfo::realloc()`

### DIFF
--- a/account-info/src/lib.rs
+++ b/account-info/src/lib.rs
@@ -136,11 +136,8 @@ impl<'a> AccountInfo<'a> {
     /// Note:  Account data can be increased within a single call by up to
     /// `solana_program::entrypoint::MAX_PERMITTED_DATA_INCREASE` bytes.
     ///
-    /// Note: Memory used to grow is already zero-initialized upon program
-    /// entrypoint and re-zeroing it wastes compute units.  If within the same
-    /// call a program reallocs from larger to smaller and back to larger again
-    /// the new space could contain stale data.  Pass `true` for `zero_init` in
-    /// this case, otherwise compute units will be wasted re-zero-initializing.
+    /// Note: `zero_init` being `false` will no longer be supported by the
+    /// program runtime.
     ///
     /// # Safety
     ///
@@ -148,6 +145,7 @@ impl<'a> AccountInfo<'a> {
     /// referenced by `AccountInfo` fields. It should only be called for
     /// instances of `AccountInfo` that were created by the runtime and received
     /// in the `process_instruction` entrypoint of a program.
+    #[deprecated(since = "2.3.0", note = "Use AccountInfo::resize() instead")]
     pub fn realloc(&self, new_len: usize, zero_init: bool) -> Result<(), ProgramError> {
         let mut data = self.try_borrow_mut_data()?;
         let old_len = data.len();
@@ -183,6 +181,22 @@ impl<'a> AccountInfo<'a> {
         }
 
         Ok(())
+    }
+
+    /// Resize the account's data: Either truncating or zero extending.
+    ///
+    /// Note:  Account data can be increased within a single call by up to
+    /// `solana_program::entrypoint::MAX_PERMITTED_DATA_INCREASE` bytes.
+    ///
+    /// # Safety
+    ///
+    /// This method makes assumptions about the layout and location of memory
+    /// referenced by `AccountInfo` fields. It should only be called for
+    /// instances of `AccountInfo` that were created by the runtime and received
+    /// in the `process_instruction` entrypoint of a program.
+    pub fn resize(&self, new_len: usize) -> Result<(), ProgramError> {
+        #[allow(deprecated)]
+        self.realloc(new_len, true)
     }
 
     #[allow(invalid_reference_casting)]


### PR DESCRIPTION
Only a minuscule amount of transactions grows accounts. Zeroing out 10 KiB for every instruction account in every instruction (including CPI) of every transaction just in case is quite wasteful. It would make more sense to only do this on demand and have programs pay for what they use.

This change makes sure that programs always call `sol_memset()` to communicate to the program runtime that they wish to grow an account and access the new space even before the next CPI or the end of the current instruction.