### PR TITLE
CI: Update git-cliff action

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -154,7 +154,7 @@ jobs:
 
       - name: Generate a changelog
         if: github.event.inputs.create_release == 'true'
-        uses: orhun/git-cliff-action@v3
+        uses: orhun/git-cliff-action@v4
         with:
           config: "scripts/cliff.toml"
           args: |


### PR DESCRIPTION
#### Problem

The git-cliff action is using v3, which uses an older version of git-cliff, which is omitting PR authors from the changelog.

#### Summary of changes

Bump the action to v4