### PR TITLE
publish: Fix git-cliff command

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -190,10 +190,7 @@ jobs:
         uses: orhun/git-cliff-action@v4
         with:
           config: "scripts/cliff.toml"
-          args: |
-            "${{ steps.publish.outputs.old_git_tag }}"..master
-            --include-path "${{ inputs.package_path }}/**"
-            --github-repo "${{ github.repository }}"
+          args: "${{ steps.publish.outputs.old_git_tag }}"..master --include-path "${{ inputs.package_path }}/**" --github-repo "${{ github.repository }}"
         env:
           OUTPUT: TEMP_CHANGELOG.md
           GITHUB_REPO: ${{ github.repository }}


### PR DESCRIPTION
#### Problem

With the new version of `git-cliff-action`, the "args" is no longer intrepreted as a list, and instead as a string, causing a failure during a publish at
https://github.com/anza-xyz/solana-sdk/actions/runs/15466949268/job/43541245695

#### Summary of changes

Put all of the args in one line