### PR TITLE
sbpf: Fix various build warnings

### DIFF
--- a/program-entrypoint/src/lib.rs
+++ b/program-entrypoint/src/lib.rs
@@ -223,6 +223,7 @@ macro_rules! custom_heap_default {
     () => {
         #[cfg(all(not(feature = "custom-heap"), target_os = "solana"))]
         #[global_allocator]
+        #[allow(deprecated)] //we get to use deprecated pub fields
         static A: $crate::BumpAllocator = $crate::BumpAllocator {
             start: $crate::HEAP_START_ADDRESS as usize,
             len: $crate::HEAP_LENGTH,

--- a/program-memory/src/lib.rs
+++ b/program-memory/src/lib.rs
@@ -11,6 +11,7 @@ pub mod syscalls {
 }
 
 /// Check that two regions do not overlap.
+#[cfg(any(test, not(target_os = "solana")))]
 fn is_nonoverlapping(src: usize, src_len: usize, dst: usize, dst_len: usize) -> bool {
     // If the absolute distance between the ptrs is at least as big as the size of the other,
     // they do not overlap.

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -35,7 +35,7 @@ pub fn get_processed_sibling_instruction(index: usize) -> Option<Instruction> {
 /// TRANSACTION_LEVEL_STACK_HEIGHT + 1, etc...
 pub fn get_stack_height() -> usize {
     #[cfg(target_os = "solana")]
-    unsafe {
+    {
         solana_instruction::syscalls::get_stack_height()
     }
 

--- a/scripts/build-sbf.sh
+++ b/scripts/build-sbf.sh
@@ -31,6 +31,6 @@ exclude_list=(
 
 for dir in $(git ls-tree -d --name-only HEAD .); do
   if [[ ! " ${exclude_list[*]} " =~ [[:space:]]${dir}[[:space:]] ]]; then
-    (cd "$dir" && cargo build-sbf)
+    (cd "$dir" && RUSTFLAGS="-Dwarnings" cargo build-sbf)
   fi
 done

--- a/secp256r1-program/src/lib.rs
+++ b/secp256r1-program/src/lib.rs
@@ -831,12 +831,17 @@ mod target_arch {
 
 #[cfg(any(target_arch = "wasm32", target_os = "solana"))]
 mod target_arch {
-    use {solana_feature_set::FeatureSet, solana_precompile_error::PrecompileError};
+    use solana_precompile_error::PrecompileError;
 
+    #[deprecated(
+        since = "2.2.4",
+        note = "Use agave_precompiles::secp256r1::verify instead"
+    )]
+    #[allow(deprecated)]
     pub fn verify(
         _data: &[u8],
         _instruction_datas: &[&[u8]],
-        _feature_set: &FeatureSet,
+        _feature_set: &solana_feature_set::FeatureSet,
     ) -> Result<(), PrecompileError> {
         Err(PrecompileError::InvalidSignature)
     }


### PR DESCRIPTION
#### Problem

When building certain crates with `cargo build-sbf`, we generate warnings currently, which isn't great for downstream users.

#### Summary of changes

Fix the warnings, and make CI stricter by forbidding warnings.