### PR TITLE
CI: Fix git cliff command again

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -190,7 +190,7 @@ jobs:
         uses: orhun/git-cliff-action@v4
         with:
           config: "scripts/cliff.toml"
-          args: "${{ steps.publish.outputs.old_git_tag }}"..master --include-path "${{ inputs.package_path }}/**" --github-repo "${{ github.repository }}"
+          args: ${{ steps.publish.outputs.old_git_tag }}..master --include-path "${{ inputs.package_path }}/**" --github-repo ${{ github.repository }}
         env:
           OUTPUT: TEMP_CHANGELOG.md
           GITHUB_REPO: ${{ github.repository }}


### PR DESCRIPTION
#### Problem

The YAML file apparently isn't parsable: https://github.com/anza-xyz/solana-sdk/actions/runs/15467354813

#### Summary of changes

Remove the quotes around the args, which seems to help pass a check.