### PR TITLE
Update solana-sdk-macro to use solana_pubkey::Pubkey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3688,9 +3688,6 @@ dependencies = [
  "bs58",
  "proc-macro2",
  "quote",
- "solana-program",
- "solana-pubkey",
- "solana-sdk",
  "syn 2.0.98",
 ]
 


### PR DESCRIPTION
- Replace ::solana_sdk::pubkey::Pubkey with ::solana_pubkey::Pubkey in SdkPubkey, Id, IdDeprecated, and Pubkeys structs
- Keep ::solana_program::pubkey::Pubkey for ProgramSdk* structs
- Add solana-pubkey dependency to Cargo.toml

Fixes #179