### PR TITLE
sysvar: Improve error handling

### DIFF
--- a/sysvar/src/lib.rs
+++ b/sysvar/src/lib.rs
@@ -110,6 +110,10 @@ pub mod slot_hashes;
 pub mod slot_history;
 pub mod stake_history;
 
+/// Return value to indicate that the `offset + length` is greater than the length of
+/// the sysvar data.
+const OFFSET_LENGTH_EXCEEDS_SYSVAR: u64 = 1;
+
 #[deprecated(
     since = "2.0.0",
     note = "please use `solana_sdk::reserved_account_keys::ReservedAccountKeys` instead"
@@ -206,7 +210,7 @@ macro_rules! impl_sysvar_get {
 
             match result {
                 $crate::__private::SUCCESS => Ok(var),
-                e => Err(e.into()),
+                _ => Err($crate::__private::ProgramError::UnsupportedSysvar),
             }
         }
     };
@@ -239,7 +243,8 @@ fn get_sysvar(
 
     match result {
         solana_program_entrypoint::SUCCESS => Ok(()),
-        e => Err(e.into()),
+        OFFSET_LENGTH_EXCEEDS_SYSVAR => Err(ProgramError::InvalidArgument),
+        _ => Err(ProgramError::UnsupportedSysvar),
     }
 }
 


### PR DESCRIPTION
### Problem

Currently the implementation of `impl_sysvar_get` macro and `get_sysvar` return a `e.into()` when the syscall fails to return success. This generated a `ProgramError::Custom(_)` error, although there are no custom errors associated with them.

### Solution

There are only two situations where a sysvar get will return an error code:
1. if you pass a wrong combination of length and offset, which tries to copy data outside the sysvar length
2. If you pass an invalid sysvar id

This PR updates the error handling to return a `ProgramError::InvalidArgument` for the first case and `ProgramError::UnsupportedSysvar` for the second.