### PR TITLE
scripts: Remove bad directories from patch script

### DIFF
--- a/scripts/patch-crates-functions.sh
+++ b/scripts/patch-crates-functions.sh
@@ -77,7 +77,6 @@ crate_dirs=(
   reserved-account-keys
   reward-info
   sanitize
-  scripts
   sdk
   sdk-ids
   sdk-macro
@@ -100,7 +99,6 @@ crate_dirs=(
   system-transaction
   sysvar
   sysvar-id
-  target
   time-utils
   transaction
   transaction-error


### PR DESCRIPTION
#### Problem

The patch script is supposed to patch all crates in the SDK repo, but some of the entries are incorrect, mainly "scripts" which is used for the scripts, and "target" which is used for build artifacts.

#### Summary of changes

Remove the entries.