### PR TITLE
program-error!: Improve ToStr ergonomics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3468,6 +3468,7 @@ version = "2.2.2"
 dependencies = [
  "borsh 1.5.5",
  "num-traits",
+ "num_enum",
  "serde",
  "serde_derive",
  "solana-decode-error",

--- a/decode-error/src/lib.rs
+++ b/decode-error/src/lib.rs
@@ -21,7 +21,10 @@ use num_traits::FromPrimitive;
 /// [`ProgramError`]: https://docs.rs/solana-program-error/latest/solana_program_error/enum.ProgramError.html
 /// [`ProgramError::Custom`]: https://docs.rs/solana-program-error/latest/solana_program_error/enum.ProgramError.html#variant.Custom
 /// [`ToPrimitive`]: num_traits::ToPrimitive
-#[deprecated(since = "2.3.0", note = "Use `num_traits::FromPrimitive` instead")]
+#[deprecated(
+    since = "2.3.0",
+    note = "Implement `solana_program_error::ToStr` and `TryFrom<u32>` by hand or with `num_enum::TryFromPrimitive` instead"
+)]
 pub trait DecodeError<E> {
     fn decode_custom_error_to_enum(custom: u32) -> Option<E>
     where

--- a/program-error/Cargo.toml
+++ b/program-error/Cargo.toml
@@ -29,3 +29,6 @@ solana-instruction = { workspace = true, default-features = false, features = [
 ] }
 solana-msg = { workspace = true }
 solana-pubkey = { workspace = true, default-features = false }
+
+[dev-dependencies]
+num_enum = { workspace = true }


### PR DESCRIPTION
#### Problem

The `ToStr` trait is a bit difficult to use, forcing a lot of redundant uses of types, when programs will just want to call `err.to_str::<MyError>()`.

#### Summary of changes

Simplify the trait to not require anything, then add a generic `to_str` function directly on `ProgramError` that allows us to get the error message for a particular error type.

Also, clarify the deprecation warning on `DecodeError`.

BREAKING CHANGE: the `ToStr` trait requires fewer bounds