### PR TITLE
deps: Run cargo-sort on the whole workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,3 @@
-[profile.release]
-split-debuginfo = "unpacked"
-lto = "thin"
-
-# Enable basic optimizations for unittests
-[profile.test]
-opt-level = 1
-
-# Enable optimizations for procmacros for faster recompile
-[profile.dev.build-override]
-opt-level = 1
-
 [workspace]
 members = [
     "account",
@@ -232,7 +220,6 @@ solana-decode-error = { path = "decode-error", version = "2.2.1" }
 solana-define-syscall = { path = "define-syscall", version = "2.2.1" }
 solana-derivation-path = { path = "derivation-path", version = "2.2.1" }
 solana-ed25519-program = { path = "ed25519-program", version = "2.2.1" }
-solana-program-entrypoint = { path = "program-entrypoint", version = "2.2.1" }
 solana-epoch-info = { path = "epoch-info", version = "2.2.1" }
 solana-epoch-rewards = { path = "epoch-rewards", version = "2.2.1" }
 solana-epoch-rewards-hasher = { path = "epoch-rewards-hasher", version = "2.2.1" }
@@ -243,9 +230,9 @@ solana-feature-set = { path = "feature-set", version = "2.2.1" }
 solana-feature-set-interface = { path = "feature-set-interface", version = "4.0.1" }
 solana-fee-calculator = { path = "fee-calculator", version = "2.2.1" }
 solana-fee-structure = { path = "fee-structure", version = "2.2.1" }
+solana-file-download = { path = "file-download", version = "2.2.1" }
 solana-frozen-abi = { path = "frozen-abi", version = "2.2.1" }
 solana-frozen-abi-macro = { path = "frozen-abi-macro", version = "2.2.1" }
-solana-file-download = { path = "file-download", version = "2.2.1" }
 solana-genesis-config = { path = "genesis-config", version = "2.2.1" }
 solana-hard-forks = { path = "hard-forks", version = "2.2.1", default-features = false }
 solana-hash = { path = "hash", version = "2.2.1", default-features = false }
@@ -273,6 +260,7 @@ solana-precompile-error = { path = "precompile-error", version = "2.2.1" }
 solana-precompiles = { path = "precompiles", version = "2.2.1" }
 solana-presigner = { path = "presigner", version = "2.2.1" }
 solana-program = { path = "program", version = "2.2.1", default-features = false }
+solana-program-entrypoint = { path = "program-entrypoint", version = "2.2.1" }
 solana-program-error = { path = "program-error", version = "2.2.1" }
 solana-program-memory = { path = "program-memory", version = "2.2.1" }
 solana-program-option = { path = "program-option", version = "2.2.1" }
@@ -285,6 +273,11 @@ solana-rent-debits = { path = "rent-debits", version = "2.2.1" }
 solana-reserved-account-keys = { path = "reserved-account-keys", version = "2.2.1", default-features = false }
 solana-reward-info = { path = "reward-info", version = "2.2.1" }
 solana-sanitize = { path = "sanitize", version = "2.2.1" }
+solana-sdk = { path = "sdk", version = "2.2.1" }
+solana-sdk-ids = { path = "sdk-ids", version = "2.2.1" }
+solana-sdk-macro = { path = "sdk-macro", version = "2.2.1" }
+solana-secp256k1-program = { path = "secp256k1-program", version = "2.2.1" }
+solana-secp256k1-recover = { path = "secp256k1-recover", version = "2.2.1" }
 solana-secp256r1-program = { path = "secp256r1-program", version = "2.2.1", default-features = false }
 solana-seed-derivable = { path = "seed-derivable", version = "2.2.1" }
 solana-seed-phrase = { path = "seed-phrase", version = "2.2.1" }
@@ -292,27 +285,22 @@ solana-serde = { path = "serde", version = "2.2.1" }
 solana-serde-varint = { path = "serde-varint", version = "2.2.1" }
 solana-serialize-utils = { path = "serialize-utils", version = "2.2.1" }
 solana-sha256-hasher = { path = "sha256-hasher", version = "2.2.1" }
+solana-short-vec = { path = "short-vec", version = "2.2.1" }
+solana-shred-version = { path = "shred-version", version = "2.2.1" }
 solana-signature = { path = "signature", version = "2.2.1", default-features = false }
 solana-signer = { path = "signer", version = "2.2.1" }
 solana-slot-hashes = { path = "slot-hashes", version = "2.2.1" }
 solana-slot-history = { path = "slot-history", version = "2.2.1" }
-solana-time-utils = { path = "time-utils", version = "2.2.1" }
-solana-sdk = { path = "sdk", version = "2.2.1" }
-solana-sdk-ids = { path = "sdk-ids", version = "2.2.1" }
-solana-sdk-macro = { path = "sdk-macro", version = "2.2.1" }
-solana-secp256k1-program = { path = "secp256k1-program", version = "2.2.1" }
-solana-secp256k1-recover = { path = "secp256k1-recover", version = "2.2.1" }
-solana-short-vec = { path = "short-vec", version = "2.2.1" }
-solana-shred-version = { path = "shred-version", version = "2.2.1" }
 solana-stable-layout = { path = "stable-layout", version = "2.2.1" }
 solana-stake-interface = { version = "1.2.1" }
 solana-system-interface = "1.0"
 solana-system-transaction = { path = "system-transaction", version = "2.2.1" }
 solana-sysvar = { path = "sysvar", version = "2.2.1" }
 solana-sysvar-id = { path = "sysvar-id", version = "2.2.1" }
+solana-time-utils = { path = "time-utils", version = "2.2.1" }
 solana-transaction = { path = "transaction", version = "2.2.1" }
-solana-transaction-error = { path = "transaction-error", version = "2.2.1" }
 solana-transaction-context = { version = "2.2.1" }
+solana-transaction-error = { path = "transaction-error", version = "2.2.1" }
 solana-validator-exit = { path = "validator-exit", version = "2.2.1" }
 solana-vote-interface = { path = "vote-interface", version = "2.2.1" }
 static_assertions = "1.1.0"
@@ -325,6 +313,18 @@ tiny-bip39 = "0.8.2"
 toml = "0.8.20"
 uriparse = "0.6.4"
 wasm-bindgen = "0.2.100"
+
+[profile.release]
+split-debuginfo = "unpacked"
+lto = "thin"
+
+# Enable basic optimizations for unittests
+[profile.test]
+opt-level = 1
+
+# Enable optimizations for procmacros for faster recompile
+[profile.dev.build-override]
+opt-level = 1
 
 [patch.crates-io]
 # We include the following crates as our dependencies above from crates.io:

--- a/account-info/Cargo.toml
+++ b/account-info/Cargo.toml
@@ -9,17 +9,17 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+bincode = ["dep:bincode", "dep:serde"]
+
 [dependencies]
 bincode = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 solana-program-error = { workspace = true }
 solana-program-memory = { workspace = true }
 solana-pubkey = { workspace = true, default-features = false }
-
-[features]
-bincode = ["dep:bincode", "dep:serde"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]

--- a/account/Cargo.toml
+++ b/account/Cargo.toml
@@ -9,24 +9,10 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[dependencies]
-bincode = { workspace = true, optional = true }
-qualifier_attr = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
-serde_bytes = { workspace = true, optional = true }
-serde_derive = { workspace = true, optional = true }
-solana-account-info = { workspace = true }
-solana-clock = { workspace = true }
-solana-frozen-abi = { workspace = true, optional = true }
-solana-frozen-abi-macro = { workspace = true, optional = true }
-solana-instruction = { workspace = true }
-solana-logger = { workspace = true, optional = true }
-solana-pubkey = { workspace = true }
-solana-sdk-ids = { workspace = true }
-solana-sysvar = { workspace = true, features = ["bincode"], optional = true }
-
-[dev-dependencies]
-solana-account = { path = ".", features = ["dev-context-only-utils"] }
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 bincode = [
@@ -49,7 +35,21 @@ serde = [
     "solana-pubkey/serde",
 ]
 
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
+[dependencies]
+bincode = { workspace = true, optional = true }
+qualifier_attr = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+serde_bytes = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
+solana-account-info = { workspace = true }
+solana-clock = { workspace = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
+solana-instruction = { workspace = true }
+solana-logger = { workspace = true, optional = true }
+solana-pubkey = { workspace = true }
+solana-sdk-ids = { workspace = true }
+solana-sysvar = { workspace = true, features = ["bincode"], optional = true }
+
+[dev-dependencies]
+solana-account = { path = ".", features = ["dev-context-only-utils"] }

--- a/address-lookup-table-interface/Cargo.toml
+++ b/address-lookup-table-interface/Cargo.toml
@@ -9,6 +9,23 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+bincode = [
+    "dep:bincode",
+    "dep:solana-instruction",
+    "serde",
+    "solana-instruction/bincode",
+]
+bytemuck = ["dep:bytemuck", "solana-pubkey/bytemuck"]
+dev-context-only-utils = ["bincode", "bytemuck"]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "serde"]
+serde = ["dep:serde", "dep:serde_derive", "solana-pubkey/serde"]
+
 [dependencies]
 bincode = { workspace = true, optional = true }
 bytemuck = { workspace = true, optional = true }
@@ -34,23 +51,6 @@ solana-address-lookup-table-interface = { path = ".", features = [
     "dev-context-only-utils",
 ] }
 solana-hash = { workspace = true }
-
-[features]
-bincode = [
-    "dep:bincode",
-    "dep:solana-instruction",
-    "serde",
-    "solana-instruction/bincode",
-]
-bytemuck = ["dep:bytemuck", "solana-pubkey/bytemuck"]
-dev-context-only-utils = ["bincode", "bytemuck"]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "serde"]
-serde = ["dep:serde", "dep:serde_derive", "solana-pubkey/serde"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
 
 [lints]
 workspace = true

--- a/atomic-u64/Cargo.toml
+++ b/atomic-u64/Cargo.toml
@@ -9,8 +9,8 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[target.'cfg(not(target_pointer_width = "64"))'.dependencies]
-parking_lot = { workspace = true }
-
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[target.'cfg(not(target_pointer_width = "64"))'.dependencies]
+parking_lot = { workspace = true }

--- a/big-mod-exp/Cargo.toml
+++ b/big-mod-exp/Cargo.toml
@@ -9,21 +9,21 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[target.'cfg(target_os = "solana")'.dependencies]
-solana-define-syscall = { workspace = true }
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 num-bigint = { workspace = true }
 num-traits = { workspace = true }
+
+[target.'cfg(target_os = "solana")'.dependencies]
+solana-define-syscall = { workspace = true }
 
 [dev-dependencies]
 array-bytes = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
 
 [lints]
 workspace = true

--- a/bincode/Cargo.toml
+++ b/bincode/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 bincode = { workspace = true }
 serde = { workspace = true }
@@ -18,9 +21,6 @@ solana-instruction = { workspace = true, default-features = false, features = [
 
 [dev-dependencies]
 solana-system-interface = { workspace = true, features = ["bincode"] }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
 
 [lints]
 workspace = true

--- a/blake3-hasher/Cargo.toml
+++ b/blake3-hasher/Cargo.toml
@@ -14,6 +14,14 @@ targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
+[features]
+borsh = ["dep:borsh", "std"]
+dev-context-only-utils = ["std"]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "std"]
+serde = ["dep:serde", "dep:serde_derive"]
+blake3 = ["dep:blake3"]
+std = ["solana-hash/std"]
+
 [dependencies]
 borsh = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
@@ -40,14 +48,6 @@ solana-define-syscall = { workspace = true }
 [dev-dependencies]
 bs58 = { workspace = true, features = ["std"] }
 solana-blake3-hasher = { path = ".", features = ["dev-context-only-utils"] }
-
-[features]
-borsh = ["dep:borsh", "std"]
-dev-context-only-utils = ["std"]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "std"]
-serde = ["dep:serde", "dep:serde_derive"]
-blake3 = ["dep:blake3"]
-std = ["solana-hash/std"]
 
 [lints]
 workspace = true

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -9,12 +9,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 borsh = { workspace = true }
 borsh0-10 = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
 
 [lints]
 workspace = true

--- a/client-traits/Cargo.toml
+++ b/client-traits/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 solana-account = { workspace = true }
 solana-commitment-config = { workspace = true }
@@ -23,6 +26,3 @@ solana-signer = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-transaction = { workspace = true, features = ["bincode"] }
 solana-transaction-error = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/clock/Cargo.toml
+++ b/clock/Cargo.toml
@@ -9,6 +9,15 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+serde = ["dep:serde", "dep:serde_derive"]
+sysvar = ["dep:solana-sdk-ids", "dep:solana-sysvar-id"]
+
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
@@ -19,12 +28,3 @@ solana-sysvar-id = { workspace = true, optional = true }
 [dev-dependencies]
 solana-clock = { path = ".", features = ["sysvar"] }
 static_assertions = { workspace = true }
-
-[features]
-serde = ["dep:serde", "dep:serde_derive"]
-sysvar = ["dep:solana-sdk-ids", "dep:solana-sysvar-id"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]

--- a/cluster-type/Cargo.toml
+++ b/cluster-type/Cargo.toml
@@ -9,18 +9,18 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+serde = ["dep:serde", "dep:serde_derive"]
+
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-hash = { workspace = true, default-features = false }
-
-[features]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
-serde = ["dep:serde", "dep:serde_derive"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]

--- a/commitment-config/Cargo.toml
+++ b/commitment-config/Cargo.toml
@@ -9,12 +9,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[dependencies]
-serde = { workspace = true, optional = true }
-serde_derive = { workspace = true, optional = true }
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
 serde = ["dep:serde", "dep:serde_derive"]
 
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
+[dependencies]
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }

--- a/compute-budget-interface/Cargo.toml
+++ b/compute-budget-interface/Cargo.toml
@@ -9,6 +9,17 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+borsh = ["dep:borsh"]
+dev-context-only-utils = ["borsh"]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "serde"]
+serde = ["dep:serde", "dep:serde_derive"]
+
 [dependencies]
 borsh = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
@@ -21,17 +32,6 @@ solana-frozen-abi-macro = { workspace = true, features = [
 ], optional = true }
 solana-instruction = { workspace = true, features = ["std"] }
 solana-sdk-ids = { workspace = true }
-
-[features]
-borsh = ["dep:borsh"]
-dev-context-only-utils = ["borsh"]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "serde"]
-serde = ["dep:serde", "dep:serde_derive"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
 
 [lints]
 workspace = true

--- a/cpi/Cargo.toml
+++ b/cpi/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-instruction = { workspace = true }
@@ -25,9 +28,6 @@ solana-pubkey = { workspace = true, features = ["curve25519"] }
 solana-sdk-ids = { workspace = true }
 solana-system-interface = { workspace = true, features = ["bincode"] }
 static_assertions = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
 
 [lints]
 workspace = true

--- a/derivation-path/Cargo.toml
+++ b/derivation-path/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 derivation-path = { workspace = true }
 qstring = { workspace = true }
@@ -16,6 +19,3 @@ uriparse = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/ed25519-program/Cargo.toml
+++ b/ed25519-program/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 bytemuck = { workspace = true }
 bytemuck_derive = { workspace = true }
@@ -26,9 +29,6 @@ solana-keypair = { workspace = true }
 solana-logger = { workspace = true }
 solana-sdk = { path = "../sdk" }
 solana-signer = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
 
 [lints]
 workspace = true

--- a/epoch-info/Cargo.toml
+++ b/epoch-info/Cargo.toml
@@ -9,15 +9,15 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[dependencies]
-serde = { workspace = true, optional = true }
-serde_derive = { workspace = true, optional = true }
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
 serde = ["dep:serde", "dep:serde_derive"]
 
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
+[dependencies]
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/epoch-rewards-hasher/Cargo.toml
+++ b/epoch-rewards-hasher/Cargo.toml
@@ -9,13 +9,13 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 siphasher = { workspace = true }
 solana-hash = { workspace = true }
 solana-pubkey = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
 
 [lints]
 workspace = true

--- a/epoch-rewards/Cargo.toml
+++ b/epoch-rewards/Cargo.toml
@@ -9,6 +9,22 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-hash/frozen-abi",
+    "std",
+]
+serde = ["dep:serde", "dep:serde_derive", "solana-hash/serde"]
+std = []
+sysvar = ["dep:solana-sysvar-id"]
+
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
@@ -21,17 +37,6 @@ solana-sysvar-id = { workspace = true, optional = true }
 
 [dev-dependencies]
 solana-epoch-rewards = { path = ".", features = ["sysvar"] }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "solana-hash/frozen-abi", "std"]
-serde = ["dep:serde", "dep:serde_derive", "solana-hash/serde"]
-std = []
-sysvar = ["dep:solana-sysvar-id"]
 
 [lints]
 workspace = true

--- a/epoch-schedule/Cargo.toml
+++ b/epoch-schedule/Cargo.toml
@@ -9,6 +9,14 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+serde = ["dep:serde", "dep:serde_derive"]
+sysvar = ["dep:solana-sdk-ids", "dep:solana-sysvar-id"]
+
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
@@ -18,18 +26,10 @@ solana-sdk-ids = { workspace = true, optional = true }
 solana-sdk-macro = { workspace = true }
 solana-sysvar-id = { workspace = true, optional = true }
 
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-
 [dev-dependencies]
 solana-clock = { workspace = true }
 solana-epoch-schedule = { path = ".", features = ["sysvar"] }
 static_assertions = { workspace = true }
-
-[features]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
-serde = ["dep:serde", "dep:serde_derive"]
-sysvar = ["dep:solana-sdk-ids", "dep:solana-sysvar-id"]
 
 [lints]
 workspace = true

--- a/example-mocks/Cargo.toml
+++ b/example-mocks/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 serde = { workspace = true }
 serde_derive = { workspace = true }
@@ -23,6 +26,3 @@ solana-pubkey = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-system-interface = { workspace = true }
 thiserror = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/feature-gate-interface/Cargo.toml
+++ b/feature-gate-interface/Cargo.toml
@@ -9,6 +9,23 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+bincode = [
+    "dep:bincode",
+    "dep:solana-account",
+    "dep:solana-account-info",
+    "dep:solana-instruction",
+    "dep:solana-program-error",
+    "dep:solana-rent",
+    "dep:solana-system-interface",
+    "serde",
+]
+dev-context-only-utils = ["bincode"]
+serde = ["dep:serde", "dep:serde_derive"]
+
 [dependencies]
 bincode = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
@@ -26,23 +43,6 @@ solana-system-interface = { workspace = true, optional = true, features = [
 
 [dev-dependencies]
 solana-feature-gate-interface = { path = ".", features = ["dev-context-only-utils"] }
-
-[features]
-bincode = [
-    "dep:bincode",
-    "dep:solana-account",
-    "dep:solana-account-info",
-    "dep:solana-instruction",
-    "dep:solana-program-error",
-    "dep:solana-rent",
-    "dep:solana-system-interface",
-    "serde"
-]
-dev-context-only-utils = ["bincode"]
-serde = ["dep:serde", "dep:serde_derive"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
 
 [lints]
 workspace = true

--- a/feature-set-interface/Cargo.toml
+++ b/feature-set-interface/Cargo.toml
@@ -9,6 +9,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+
 [dependencies]
 ahash = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
@@ -18,12 +24,6 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
 solana-pubkey = { workspace = true }
-
-[features]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
 
 [lints]
 workspace = true

--- a/feature-set/Cargo.toml
+++ b/feature-set/Cargo.toml
@@ -9,6 +9,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+
 [dependencies]
 ahash = { workspace = true }
 lazy_static = { workspace = true }
@@ -22,12 +28,6 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
 solana-hash = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-sha256-hasher = { workspace = true }
-
-[features]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
 
 [lints]
 workspace = true

--- a/fee-calculator/Cargo.toml
+++ b/fee-calculator/Cargo.toml
@@ -9,6 +9,15 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+serde = ["dep:serde", "dep:serde_derive"]
+
 [dependencies]
 log = { workspace = true }
 serde = { workspace = true, optional = true }
@@ -20,12 +29,3 @@ solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-clock = { workspace = true }
 solana-logger = { workspace = true }
 static_assertions = { workspace = true }
-
-[features]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
-serde = ["dep:serde", "dep:serde_derive"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]

--- a/fee-structure/Cargo.toml
+++ b/fee-structure/Cargo.toml
@@ -9,6 +9,15 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi"]
+serde = ["dep:serde", "dep:serde_derive"]
+
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
@@ -17,17 +26,8 @@ solana-frozen-abi = { workspace = true, optional = true, features = [
 ] }
 solana-native-token = { workspace = true }
 
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
-
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 solana-message = { workspace = true }
-
-[features]
-frozen-abi = ["dep:solana-frozen-abi"]
-serde = ["dep:serde", "dep:serde_derive"]
 
 [lints]
 workspace = true

--- a/file-download/Cargo.toml
+++ b/file-download/Cargo.toml
@@ -9,11 +9,11 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 console = { workspace = true }
 indicatif = { workspace = true }
 log = { workspace = true }
 reqwest = { workspace = true, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/frozen-abi-macro/Cargo.toml
+++ b/frozen-abi-macro/Cargo.toml
@@ -12,16 +12,16 @@ edition = { workspace = true }
 [lib]
 proc-macro = true
 
-[dependencies]
-proc-macro2 = { workspace = true }
-quote = { workspace = true }
-syn = { workspace = true, features = ["full", "extra-traits"] }
-
 [features]
 default = []
 # activate the frozen-abi feature when we actually want to do frozen-abi testing,
 # otherwise leave it off because it requires nightly Rust
 frozen-abi = []
+
+[dependencies]
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true, features = ["full", "extra-traits"] }
 
 [lints]
 workspace = true

--- a/frozen-abi/Cargo.toml
+++ b/frozen-abi/Cargo.toml
@@ -9,6 +9,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[features]
+default = []
+# activate the frozen-abi feature when we actually want to do frozen-abi testing,
+# otherwise leave it off because it requires nightly Rust
+frozen-abi = []
+
 [dependencies]
 bs58 = { workspace = true, features = ["alloc"] }
 bv = { workspace = true, features = ["serde"] }
@@ -28,14 +34,8 @@ memmap2 = { workspace = true }
 [target.'cfg(not(target_os = "solana"))'.dev-dependencies]
 bitflags = { workspace = true, features = ["serde"] }
 serde_bytes = { workspace = true }
-solana-logger = { workspace = true }
 serde_with = { workspace = true, features = ["macros"] }
-
-[features]
-default = []
-# activate the frozen-abi feature when we actually want to do frozen-abi testing,
-# otherwise leave it off because it requires nightly Rust
-frozen-abi = []
+solana-logger = { workspace = true }
 
 [lints]
 workspace = true

--- a/genesis-config/Cargo.toml
+++ b/genesis-config/Cargo.toml
@@ -9,6 +9,26 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+serde = [
+    "dep:serde",
+    "dep:serde_derive",
+    "solana-account/serde",
+    "solana-clock/serde",
+    "solana-cluster-type/serde",
+    "solana-epoch-schedule/serde",
+    "solana-fee-calculator/serde",
+    "solana-inflation/serde",
+    "solana-poh-config/serde",
+    "solana-rent/serde",
+]
+
 [dependencies]
 bincode = { workspace = true }
 chrono = { workspace = true, features = ["alloc"] }
@@ -38,26 +58,6 @@ solana-time-utils = { workspace = true }
 [dev-dependencies]
 solana-genesis-config = { path = ".", features = ["serde"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
-
-[features]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
-serde = [
-    "dep:serde",
-    "dep:serde_derive",
-    "solana-account/serde",
-    "solana-clock/serde",
-    "solana-cluster-type/serde",
-    "solana-epoch-schedule/serde",
-    "solana-fee-calculator/serde",
-    "solana-inflation/serde",
-    "solana-poh-config/serde",
-    "solana-rent/serde",
-]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
 
 [lints]
 workspace = true

--- a/hard-forks/Cargo.toml
+++ b/hard-forks/Cargo.toml
@@ -9,18 +9,18 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[dependencies]
-serde = { workspace = true, optional = true }
-serde_derive = { workspace = true, optional = true }
-solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
-solana-frozen-abi-macro = { workspace = true, optional = true, features = ["frozen-abi"] }
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 serde = ["dep:serde", "dep:serde_derive"]
 
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
+[dependencies]
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
+solana-frozen-abi-macro = { workspace = true, optional = true, features = ["frozen-abi"] }
 
 [lints]
 workspace = true

--- a/hash/Cargo.toml
+++ b/hash/Cargo.toml
@@ -14,6 +14,14 @@ targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
+[features]
+borsh = ["dep:borsh", "std"]
+bytemuck = ["dep:bytemuck", "dep:bytemuck_derive"]
+default = ["std"]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "std"]
+serde = ["dep:serde", "dep:serde_derive"]
+std = []
+
 [dependencies]
 borsh = { workspace = true, optional = true }
 bytemuck = { workspace = true, optional = true }
@@ -30,24 +38,12 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
 ] }
 solana-sanitize = { workspace = true }
 
-[dev-dependencies]
-bs58 = { workspace = true, default-features = false, features = ["alloc"] }
-
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = { workspace = true }
 wasm-bindgen = { workspace = true }
 
-[features]
-borsh = ["dep:borsh", "std"]
-bytemuck = ["dep:bytemuck", "dep:bytemuck_derive"]
-default = ["std"]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "std"
-]
-serde = ["dep:serde", "dep:serde_derive"]
-std = []
+[dev-dependencies]
+bs58 = { workspace = true, default-features = false, features = ["alloc"] }
 
 [lints]
 workspace = true

--- a/inflation/Cargo.toml
+++ b/inflation/Cargo.toml
@@ -9,15 +9,15 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[dependencies]
-serde = { workspace = true, optional = true }
-serde_derive = { workspace = true, optional = true }
-solana-frozen-abi = { workspace = true, optional = true }
-solana-frozen-abi-macro = { workspace = true, optional = true }
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 serde = ["dep:serde", "dep:serde_derive"]
 
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
+[dependencies]
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }

--- a/instruction/Cargo.toml
+++ b/instruction/Cargo.toml
@@ -9,26 +9,10 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[dependencies]
-bincode = { workspace = true, optional = true }
-borsh = { workspace = true, optional = true }
-num-traits = { workspace = true }
-serde = { workspace = true, optional = true }
-serde_derive = { workspace = true, optional = true }
-solana-frozen-abi = { workspace = true, optional = true }
-solana-frozen-abi-macro = { workspace = true, optional = true }
-solana-pubkey = { workspace = true, default-features = false }
-
-[target.'cfg(target_os = "solana")'.dependencies]
-solana-define-syscall = { workspace = true }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { workspace = true, features = ["js", "wasm-bindgen"] }
-js-sys = { workspace = true }
-wasm-bindgen = { workspace = true }
-
-[dev-dependencies]
-solana-instruction = { path = ".", features = ["borsh"] }
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 bincode = ["dep:bincode", "dep:serde"]
@@ -40,18 +24,30 @@ frozen-abi = [
     "serde",
     "std",
 ]
-serde = [
-    "dep:serde",
-    "dep:serde_derive",
-    "solana-pubkey/serde",
-]
+serde = ["dep:serde", "dep:serde_derive", "solana-pubkey/serde"]
 std = []
 syscalls = ["std"]
 
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
+[dependencies]
+bincode = { workspace = true, optional = true }
+borsh = { workspace = true, optional = true }
+num-traits = { workspace = true }
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
+solana-pubkey = { workspace = true, default-features = false }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { workspace = true, features = ["js", "wasm-bindgen"] }
+js-sys = { workspace = true }
+wasm-bindgen = { workspace = true }
+
+[target.'cfg(target_os = "solana")'.dependencies]
+solana-define-syscall = { workspace = true }
+
+[dev-dependencies]
+solana-instruction = { path = ".", features = ["borsh"] }
 
 [lints]
 workspace = true

--- a/instructions-sysvar/Cargo.toml
+++ b/instructions-sysvar/Cargo.toml
@@ -9,6 +9,14 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+dev-context-only-utils = ["dep:qualifier_attr"]
+
 [dependencies]
 qualifier_attr = { workspace = true, optional = true }
 solana-account-info = { workspace = true }
@@ -22,14 +30,6 @@ solana-sysvar-id = { workspace = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 bitflags = { workspace = true }
-
-[features]
-dev-context-only-utils = ["dep:qualifier_attr"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
 
 [lints]
 workspace = true

--- a/keccak-hasher/Cargo.toml
+++ b/keccak-hasher/Cargo.toml
@@ -14,6 +14,13 @@ targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
+[features]
+borsh = ["dep:borsh", "std"]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "std"]
+serde = ["dep:serde", "dep:serde_derive"]
+sha3 = ["dep:sha3"]
+std = ["solana-hash/std"]
+
 [dependencies]
 borsh = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
@@ -36,13 +43,6 @@ sha3 = { workspace = true }
 # onchain
 sha3 = { workspace = true, optional = true }
 solana-define-syscall = { workspace = true }
-
-[features]
-borsh = ["dep:borsh", "std"]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "std"]
-serde = ["dep:serde", "dep:serde_derive"]
-sha3 = ["dep:sha3"]
-std = ["solana-hash/std"]
 
 [lints]
 workspace = true

--- a/keypair/Cargo.toml
+++ b/keypair/Cargo.toml
@@ -9,6 +9,18 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+seed-derivable = [
+    "dep:solana-derivation-path",
+    "dep:solana-seed-derivable",
+    "dep:ed25519-dalek-bip32",
+]
+
 [dependencies]
 ed25519-dalek = { workspace = true }
 ed25519-dalek-bip32 = { workspace = true, optional = true }
@@ -28,11 +40,3 @@ wasm-bindgen = { workspace = true }
 serde_json = { workspace = true }
 static_assertions = { workspace = true }
 tiny-bip39 = { workspace = true }
-
-[features]
-seed-derivable = ["dep:solana-derivation-path", "dep:solana-seed-derivable", "dep:ed25519-dalek-bip32"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]

--- a/loader-v2-interface/Cargo.toml
+++ b/loader-v2-interface/Cargo.toml
@@ -9,6 +9,15 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+bincode = ["dep:solana-instruction", "serde"]
+serde = ["dep:serde", "dep:serde_bytes", "dep:serde_derive"]
+
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_bytes = { workspace = true, optional = true }
@@ -16,15 +25,6 @@ serde_derive = { workspace = true, optional = true }
 solana-instruction = { workspace = true, features = ["bincode", "std"], optional = true }
 solana-pubkey = { workspace = true }
 solana-sdk-ids = { workspace = true }
-
-[features]
-bincode = ["dep:solana-instruction", "serde"]
-serde = ["dep:serde", "dep:serde_bytes", "dep:serde_derive"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
 
 [lints]
 workspace = true

--- a/loader-v3-interface/Cargo.toml
+++ b/loader-v3-interface/Cargo.toml
@@ -9,6 +9,17 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+bincode = ["dep:solana-system-interface", "serde", "solana-instruction/bincode"]
+dev-context-only-utils = ["bincode"]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "serde"]
+serde = ["dep:serde", "dep:serde_bytes", "dep:serde_derive", "solana-pubkey/serde"]
+
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_bytes = { workspace = true, optional = true }
@@ -27,17 +38,6 @@ solana-system-interface = { workspace = true, features = ["bincode"], optional =
 [dev-dependencies]
 bincode = { workspace = true }
 solana-loader-v3-interface = { path = ".", features = ["dev-context-only-utils"] }
-
-[features]
-bincode = ["dep:solana-system-interface", "serde", "solana-instruction/bincode"]
-dev-context-only-utils = ["bincode"]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "serde"]
-serde = ["dep:serde", "dep:serde_bytes", "dep:serde_derive", "solana-pubkey/serde"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
 
 [lints]
 workspace = true

--- a/loader-v4-interface/Cargo.toml
+++ b/loader-v4-interface/Cargo.toml
@@ -9,6 +9,17 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+bincode = ["dep:solana-system-interface", "serde", "solana-instruction/bincode"]
+dev-context-only-utils = ["bincode"]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "serde"]
+serde = ["dep:serde", "dep:serde_bytes", "dep:serde_derive", "solana-pubkey/serde"]
+
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_bytes = { workspace = true, optional = true }
@@ -27,17 +38,6 @@ solana-system-interface = { workspace = true, features = ["bincode"], optional =
 [dev-dependencies]
 memoffset = { workspace = true }
 solana-loader-v4-interface = { path = ".", features = ["dev-context-only-utils"] }
-
-[features]
-bincode = ["dep:solana-system-interface", "serde", "solana-instruction/bincode"]
-dev-context-only-utils = ["bincode"]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "serde"]
-serde = ["dep:serde", "dep:serde_bytes", "dep:serde_derive", "solana-pubkey/serde"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
 
 [lints]
 workspace = true

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -9,6 +9,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[lib]
+name = "solana_logger"
+
 [dependencies]
 env_logger = { workspace = true }
 lazy_static = { workspace = true }
@@ -17,9 +23,3 @@ log = { workspace = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libc = { workspace = true }
 signal-hook = { workspace = true }
-
-[lib]
-name = "solana_logger"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/message/Cargo.toml
+++ b/message/Cargo.toml
@@ -9,6 +9,36 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+bincode = [
+    "dep:bincode",
+    "dep:solana-bincode",
+    "dep:solana-system-interface",
+    "serde",
+]
+blake3 = ["dep:blake3"]
+dev-context-only-utils = ["bincode", "blake3"]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "dep:solana-logger",
+    "solana-hash/frozen-abi",
+    "solana-pubkey/frozen-abi",
+    "serde",
+]
+serde = [
+    "dep:serde",
+    "dep:serde_derive",
+    "dep:solana-short-vec",
+    "solana-hash/serde",
+    "solana-pubkey/serde",
+]
+
 [dependencies]
 bincode = { workspace = true, optional = true }
 blake3 = { workspace = true, features = ["traits-preview"], optional = true }
@@ -45,36 +75,6 @@ solana-program = { path = "../program" }
 solana-sha256-hasher = { workspace = true }
 solana-sysvar = { workspace = true }
 static_assertions = { workspace = true }
-
-[features]
-bincode = [
-    "dep:bincode",
-    "dep:solana-bincode",
-    "dep:solana-system-interface",
-    "serde",
-]
-blake3 = ["dep:blake3"]
-dev-context-only-utils = ["bincode", "blake3"]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "dep:solana-logger",
-    "solana-hash/frozen-abi",
-    "solana-pubkey/frozen-abi",
-    "serde",
-]
-serde = [
-    "dep:serde",
-    "dep:serde_derive",
-    "dep:solana-short-vec",
-    "solana-hash/serde",
-    "solana-pubkey/serde",
-]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
 
 [lints]
 workspace = true

--- a/msg/Cargo.toml
+++ b/msg/Cargo.toml
@@ -9,11 +9,11 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[target.'cfg(target_os = "solana")'.dependencies]
-solana-define-syscall = { workspace = true }
-
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[target.'cfg(target_os = "solana")'.dependencies]
+solana-define-syscall = { workspace = true }
 
 [lints]
 workspace = true

--- a/nonce/Cargo.toml
+++ b/nonce/Cargo.toml
@@ -9,17 +9,10 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[dependencies]
-serde = { workspace = true, optional = true }
-serde_derive = { workspace = true, optional = true }
-solana-fee-calculator = { workspace = true }
-solana-hash = { workspace = true, default-features = false }
-solana-pubkey = { workspace = true, default-features = false }
-solana-sha256-hasher = { workspace = true }
-
-[dev-dependencies]
-bincode = { workspace = true }
-solana-nonce = { path = ".", features = ["dev-context-only-utils"] }
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 dev-context-only-utils = ["serde"]
@@ -31,7 +24,14 @@ serde = [
     "solana-pubkey/serde",
 ]
 
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
+[dependencies]
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
+solana-fee-calculator = { workspace = true }
+solana-hash = { workspace = true, default-features = false }
+solana-pubkey = { workspace = true, default-features = false }
+solana-sha256-hasher = { workspace = true }
+
+[dev-dependencies]
+bincode = { workspace = true }
+solana-nonce = { path = ".", features = ["dev-context-only-utils"] }

--- a/offchain-message/Cargo.toml
+++ b/offchain-message/Cargo.toml
@@ -9,6 +9,15 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+dev-context-only-utils = ["verify"]
+verify = ["dep:solana-pubkey", "solana-signature/verify"]
+
 [dependencies]
 num_enum = { workspace = true }
 solana-hash = { workspace = true }
@@ -23,12 +32,3 @@ solana-signer = { workspace = true }
 solana-keypair = { workspace = true }
 solana-offchain-message = { path = ".", features = ["dev-context-only-utils"] }
 static_assertions = { workspace = true }
-
-[features]
-dev-context-only-utils = ["verify"]
-verify = ["dep:solana-pubkey", "solana-signature/verify"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]

--- a/package-metadata-macro/Cargo.toml
+++ b/package-metadata-macro/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [lib]
 proc-macro = true
 
@@ -17,6 +20,3 @@ proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true, features = ["full"] }
 toml = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/package-metadata/Cargo.toml
+++ b/package-metadata/Cargo.toml
@@ -9,9 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 solana-package-metadata-macro = { workspace = true }
 solana-pubkey = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/packet/Cargo.toml
+++ b/packet/Cargo.toml
@@ -9,6 +9,23 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+bincode = ["dep:bincode", "serde"]
+dev-context-only-utils = ["bincode"]
+serde = [
+    "bitflags/serde",
+    "dep:cfg_eval",
+    "dep:serde",
+    "dep:serde_derive",
+    "dep:serde_with",
+]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+
 [dependencies]
 bincode = { workspace = true, optional = true }
 bitflags = { workspace = true }
@@ -22,23 +39,6 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = ["froz
 [dev-dependencies]
 solana-packet = { path = ".", features = ["dev-context-only-utils"] }
 static_assertions = { workspace = true }
-
-[features]
-bincode = ["dep:bincode", "serde"]
-dev-context-only-utils = ["bincode"]
-serde = [
-    "bitflags/serde",
-    "dep:cfg_eval",
-    "dep:serde",
-    "dep:serde_derive",
-    "dep:serde_with"
-]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
 
 [lints]
 workspace = true

--- a/poh-config/Cargo.toml
+++ b/poh-config/Cargo.toml
@@ -14,6 +14,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+serde = ["dep:serde", "dep:serde_derive"]
+
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
@@ -27,13 +31,6 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
 [dev-dependencies]
 solana-clock = { workspace = true }
 static_assertions = { workspace = true }
-
-[features]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-]
-serde = ["dep:serde", "dep:serde_derive"]
 
 [lints]
 workspace = true

--- a/precompile-error/Cargo.toml
+++ b/precompile-error/Cargo.toml
@@ -9,9 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 num-traits = { workspace = true }
 solana-decode-error = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/precompiles/Cargo.toml
+++ b/precompiles/Cargo.toml
@@ -9,6 +9,15 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+# Enables the "vendored" feature of openssl inside of secp256r1-program
+openssl-vendored = ["solana-secp256r1-program/openssl-vendored"]
+
 [dependencies]
 lazy_static = { workspace = true }
 solana-ed25519-program = { workspace = true }
@@ -19,15 +28,6 @@ solana-pubkey = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-secp256k1-program = { workspace = true, features = ["bincode"] }
 solana-secp256r1-program = { workspace = true, default-features = false }
-
-[features]
-# Enables the "vendored" feature of openssl inside of secp256r1-program
-openssl-vendored = ["solana-secp256r1-program/openssl-vendored"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
 
 [lints]
 workspace = true

--- a/presigner/Cargo.toml
+++ b/presigner/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 solana-pubkey = { workspace = true }
 solana-signature = { workspace = true, features = ["verify"] }
@@ -16,6 +19,3 @@ solana-signer = { workspace = true }
 
 [dev-dependencies]
 solana-keypair = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/program-entrypoint/Cargo.toml
+++ b/program-entrypoint/Cargo.toml
@@ -9,11 +9,11 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 solana-account-info = { workspace = true }
 solana-msg = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true, default-features = false }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/program-error/Cargo.toml
+++ b/program-error/Cargo.toml
@@ -9,6 +9,15 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+borsh = ["dep:borsh"]
+serde = ["dep:serde", "dep:serde_derive"]
+
 [dependencies]
 borsh = { workspace = true, optional = true }
 num-traits = { workspace = true }
@@ -20,12 +29,3 @@ solana-instruction = { workspace = true, default-features = false, features = [
 ] }
 solana-msg = { workspace = true }
 solana-pubkey = { workspace = true, default-features = false }
-
-[features]
-borsh = ["dep:borsh"]
-serde = ["dep:serde", "dep:serde_derive"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]

--- a/program-pack/Cargo.toml
+++ b/program-pack/Cargo.toml
@@ -9,8 +9,8 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[dependencies]
-solana-program-error = { workspace = true }
-
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+solana-program-error = { workspace = true }

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -12,6 +12,43 @@ edition = { workspace = true }
 rust-version = "1.79.0"                          # solana platform-tools rust version
 include = ["src/**/*", "README.md"]
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["borsh"]
+borsh = [
+    "dep:borsh",
+    "dep:borsh0-10",
+    "dep:solana-borsh",
+    "solana-hash/borsh",
+    "solana-instruction/borsh",
+    "solana-program-error/borsh",
+    "solana-pubkey/borsh",
+    "solana-stake-interface/borsh",
+]
+dev-context-only-utils = ["solana-instructions-sysvar/dev-context-only-utils"]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-epoch-rewards/frozen-abi",
+    "solana-epoch-schedule/frozen-abi",
+    "solana-fee-calculator/frozen-abi",
+    "solana-hash/frozen-abi",
+    "solana-instruction/frozen-abi",
+    "solana-message/frozen-abi",
+    "solana-pubkey/frozen-abi",
+    "solana-rent/frozen-abi",
+    "solana-short-vec/frozen-abi",
+    "solana-stake-interface/frozen-abi",
+    "solana-sysvar/frozen-abi",
+]
+
 [dependencies]
 bincode = { workspace = true }
 blake3 = { workspace = true, features = ["traits-preview"] }
@@ -89,6 +126,17 @@ solana-sysvar-id = { workspace = true }
 solana-vote-interface = { workspace = true, features = ["bincode"] }
 thiserror = { workspace = true }
 
+[target.'cfg(not(target_os = "solana"))'.dependencies]
+num-bigint = { workspace = true }
+rand = { workspace = true }
+solana-example-mocks = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+console_error_panic_hook = { workspace = true }
+console_log = { workspace = true }
+getrandom = { workspace = true, features = ["js", "wasm-bindgen"] }
+wasm-bindgen = { workspace = true }
+
 # This is currently needed to build on-chain programs reliably.
 # Borsh 0.10 may pull in hashbrown 0.13, which uses ahash 0.8, which uses
 # getrandom 0.2 underneath. This explicit dependency allows for no-std if cargo
@@ -99,21 +147,6 @@ thiserror = { workspace = true }
 getrandom = { workspace = true, features = ["custom"] }
 solana-define-syscall = { workspace = true }
 
-[target.'cfg(not(target_os = "solana"))'.dependencies]
-num-bigint = { workspace = true }
-rand = { workspace = true }
-solana-example-mocks = { workspace = true }
-
-[target.'cfg(not(target_os = "solana"))'.dev-dependencies]
-arbitrary = { workspace = true, features = ["derive"] }
-solana-logger = { workspace = true }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-console_error_panic_hook = { workspace = true }
-console_log = { workspace = true }
-getrandom = { workspace = true, features = ["js", "wasm-bindgen"] }
-wasm-bindgen = { workspace = true }
-
 [dev-dependencies]
 array-bytes = { workspace = true }
 assert_matches = { workspace = true }
@@ -122,42 +155,9 @@ serde_json = { workspace = true }
 solana-pubkey = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sysvar = { workspace = true, features = ["dev-context-only-utils"] }
 
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
-
-[lib]
-crate-type = ["cdylib", "rlib"]
-
-[features]
-default = ["borsh"]
-borsh = [
-    "dep:borsh",
-    "dep:borsh0-10",
-    "dep:solana-borsh",
-    "solana-hash/borsh",
-    "solana-instruction/borsh",
-    "solana-program-error/borsh",
-    "solana-pubkey/borsh",
-    "solana-stake-interface/borsh",
-]
-dev-context-only-utils = ["solana-instructions-sysvar/dev-context-only-utils"]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-epoch-rewards/frozen-abi",
-    "solana-epoch-schedule/frozen-abi",
-    "solana-fee-calculator/frozen-abi",
-    "solana-hash/frozen-abi",
-    "solana-instruction/frozen-abi",
-    "solana-message/frozen-abi",
-    "solana-pubkey/frozen-abi",
-    "solana-rent/frozen-abi",
-    "solana-short-vec/frozen-abi",
-    "solana-stake-interface/frozen-abi",
-    "solana-sysvar/frozen-abi"
-]
+[target.'cfg(not(target_os = "solana"))'.dev-dependencies]
+arbitrary = { workspace = true, features = ["derive"] }
+solana-logger = { workspace = true }
 
 [lints]
 workspace = true

--- a/pubkey/Cargo.toml
+++ b/pubkey/Cargo.toml
@@ -9,6 +9,23 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+borsh = ["dep:borsh", "dep:borsh0-10", "std"]
+bytemuck = ["dep:bytemuck", "dep:bytemuck_derive"]
+curve25519 = ["dep:curve25519-dalek", "sha2"]
+default = ["std"]
+dev-context-only-utils = ["dep:arbitrary", "rand"]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "std"]
+rand = ["dep:rand", "std"]
+serde = ["dep:serde", "dep:serde_derive"]
+sha2 = ["dep:solana-sha256-hasher", "solana-sha256-hasher/sha2"]
+std = []
+
 [dependencies]
 arbitrary = { workspace = true, features = ["derive"], optional = true }
 borsh = { workspace = true, optional = true }
@@ -31,10 +48,6 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
 ] }
 solana-sanitize = { workspace = true }
 
-[target.'cfg(target_os = "solana")'.dependencies]
-solana-define-syscall = { workspace = true }
-solana-sha256-hasher = { workspace = true }
-
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 curve25519-dalek = { workspace = true, optional = true }
 solana-sha256-hasher = { workspace = true, optional = true }
@@ -43,6 +56,10 @@ solana-sha256-hasher = { workspace = true, optional = true }
 getrandom = { workspace = true, features = ["js", "wasm-bindgen"] }
 js-sys = { workspace = true }
 wasm-bindgen = { workspace = true }
+
+[target.'cfg(target_os = "solana")'.dependencies]
+solana-define-syscall = { workspace = true }
+solana-sha256-hasher = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -59,27 +76,6 @@ solana-pubkey = { path = ".", features = [
 ] }
 strum = { workspace = true }
 strum_macros = { workspace = true }
-
-[features]
-borsh = ["dep:borsh", "dep:borsh0-10", "std"]
-bytemuck = ["dep:bytemuck", "dep:bytemuck_derive"]
-curve25519 = ["dep:curve25519-dalek", "sha2"]
-default = ["std"]
-dev-context-only-utils = ["dep:arbitrary", "rand"]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "std",
-]
-rand = ["dep:rand", "std"]
-serde = ["dep:serde", "dep:serde_derive"]
-sha2 = ["dep:solana-sha256-hasher", "solana-sha256-hasher/sha2"]
-std = []
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
 
 [lints]
 workspace = true

--- a/quic-definitions/Cargo.toml
+++ b/quic-definitions/Cargo.toml
@@ -9,11 +9,11 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[dependencies]
-solana-keypair = { workspace = true }
-
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+solana-keypair = { workspace = true }
 
 [lints]
 workspace = true

--- a/rent-collector/Cargo.toml
+++ b/rent-collector/Cargo.toml
@@ -9,6 +9,20 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+serde = [
+    "dep:serde",
+    "dep:serde_derive",
+    "solana-epoch-schedule/serde",
+    "solana-rent/serde",
+]
+
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
@@ -26,20 +40,6 @@ solana-sdk-ids = { workspace = true }
 assert_matches = { workspace = true }
 solana-logger = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
-
-[features]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
-serde = [
-  "dep:serde",
-  "dep:serde_derive",
-  "solana-epoch-schedule/serde",
-  "solana-rent/serde",
-]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
 
 [lints]
 workspace = true

--- a/rent-debits/Cargo.toml
+++ b/rent-debits/Cargo.toml
@@ -9,17 +9,17 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[dependencies]
-solana-pubkey = { workspace = true }
-solana-reward-info = { workspace = true }
-
-[features]
-dev-context-only-utils = []
-
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+dev-context-only-utils = []
+
+[dependencies]
+solana-pubkey = { workspace = true }
+solana-reward-info = { workspace = true }
 
 [lints]
 workspace = true

--- a/rent/Cargo.toml
+++ b/rent/Cargo.toml
@@ -9,6 +9,14 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+serde = ["dep:serde", "dep:serde_derive"]
+sysvar = ["dep:solana-sdk-ids", "dep:solana-sysvar-id"]
+
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
@@ -21,14 +29,6 @@ solana-sysvar-id = { workspace = true, optional = true }
 [dev-dependencies]
 solana-clock = { workspace = true }
 static_assertions = { workspace = true }
-
-[features]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
-serde = ["dep:serde", "dep:serde_derive"]
-sysvar = ["dep:solana-sdk-ids", "dep:solana-sysvar-id"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
 
 [lints]
 workspace = true

--- a/reserved-account-keys/Cargo.toml
+++ b/reserved-account-keys/Cargo.toml
@@ -9,6 +9,14 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+
 [dependencies]
 lazy_static = { workspace = true }
 solana-feature-set = { workspace = true }
@@ -24,14 +32,6 @@ solana-sdk-ids = { workspace = true }
 [dev-dependencies]
 solana-message = { workspace = true }
 solana-sysvar = { workspace = true }
-
-[features]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
 
 [lints]
 workspace = true

--- a/reward-info/Cargo.toml
+++ b/reward-info/Cargo.toml
@@ -9,15 +9,15 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[dependencies]
-serde = { workspace = true, optional = true }
-serde_derive = { workspace = true, optional = true }
-solana-frozen-abi = { workspace = true, optional = true }
-solana-frozen-abi-macro = { workspace = true, optional = true }
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 serde = ["dep:serde", "dep:serde_derive"]
 
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
+[dependencies]
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }

--- a/sdk-ids/Cargo.toml
+++ b/sdk-ids/Cargo.toml
@@ -9,11 +9,11 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[dependencies]
-solana-pubkey = { workspace = true, default-features = false }
-
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+solana-pubkey = { workspace = true, default-features = false }
 
 [lints]
 workspace = true

--- a/sdk-macro/Cargo.toml
+++ b/sdk-macro/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [lib]
 proc-macro = true
 
@@ -17,6 +20,3 @@ bs58 = { workspace = true, features = ["alloc"] }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true, features = ["full"] }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -11,6 +11,14 @@ license = { workspace = true }
 edition = { workspace = true }
 include = ["src/**/*", "README.md"]
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [features]
 # "program" feature is a legacy feature retained to support v1.3 and older
 # programs.  New development should not use this feature.  Instead use the
@@ -77,7 +85,7 @@ frozen-abi = [
     "solana-short-vec/frozen-abi",
     "solana-signature/frozen-abi",
     "solana-transaction/frozen-abi",
-    "solana-transaction-error/frozen-abi"
+    "solana-transaction-error/frozen-abi",
 ]
 # Enables the "vendored" feature of openssl inside of secp256r1-program
 openssl-vendored = ["solana-precompiles/openssl-vendored"]
@@ -190,14 +198,6 @@ serde_with = { workspace = true, features = ["macros"] }
 solana-instructions-sysvar = { workspace = true, features = ["dev-context-only-utils"] }
 solana-program = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk = { path = ".", features = ["dev-context-only-utils"] }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
-
-[lib]
-crate-type = ["cdylib", "rlib"]
 
 [lints]
 workspace = true

--- a/secp256k1-program/Cargo.toml
+++ b/secp256k1-program/Cargo.toml
@@ -9,6 +9,23 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+bincode = [
+    "dep:bincode",
+    "dep:solana-feature-set",
+    "dep:solana-instruction",
+    "dep:solana-precompile-error",
+    "dep:solana-sdk-ids",
+    "serde",
+]
+dev-context-only-utils = ["bincode"]
+serde = ["dep:serde", "dep:serde_derive"]
+
 [dependencies]
 bincode = { workspace = true, optional = true }
 digest = { workspace = true }
@@ -37,20 +54,3 @@ solana-program-error = { workspace = true }
 solana-sdk = { path = "../sdk" }
 solana-secp256k1-program = { path = ".", features = ["dev-context-only-utils"] }
 solana-signer = { workspace = true }
-
-[features]
-bincode = [
-    "dep:bincode",
-    "dep:solana-feature-set",
-    "dep:solana-instruction",
-    "dep:solana-precompile-error",
-    "dep:solana-sdk-ids",
-    "serde",
-]
-dev-context-only-utils = ["bincode"]
-serde = ["dep:serde", "dep:serde_derive"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]

--- a/secp256k1-recover/Cargo.toml
+++ b/secp256k1-recover/Cargo.toml
@@ -9,6 +9,13 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+borsh = ["dep:borsh"]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+
 [dependencies]
 borsh = { workspace = true, optional = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
@@ -19,11 +26,11 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
 ] }
 thiserror = { workspace = true }
 
-[target.'cfg(target_os = "solana")'.dependencies]
-solana-define-syscall = { workspace = true }
-
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 libsecp256k1 = { workspace = true }
+
+[target.'cfg(target_os = "solana")'.dependencies]
+solana-define-syscall = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -32,13 +39,6 @@ solana-program = { path = "../program" }
 
 [target.'cfg(not(target_os = "solana"))'.dev-dependencies]
 libsecp256k1 = { workspace = true, features = ["hmac"] }
-
-[features]
-borsh = ["dep:borsh"]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
 
 [lints]
 workspace = true

--- a/secp256r1-program/Cargo.toml
+++ b/secp256r1-program/Cargo.toml
@@ -9,6 +9,15 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+default = []
+openssl-vendored = ["openssl/vendored"]
+
 [dependencies]
 bytemuck = { workspace = true, features = ["derive"] }
 solana-feature-set = { workspace = true }
@@ -16,21 +25,12 @@ solana-precompile-error = { workspace = true }
 solana-sdk-ids = { workspace = true }
 
 [target.'cfg(all(not(target_arch = "wasm32"), not(target_os = "solana")))'.dependencies]
-solana-instruction = { workspace = true, features = ["std"] }
 openssl = { workspace = true }
+solana-instruction = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 solana-logger = { workspace = true }
 solana-sdk = { path = "../sdk" }
-
-[features]
-default = []
-openssl-vendored = ["openssl/vendored"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
 
 [lints]
 workspace = true

--- a/seed-derivable/Cargo.toml
+++ b/seed-derivable/Cargo.toml
@@ -9,8 +9,8 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[dependencies]
-solana-derivation-path = { workspace = true }
-
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+solana-derivation-path = { workspace = true }

--- a/seed-phrase/Cargo.toml
+++ b/seed-phrase/Cargo.toml
@@ -9,10 +9,10 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 hmac = { workspace = true }
 pbkdf2 = { workspace = true }
 sha2 = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/serde-varint/Cargo.toml
+++ b/serde-varint/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 serde = { workspace = true }
 
@@ -17,6 +20,3 @@ bincode = { workspace = true }
 rand = { workspace = true }
 serde_derive = { workspace = true }
 solana-short-vec = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -9,12 +9,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 serde = { workspace = true }
 
 [dev-dependencies]
 bincode = { workspace = true }
 serde_derive = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/serialize-utils/Cargo.toml
+++ b/serialize-utils/Cargo.toml
@@ -9,6 +9,9 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 solana-instruction = { workspace = true, default-features = false, features = [
     "std",
@@ -25,6 +28,3 @@ solana-pubkey = { workspace = true, default-features = false, features = [
     "borsh",
     "serde",
 ] }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/sha256-hasher/Cargo.toml
+++ b/sha256-hasher/Cargo.toml
@@ -12,6 +12,9 @@ edition = { workspace = true }
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[features]
+sha2 = ["dep:sha2"]
+
 [dependencies]
 solana-hash = { workspace = true }
 
@@ -24,9 +27,6 @@ sha2 = { workspace = true }
 # onchain
 sha2 = { workspace = true, optional = true }
 solana-define-syscall = { workspace = true }
-
-[features]
-sha2 = ["dep:sha2"]
 
 [lints]
 workspace = true

--- a/short-vec/Cargo.toml
+++ b/short-vec/Cargo.toml
@@ -9,6 +9,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+
 [dependencies]
 serde = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
@@ -22,12 +28,6 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
 assert_matches = { workspace = true }
 bincode = { workspace = true }
 serde_json = { workspace = true }
-
-[features]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
 
 [lints]
 workspace = true

--- a/shred-version/Cargo.toml
+++ b/shred-version/Cargo.toml
@@ -9,13 +9,13 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 [dependencies]
 solana-hard-forks = { workspace = true }
 solana-hash = { workspace = true }
 solana-sha256-hasher = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
 
 [lints]
 workspace = true

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -9,6 +9,20 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+default = ["std", "alloc"]
+alloc = []
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "std"]
+rand = ["dep:rand"]
+serde = ["dep:serde", "dep:serde_derive", "dep:serde-big-array"]
+std = ["alloc"]
+verify = ["dep:ed25519-dalek"]
+
 [dependencies]
 ed25519-dalek = { workspace = true, optional = true }
 five8 = { workspace = true }
@@ -34,24 +48,6 @@ serde_json = { workspace = true }
 solana-pubkey = { workspace = true, features = ["std"] }
 solana-short-vec = { workspace = true }
 solana-signature = { path = ".", features = ["serde"] }
-
-[features]
-default = ["std", "alloc"]
-alloc = []
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "std"
-]
-rand = ["dep:rand"]
-serde = ["dep:serde", "dep:serde_derive", "dep:serde-big-array"]
-std = ["alloc"]
-verify = ["dep:ed25519-dalek"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
 
 [lints]
 workspace = true

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -9,12 +9,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[dependencies]
-solana-pubkey = { workspace = true }
-solana-signature = { workspace = true }
-solana-transaction-error = { workspace = true }
-
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
+
+[dependencies]
+solana-pubkey = { workspace = true }
+solana-signature = { workspace = true }
+solana-transaction-error = { workspace = true }

--- a/slot-hashes/Cargo.toml
+++ b/slot-hashes/Cargo.toml
@@ -9,6 +9,13 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[features]
+serde = ["dep:serde", "dep:serde_derive", "solana-hash/serde"]
+sysvar = ["dep:solana-sdk-ids", "dep:solana-sysvar-id"]
+
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
@@ -18,10 +25,3 @@ solana-sysvar-id = { workspace = true, optional = true }
 
 [dev-dependencies]
 solana-sha256-hasher = { workspace = true }
-
-[features]
-serde = ["dep:serde", "dep:serde_derive", "solana-hash/serde"]
-sysvar = ["dep:solana-sdk-ids", "dep:solana-sysvar-id"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/slot-history/Cargo.toml
+++ b/slot-history/Cargo.toml
@@ -9,18 +9,18 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+serde = ["dep:serde", "dep:serde_derive", "bv/serde"]
+sysvar = ["dep:solana-sdk-ids", "dep:solana-sysvar-id"]
+
 [dependencies]
 bv = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 solana-sdk-ids = { workspace = true, optional = true }
 solana-sysvar-id = { workspace = true, optional = true }
-
-[features]
-serde = ["dep:serde", "dep:serde_derive", "bv/serde"]
-sysvar = ["dep:solana-sdk-ids", "dep:solana-sysvar-id"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]

--- a/sysvar-id/Cargo.toml
+++ b/sysvar-id/Cargo.toml
@@ -9,14 +9,14 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[dependencies]
-solana-pubkey = { workspace = true, default-features = false }
-solana-sdk-ids = { workspace = true }
-
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
+
+[dependencies]
+solana-pubkey = { workspace = true, default-features = false }
+solana-sdk-ids = { workspace = true }
 
 [lints]
 workspace = true

--- a/sysvar/Cargo.toml
+++ b/sysvar/Cargo.toml
@@ -9,6 +9,34 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+bincode = ["dep:bincode", "serde", "solana-stake-interface/bincode"]
+bytemuck = ["dep:bytemuck", "dep:bytemuck_derive"]
+dev-context-only-utils = ["bincode", "bytemuck", "solana-instructions-sysvar/dev-context-only-utils"]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-stake-interface/frozen-abi",
+]
+serde = [
+    "dep:serde",
+    "dep:serde_derive",
+    "solana-clock/serde",
+    "solana-epoch-rewards/serde",
+    "solana-epoch-schedule/serde",
+    "solana-fee-calculator/serde",
+    "solana-last-restart-slot/serde",
+    "solana-rent/serde",
+    "solana-slot-hashes/serde",
+    "solana-slot-history/serde",
+    "solana-stake-interface/serde",
+]
+
 [dependencies]
 bincode = { workspace = true, optional = true }
 bytemuck = { workspace = true, optional = true }
@@ -55,34 +83,6 @@ solana-sdk = { path = "../sdk" }
 solana-sha256-hasher = { workspace = true }
 solana-sysvar = { path = ".", features = ["dev-context-only-utils"] }
 test-case = { workspace = true }
-
-[features]
-bincode = ["dep:bincode", "serde", "solana-stake-interface/bincode"]
-bytemuck = ["dep:bytemuck", "dep:bytemuck_derive"]
-dev-context-only-utils = ["bincode", "bytemuck", "solana-instructions-sysvar/dev-context-only-utils"]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-stake-interface/frozen-abi"
-]
-serde = [
-    "dep:serde",
-    "dep:serde_derive",
-    "solana-clock/serde",
-    "solana-epoch-rewards/serde",
-    "solana-epoch-schedule/serde",
-    "solana-fee-calculator/serde",
-    "solana-last-restart-slot/serde",
-    "solana-rent/serde",
-    "solana-slot-hashes/serde",
-    "solana-slot-history/serde",
-    "solana-stake-interface/serde",
-]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
 
 [lints]
 workspace = true

--- a/transaction-error/Cargo.toml
+++ b/transaction-error/Cargo.toml
@@ -9,6 +9,15 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+serde = ["dep:serde", "dep:serde_derive", "solana-instruction/serde"]
+
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
@@ -18,15 +27,6 @@ solana-instruction = { workspace = true, default-features = false, features = [
     "std",
 ] }
 solana-sanitize = { workspace = true }
-
-[features]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
-serde = ["dep:serde", "dep:serde_derive", "solana-instruction/serde"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
 
 [lints]
 workspace = true

--- a/transaction/Cargo.toml
+++ b/transaction/Cargo.toml
@@ -9,6 +9,37 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+bincode = [
+    "dep:bincode",
+    "dep:solana-bincode",
+    "dep:solana-signer",
+    "dep:solana-system-interface",
+    "serde",
+    "solana-message/bincode",
+]
+blake3 = ["bincode", "solana-message/blake3"]
+dev-context-only-utils = ["blake3", "precompiles", "serde", "verify"]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "dep:solana-logger",
+]
+precompiles = ["dep:solana-feature-set", "dep:solana-precompiles"]
+serde = [
+    "dep:serde",
+    "dep:serde_derive",
+    "dep:solana-short-vec",
+    "solana-message/serde",
+    "solana-signature/serde",
+]
+verify = ["blake3", "solana-signature/verify"]
+
 [dependencies]
 bincode = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
@@ -51,37 +82,3 @@ solana-sha256-hasher = { workspace = true }
 solana-transaction = { path = ".", features = ["dev-context-only-utils"] }
 solana-vote-interface = { workspace = true }
 static_assertions = { workspace = true }
-
-[features]
-bincode = [
-    "dep:bincode",
-    "dep:solana-bincode",
-    "dep:solana-signer",
-    "dep:solana-system-interface",
-    "serde",
-    "solana-message/bincode",
-]
-blake3 = [
-    "bincode",
-    "solana-message/blake3",
-]
-dev-context-only-utils = ["blake3", "precompiles", "serde", "verify"]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "dep:solana-logger",
-]
-precompiles = ["dep:solana-feature-set", "dep:solana-precompiles"]
-serde = [
-    "dep:serde",
-    "dep:serde_derive",
-    "dep:solana-short-vec",
-    "solana-message/serde",
-    "solana-signature/serde",
-]
-verify = ["blake3", "solana-signature/verify"]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]

--- a/vote-interface/Cargo.toml
+++ b/vote-interface/Cargo.toml
@@ -9,6 +9,40 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+bincode = [
+    "dep:bincode",
+    "dep:solana-serialize-utils",
+    "dep:solana-system-interface",
+    "serde",
+]
+dev-context-only-utils = [
+    "bincode",
+    "dep:arbitrary",
+    "solana-pubkey/dev-context-only-utils",
+]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "serde",
+    "solana-hash/frozen-abi",
+    "solana-pubkey/frozen-abi",
+    "solana-short-vec/frozen-abi",
+]
+serde = [
+    "dep:serde",
+    "dep:serde_derive",
+    "dep:solana-serde-varint",
+    "dep:solana-short-vec",
+    "solana-hash/serde",
+    "solana-pubkey/serde",
+]
+
 [dependencies]
 arbitrary = { workspace = true, features = ["derive"], optional = true }
 bincode = { workspace = true, optional = true }
@@ -44,40 +78,6 @@ solana-epoch-schedule = { workspace = true }
 solana-logger = { workspace = true }
 solana-pubkey = { workspace = true, features = ["dev-context-only-utils"] }
 solana-vote-interface = { path = ".", features = ["dev-context-only-utils"] }
-
-[features]
-bincode = [
-    "dep:bincode",
-    "dep:solana-serialize-utils",
-    "dep:solana-system-interface",
-    "serde"
-]
-dev-context-only-utils = [
-    "bincode",
-    "dep:arbitrary",
-    "solana-pubkey/dev-context-only-utils",
-]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "serde",
-    "solana-hash/frozen-abi",
-    "solana-pubkey/frozen-abi",
-    "solana-short-vec/frozen-abi",
-]
-serde = [
-    "dep:serde",
-    "dep:serde_derive",
-    "dep:solana-serde-varint",
-    "dep:solana-short-vec",
-    "solana-hash/serde",
-    "solana-pubkey/serde"
-]
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
-all-features = true
-rustdoc-args = ["--cfg=docsrs"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
#### Problem

`cargo-sort` had a new breaking release, which changes how things are sorted. This new version is run in CI, and reports new differences.

#### Summary of changes

Run `./cargo nightly sort --workspace` and commit the changes.