### PR TITLE
[base3-encoding] Add solana base3 encoding crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,6 +2795,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-base3-encoding"
+version = "0.1.0"
+dependencies = [
+ "bitvec",
+]
+
+[[package]]
 name = "solana-big-mod-exp"
 version = "2.2.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "account-info",
     "address-lookup-table-interface",
     "atomic-u64",
+    "base3-encoding",
     "big-mod-exp",
     "bincode",
     "blake3-hasher",
@@ -134,6 +135,7 @@ assert_matches = "1.5.0"
 base64 = "0.22.1"
 bincode = "1.3.3"
 bitflags = { version = "2.8.0" }
+bitvec = "1.0.1"
 blake3 = "1.5.5"
 blst = "0.3.14"
 blstrs = "0.7.1"
@@ -208,6 +210,7 @@ solana-account = { path = "account", version = "2.2.1" }
 solana-account-info = { path = "account-info", version = "2.2.1" }
 solana-address-lookup-table-interface = { path = "address-lookup-table-interface", version = "2.2.2" }
 solana-atomic-u64 = { path = "atomic-u64", version = "2.2.1" }
+solana-base3-encoding = { path = "base3-encoding", version = "0.1.0" }
 solana-big-mod-exp = { path = "big-mod-exp", version = "2.2.1" }
 solana-bincode = { path = "bincode", version = "2.2.1" }
 solana-blake3-hasher = { path = "blake3-hasher", version = "2.2.1" }

--- a/base3-encoding/Cargo.toml
+++ b/base3-encoding/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "solana-base3-encoding"
+description = "Solana Base3 Encoding"
+documentation = "https://docs.rs/solana-base3-encoding"
+version = "0.1.0"
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[features]
+
+[dependencies]
+bitvec = { workspace = true }
+
+[dev-dependencies]
+
+[lints]
+workspace = true

--- a/base3-encoding/Cargo.toml
+++ b/base3-encoding/Cargo.toml
@@ -9,10 +9,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[features]
-
 [dependencies]
-bitvec = { workspace = true }
+bitvec = { version = "1.0.1", optional = true }
+
+[features]
+default = []
+bitvec = ["dep:bitvec"]
 
 [dev-dependencies]
 

--- a/base3-encoding/Cargo.toml
+++ b/base3-encoding/Cargo.toml
@@ -9,12 +9,12 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[features]
+bitvec = ["dep:bitvec"]
+default = []
+
 [dependencies]
 bitvec = { version = "1.0.1", optional = true }
-
-[features]
-default = []
-bitvec = ["dep:bitvec"]
 
 [dev-dependencies]
 

--- a/base3-encoding/src/lib.rs
+++ b/base3-encoding/src/lib.rs
@@ -218,8 +218,7 @@ pub use bitvec_support::*;
 
 #[cfg(feature = "bitvec")]
 mod bitvec_support {
-    use super::*;
-    use bitvec::prelude::*;
+    use {super::*, bitvec::prelude::*};
 
     /// A wrapper to encode two `BitVec`s into a single `Vec<u8>`.
     pub fn encode(
@@ -275,9 +274,10 @@ mod tests {
 
     #[cfg(feature = "bitvec")]
     mod bitvec_tests {
-        use super::super::bitvec_support::*;
-        use super::*;
-        use bitvec::prelude::*;
+        use {
+            super::{super::bitvec_support::*, *},
+            bitvec::prelude::*,
+        };
 
         fn create_test_data(len: usize) -> (BitVec<u8, Lsb0>, BitVec<u8, Lsb0>) {
             let mut base = BitVec::with_capacity(len);

--- a/base3-encoding/src/lib.rs
+++ b/base3-encoding/src/lib.rs
@@ -285,7 +285,7 @@ mod tests {
 
     #[test]
     fn test_round_trip_exact_chunk() {
-        let (base, fallback) = create_test_data(BASE3_SYMBOL_PER_CHUNK); // 80
+        let (base, fallback) = create_test_data(BASE3_SYMBOL_PER_CHUNK); // 5
         let encoded = encode(&base, &fallback).unwrap();
         let (decoded_base, decoded_fallback) = decode(&encoded, BASE3_SYMBOL_PER_CHUNK).unwrap();
         assert_eq!(base, decoded_base);
@@ -294,18 +294,18 @@ mod tests {
 
     #[test]
     fn test_round_trip_multi_chunk_partial() {
-        let (base, fallback) = create_test_data(95); // 1 full chunk, 1 partial
+        let (base, fallback) = create_test_data(7); // 1 full chunk, 1 partial
         let encoded = encode(&base, &fallback).unwrap();
-        let (decoded_base, decoded_fallback) = decode(&encoded, 95).unwrap();
+        let (decoded_base, decoded_fallback) = decode(&encoded, 7).unwrap();
         assert_eq!(base, decoded_base);
         assert_eq!(fallback, decoded_fallback);
     }
 
     #[test]
     fn test_round_trip_multi_chunk_exact() {
-        let (base, fallback) = create_test_data(160); // 2 full chunks
+        let (base, fallback) = create_test_data(10); // 2 full chunks
         let encoded = encode(&base, &fallback).unwrap();
-        let (decoded_base, decoded_fallback) = decode(&encoded, 160).unwrap();
+        let (decoded_base, decoded_fallback) = decode(&encoded, 10).unwrap();
         assert_eq!(base, decoded_base);
         assert_eq!(fallback, decoded_fallback);
     }

--- a/base3-encoding/src/lib.rs
+++ b/base3-encoding/src/lib.rs
@@ -82,7 +82,7 @@ pub fn encode_from_bytes(
         .ok_or(EncodeError::ArithmeticOverflow)?;
 
     let capacity = total_byte_length
-        .checked_add(2)
+        .checked_add(2) // we use 2 bytes to hold the bit lengths
         .ok_or(EncodeError::ArithmeticOverflow)?;
     let mut result = Vec::with_capacity(capacity);
 

--- a/base3-encoding/src/lib.rs
+++ b/base3-encoding/src/lib.rs
@@ -1,0 +1,329 @@
+//! Provides a space-efficient encoding scheme for two `BitVec`s.
+//!
+//! This module implements a compression algorithm to encode two boolean vectors
+//! (`BitVec`) of the same length into a single byte vector (`Vec<u8>`). It achieves
+//! this by mapping each pair of corresponding bits from the input vectors into a
+//! single ternary (base-3) digit.
+//!
+//! # Principle
+//!
+//! The core idea is to treat pairs of booleans as a single unit with three
+//! valid states, which can be represented by the digits 0, 1, and 2.
+//!
+//! - `(false, false)` -> `0`
+//! - `(true, false)`  -> `1`
+//! - `(false, true)`  -> `2`
+//!
+//! The combination `(true, true)` is considered invalid and will result in an error
+//! during encoding.
+//!
+//! These ternary digits are then packed into 128-bit integers (`u128`) for compact
+//! storage. Since `3^80 < 2^128`, each `u128` can hold 80 ternary digits.
+//!
+//! # Encoded Format
+//!
+//! The resulting `Vec<u8>` has a simple structure:
+//! 1.  **Length Prefix (2 bytes)**: A `u16` in big-endian format storing the original
+//!     number of bits (i.e., the length of the input vectors).
+//! 2.  **Data Payload (N * 16 bytes)**: A sequence of 16-byte chunks, where each
+//!     chunk is the big-endian representation of a `u128` value containing the
+//!     encoded data.
+
+use bitvec::prelude::*;
+
+/// An error that can occur during the encoding process.
+#[derive(Debug, PartialEq, Eq)]
+pub enum EncodeError {
+    /// The provided bit-vectors have unmatching lengths.
+    MismatchedLengths,
+    /// The combination `(true, true)` was found, which is not allowed.
+    InvalidBitCombination,
+    /// The length of the input vectors exceeds `u16::MAX` (65,535).
+    LengthExceedsLimit,
+    /// Arithmetic overflow.
+    ArithmeticOverflow,
+}
+
+const BASE3_SYMBOL_PER_CHUNK: usize = 80;
+const ENCODED_BYTES_PER_CHUNK: usize = 16; // std::mem::size_of::<u128>()
+
+/// Encodes two `BitVec`s into a single `Vec<u8>`.
+///
+/// This function takes two bit vectors, `bit_vec_base` and `bit_vec_fallback`,
+/// and combines them using a ternary encoding scheme.
+///
+/// # Algorithm
+/// 1.  Validates that the input vectors have the same length and do not exceed
+///     `u16::MAX`.
+/// 2.  Writes the length of the vectors as a 2-byte big-endian `u16` to the
+///     output buffer.
+/// 3.  Iterates through the input vectors in chunks of 80 bits.
+/// 4.  For each chunk, it converts the 80 bit-pairs into 80 ternary digits and
+///     constructs a `u128` number from them.
+/// 5.  This `u128` number is appended to the output buffer as 16 big-endian bytes.
+///
+/// # Errors
+/// Returns an `EncodeError` if:
+/// - The input vectors have different lengths (`MismatchedLengths`).
+/// - A `(true, true)` bit pair is encountered (`InvalidBitCombination`).
+/// - The input vector length is greater than 65,535 (`LengthExceedsLimit`).
+pub fn encode(
+    bit_vec_base: &BitVec<u8, Lsb0>,
+    bit_vec_fallback: &BitVec<u8, Lsb0>,
+) -> Result<Vec<u8>, EncodeError> {
+    let bit_vec_len = bit_vec_base.len();
+    if bit_vec_len != bit_vec_fallback.len() {
+        return Err(EncodeError::MismatchedLengths);
+    }
+
+    if bit_vec_len > u16::MAX as usize {
+        return Err(EncodeError::LengthExceedsLimit);
+    }
+
+    let total_u128_length = bit_vec_len
+        .checked_add(BASE3_SYMBOL_PER_CHUNK - 1)
+        .ok_or(EncodeError::ArithmeticOverflow)?
+        .checked_div(BASE3_SYMBOL_PER_CHUNK)
+        .ok_or(EncodeError::ArithmeticOverflow)?; // computes `ceil(bit_vec_len / 80)`
+
+    let total_byte_length = total_u128_length
+        .checked_mul(ENCODED_BYTES_PER_CHUNK)
+        .ok_or(EncodeError::ArithmeticOverflow)?;
+
+    let capacity = total_byte_length
+        .checked_add(2)
+        .ok_or(EncodeError::ArithmeticOverflow)?;
+    let mut result = Vec::with_capacity(capacity);
+
+    result.extend_from_slice(&(bit_vec_base.len() as u16).to_be_bytes());
+
+    // Process the bits of `bit_vec_base` and `bit_vec_fallback` in chunks of 80 bits
+    for (base_chunk, fallback_chunk) in bit_vec_base.chunks(80).zip(bit_vec_fallback.chunks(80)) {
+        let mut block_num: u128 = 0; // base10 number assigned for each chunk block
+
+        // Iterate over corresponding bits in the chunk
+        for (base_bit, fallback_bit) in base_chunk.iter().zip(fallback_chunk.iter()) {
+            block_num *= 3;
+            block_num += match (*base_bit, *fallback_bit) {
+                (false, false) => 0u128,
+                (true, false) => 1u128,
+                (false, true) => 2u128,
+                (true, true) => return Err(EncodeError::InvalidBitCombination),
+            };
+        }
+
+        result.extend_from_slice(&block_num.to_be_bytes());
+    }
+
+    Ok(result)
+}
+
+/// An error that can occur during the decoding process.
+#[derive(Debug, PartialEq, Eq)]
+pub enum DecodeError {
+    /// The byte slice is too short to contain a valid 2-byte length prefix.
+    InvalidLengthPrefix,
+    /// The data payload is not a multiple of the 16-byte block size, indicating
+    /// potential corruption.
+    CorruptDataPayload,
+}
+
+/// Decodes a byte vector created by `encode` back into two `BitVec`s.
+///
+/// This function reverses the process of the `encode` function, reconstructing
+/// the original two bit vectors from a byte slice.
+///
+/// # Algorithm
+/// 1.  Reads the first 2 bytes to determine the `total_bits` of the original data.
+/// 2.  Validates that the remaining data payload is a multiple of 16 bytes.
+/// 3.  Iterates through the data payload in 16-byte chunks.
+/// 4.  For each chunk, it reconstructs the `u128` value.
+/// 5.  It uses modulo-3 arithmetic to decode the `u128` back into ternary digits.
+///     The number of digits to decode is determined by the number of bits
+///     remaining to be decoded, which correctly handles the final, partial chunk.
+/// 6.  Each ternary digit is mapped back to its original `(base_bit, fallback_bit)`
+///     pair and pushed to the respective output vectors.
+///
+/// # Errors
+/// Returns a `DecodeError` if:
+/// - The input byte slice is less than 2 bytes long (`InvalidLengthPrefix`).
+/// - The data payload (after the length prefix) is not a multiple of 16
+///   (`CorruptDataPayload`).
+#[allow(clippy::type_complexity)]
+pub fn decode(bytes: &[u8]) -> Result<(BitVec<u8, Lsb0>, BitVec<u8, Lsb0>), DecodeError> {
+    if bytes.len() < 2 {
+        return Err(DecodeError::InvalidLengthPrefix);
+    }
+    let mut len_arr = [0u8; 2];
+    len_arr.copy_from_slice(&bytes[..2]);
+    let total_bits = u16::from_be_bytes(len_arr) as usize;
+
+    let data_bytes = &bytes[2..];
+    if data_bytes
+        .len()
+        .checked_rem(ENCODED_BYTES_PER_CHUNK)
+        .unwrap()
+        != 0
+    {
+        return Err(DecodeError::CorruptDataPayload);
+    }
+
+    let mut bit_vec_base = BitVec::with_capacity(total_bits);
+    let mut bit_vec_fallback = BitVec::with_capacity(total_bits);
+
+    let mut bits_remaining = total_bits;
+    for block_bytes in data_bytes.chunks_exact(ENCODED_BYTES_PER_CHUNK) {
+        if bits_remaining == 0 {
+            break;
+        }
+
+        let mut block_arr = [0u8; ENCODED_BYTES_PER_CHUNK];
+        block_arr.copy_from_slice(block_bytes);
+        let mut block_num = u128::from_be_bytes(block_arr);
+
+        let bits_in_this_chunk = bits_remaining.min(BASE3_SYMBOL_PER_CHUNK);
+        let mut decoded_chunk_rev = Vec::with_capacity(bits_in_this_chunk);
+
+        for _ in 0..bits_in_this_chunk {
+            let remainder = block_num.checked_rem(3).unwrap() as u8;
+            block_num = block_num.checked_div(3).unwrap(); // div by 3 will never panic
+
+            let (base_bit, fallback_bit) = match remainder {
+                0 => (false, false),
+                1 => (true, false),
+                2 => (false, true),
+                _ => unreachable!(),
+            };
+            decoded_chunk_rev.push((base_bit, fallback_bit));
+        }
+
+        decoded_chunk_rev.reverse();
+
+        for (base_bit, fallback_bit) in decoded_chunk_rev {
+            bit_vec_base.push(base_bit);
+            bit_vec_fallback.push(fallback_bit);
+        }
+
+        bits_remaining = bits_remaining.checked_sub(bits_in_this_chunk).unwrap();
+    }
+
+    bit_vec_base.truncate(total_bits);
+    bit_vec_fallback.truncate(total_bits);
+
+    Ok((bit_vec_base, bit_vec_fallback))
+}
+
+// The tests module remains the same as you provided.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_test_data(len: usize) -> (BitVec<u8, Lsb0>, BitVec<u8, Lsb0>) {
+        let mut base = BitVec::with_capacity(len);
+        let mut fallback = BitVec::with_capacity(len);
+        for i in 0..len {
+            match i % 3 {
+                0 => {
+                    // (false, false) -> 0
+                    base.push(false);
+                    fallback.push(false);
+                }
+                1 => {
+                    // (true, false) -> 1
+                    base.push(true);
+                    fallback.push(false);
+                }
+                _ => {
+                    // (false, true) -> 2
+                    base.push(false);
+                    fallback.push(true);
+                }
+            }
+        }
+        (base, fallback)
+    }
+
+    #[test]
+    fn test_round_trip_empty() {
+        let (base, fallback) = create_test_data(0);
+        let encoded = encode(&base, &fallback).unwrap();
+        assert_eq!(encoded, vec![0, 0]);
+        let (decoded_base, decoded_fallback) = decode(&encoded).unwrap();
+        assert_eq!(base, decoded_base);
+        assert_eq!(fallback, decoded_fallback);
+    }
+
+    #[test]
+    fn test_round_trip_small() {
+        let (base, fallback) = create_test_data(10);
+        let encoded = encode(&base, &fallback).unwrap();
+        let (decoded_base, decoded_fallback) = decode(&encoded).unwrap();
+        assert_eq!(base, decoded_base);
+        assert_eq!(fallback, decoded_fallback);
+    }
+
+    #[test]
+    fn test_round_trip_exact_chunk() {
+        let (base, fallback) = create_test_data(BASE3_SYMBOL_PER_CHUNK); // 80
+        let encoded = encode(&base, &fallback).unwrap();
+        let (decoded_base, decoded_fallback) = decode(&encoded).unwrap();
+        assert_eq!(base, decoded_base);
+        assert_eq!(fallback, decoded_fallback);
+    }
+
+    #[test]
+    fn test_round_trip_multi_chunk_partial() {
+        let (base, fallback) = create_test_data(95); // 1 full chunk, 1 partial
+        let encoded = encode(&base, &fallback).unwrap();
+        let (decoded_base, decoded_fallback) = decode(&encoded).unwrap();
+        assert_eq!(base, decoded_base);
+        assert_eq!(fallback, decoded_fallback);
+    }
+
+    #[test]
+    fn test_round_trip_multi_chunk_exact() {
+        let (base, fallback) = create_test_data(160); // 2 full chunks
+        let encoded = encode(&base, &fallback).unwrap();
+        let (decoded_base, decoded_fallback) = decode(&encoded).unwrap();
+        assert_eq!(base, decoded_base);
+        assert_eq!(fallback, decoded_fallback);
+    }
+
+    #[test]
+    fn test_encode_error_mismatched_lengths() {
+        let (base, _) = create_test_data(10);
+        let (_, fallback) = create_test_data(11);
+        let result = encode(&base, &fallback);
+        assert_eq!(result, Err(EncodeError::MismatchedLengths));
+    }
+
+    #[test]
+    fn test_encode_error_invalid_combination() {
+        let mut base = BitVec::<u8, Lsb0>::new();
+        base.push(false);
+        base.push(true);
+
+        let mut fallback = BitVec::<u8, Lsb0>::new();
+        fallback.push(false);
+        fallback.push(true);
+
+        let result = encode(&base, &fallback);
+        assert_eq!(result, Err(EncodeError::InvalidBitCombination));
+    }
+
+    #[test]
+    fn test_decode_error_invalid_length_prefix() {
+        let bytes = vec![1];
+        let result = decode(&bytes);
+        assert_eq!(result, Err(DecodeError::InvalidLengthPrefix));
+    }
+
+    #[test]
+    fn test_decode_error_corrupt_payload() {
+        let (base, fallback) = create_test_data(10);
+        let mut encoded = encode(&base, &fallback).unwrap();
+        encoded.pop(); // Make the payload an invalid length
+        let result = decode(&encoded);
+        assert_eq!(result, Err(DecodeError::CorruptDataPayload));
+    }
+}

--- a/base3-encoding/src/lib.rs
+++ b/base3-encoding/src/lib.rs
@@ -65,6 +65,8 @@ pub fn encode_from_bytes(
         .checked_div(8)
         .ok_or(EncodeError::ArithmeticOverflow)?;
 
+    // If `base_bytes.len()` or `fallback_bytes.len()` is greater than `required_bytes`,
+    // the extra bytes will simply be ignored.
     if base_bytes.len() < required_bytes || fallback_bytes.len() < required_bytes {
         return Err(EncodeError::MismatchedLengths);
     }

--- a/base3-encoding/src/lib.rs
+++ b/base3-encoding/src/lib.rs
@@ -103,13 +103,17 @@ pub fn encode(
 
         // Iterate over corresponding bits in the chunk
         for (base_bit, fallback_bit) in base_chunk.iter().zip(fallback_chunk.iter()) {
-            block_num *= 3;
-            block_num += match (*base_bit, *fallback_bit) {
+            let chunk_num = match (*base_bit, *fallback_bit) {
                 (false, false) => 0u128,
                 (true, false) => 1u128,
                 (false, true) => 2u128,
                 (true, true) => return Err(EncodeError::InvalidBitCombination),
             };
+            block_num = block_num
+                .checked_mul(3)
+                .ok_or(EncodeError::ArithmeticOverflow)?
+                .checked_add(chunk_num)
+                .ok_or(EncodeError::ArithmeticOverflow)?;
         }
 
         result.extend_from_slice(&block_num.to_be_bytes());

--- a/base3-encoding/src/lib.rs
+++ b/base3-encoding/src/lib.rs
@@ -1,7 +1,7 @@
-//! Provides a space-efficient encoding scheme for two `BitVec`s.
+//! Provides a space-efficient encoding scheme for two boolean vectors.
 //!
 //! This module implements a compression algorithm to encode two boolean vectors
-//! (`BitVec`) of the same length into a single byte vector (`Vec<u8>`). It achieves
+//! of the same length into a single byte vector (`Vec<u8>`). It achieves
 //! this by mapping each pair of corresponding bits from the input vectors into a
 //! single ternary (base-3) digit.
 //!
@@ -28,8 +28,6 @@
 //! 2.  **Data Payload (N * 1 byte)**: A sequence of single bytes, where each
 //!     byte is a `u8` value containing 5 encoded ternary digits.
 
-use bitvec::prelude::*;
-
 /// An error that can occur during the encoding process.
 #[derive(Debug, PartialEq, Eq)]
 pub enum EncodeError {
@@ -47,41 +45,31 @@ pub enum EncodeError {
 const BASE3_SYMBOL_PER_CHUNK: usize = 5;
 const ENCODED_BYTES_PER_CHUNK: usize = 1; // std::mem::size_of::<u8>()
 
-/// Encodes two `BitVec`s into a single `Vec<u8>`.
+/// Encodes two boolean vectors, provided as byte slices, into a single `Vec<u8>`.
 ///
-/// This function takes two bit vectors, `bit_vec_base` and `bit_vec_fallback`,
-/// and combines them using a ternary encoding scheme.
-///
-/// # Algorithm
-/// 1.  Validates that the input vectors have the same length and do not exceed
-///     `u16::MAX`.
-/// 2.  Writes the length of the vectors as a 2-byte little-endian `u16` to the
-///     output buffer.
-/// 3.  Iterates through the input vectors in chunks of 5 bits.
-/// 4.  For each chunk, it converts the 5 bit-pairs into 5 ternary digits and
-///     constructs a `u8` number from them. The first bit-pair becomes the least
-///     significant ternary digit.
-/// 5.  This `u8` number is appended to the output buffer as a single byte.
-///
-/// # Errors
-/// Returns an `EncodeError` if:
-/// - The input vectors have different lengths (`MismatchedLengths`).
-/// - A `(true, true)` bit pair is encountered (`InvalidBitCombination`).
-/// - The input vector length is greater than 65,535 (`LengthExceedsLimit`).
-pub fn encode(
-    bit_vec_base: &BitVec<u8, Lsb0>,
-    bit_vec_fallback: &BitVec<u8, Lsb0>,
+/// # Parameters
+/// - `base_bytes`: The byte slice for the base boolean vector.
+/// - `fallback_bytes`: The byte slice for the fallback boolean vector.
+/// - `num_bits`: The exact number of bits from the start of the slices to encode.
+pub fn encode_from_bytes(
+    base_bytes: &[u8],
+    fallback_bytes: &[u8],
+    num_bits: usize,
 ) -> Result<Vec<u8>, EncodeError> {
-    let bit_vec_len = bit_vec_base.len();
-    if bit_vec_len != bit_vec_fallback.len() {
+    if num_bits > u16::MAX as usize {
+        return Err(EncodeError::LengthExceedsLimit);
+    }
+    let required_bytes = num_bits
+        .checked_add(7)
+        .ok_or(EncodeError::ArithmeticOverflow)?
+        .checked_div(8)
+        .ok_or(EncodeError::ArithmeticOverflow)?;
+
+    if base_bytes.len() < required_bytes || fallback_bytes.len() < required_bytes {
         return Err(EncodeError::MismatchedLengths);
     }
 
-    if bit_vec_len > u16::MAX as usize {
-        return Err(EncodeError::LengthExceedsLimit);
-    }
-
-    let total_u8_length = bit_vec_len
+    let total_u8_length = num_bits
         .checked_add(BASE3_SYMBOL_PER_CHUNK - 1)
         .ok_or(EncodeError::ArithmeticOverflow)?
         .checked_div(BASE3_SYMBOL_PER_CHUNK)
@@ -96,19 +84,21 @@ pub fn encode(
         .ok_or(EncodeError::ArithmeticOverflow)?;
     let mut result = Vec::with_capacity(capacity);
 
-    result.extend_from_slice(&(bit_vec_base.len() as u16).to_le_bytes());
+    result.extend_from_slice(&(num_bits as u16).to_le_bytes());
 
-    // Process the bits of `bit_vec_base` and `bit_vec_fallback` in chunks of 5 bits
-    for (base_chunk, fallback_chunk) in bit_vec_base
-        .chunks(BASE3_SYMBOL_PER_CHUNK)
-        .zip(bit_vec_fallback.chunks(BASE3_SYMBOL_PER_CHUNK))
-    {
-        let mut block_num: u8 = 0; // base10 number assigned for each chunk block
+    for chunk_index in 0..total_u8_length {
+        let mut block_num: u8 = 0;
+        let start_bit = chunk_index * BASE3_SYMBOL_PER_CHUNK;
+        let end_bit = (start_bit + BASE3_SYMBOL_PER_CHUNK).min(num_bits);
 
-        // Iterate over corresponding bits in the chunk in reverse to make the first
-        // bit-pair the least significant digit
-        for (base_bit, fallback_bit) in base_chunk.iter().zip(fallback_chunk.iter()).rev() {
-            let chunk_num = match (*base_bit, *fallback_bit) {
+        for i in (start_bit..end_bit).rev() {
+            let byte_idx = i / 8;
+            let bit_idx = i % 8;
+
+            let base_bit = (base_bytes[byte_idx] >> bit_idx) & 1 == 1;
+            let fallback_bit = (fallback_bytes[byte_idx] >> bit_idx) & 1 == 1;
+
+            let chunk_num = match (base_bit, fallback_bit) {
                 (false, false) => 0u8,
                 (true, false) => 1u8,
                 (false, true) => 2u8,
@@ -120,8 +110,7 @@ pub fn encode(
                 .checked_add(chunk_num)
                 .ok_or(EncodeError::ArithmeticOverflow)?;
         }
-
-        result.extend_from_slice(&block_num.to_le_bytes());
+        result.push(block_num);
     }
 
     Ok(result)
@@ -134,40 +123,15 @@ pub enum DecodeError {
     InvalidLengthPrefix,
     /// The data payload does not have the expected length.
     CorruptDataPayload,
+    /// Arithmetic overflow.
+    ArithmeticOverflow,
 }
 
-/// Decodes a byte vector created by `encode` back into two `BitVec`s.
-///
-/// This function reverses the process of the `encode` function, reconstructing
-/// the original two bit vectors from a byte slice.
-///
-/// # Parameters
-/// - `bytes`: The byte slice containing the encoded data.
-/// - `max_len`: The maximum expected length of the decoded bit vectors. This is a
-///   security parameter to prevent DoS attacks from maliciously large length headers.
-///
-/// # Algorithm
-/// 1.  Reads the first 2 bytes to determine the `total_bits` of the original data.
-/// 2.  Validates that `total_bits` does not exceed `max_len`.
-/// 3.  Validates that the remaining data payload is a multiple of 1 byte.
-/// 4.  Iterates through the data payload in 1-byte chunks.
-/// 5.  For each chunk, it reconstructs the `u8` value.
-/// 6.  It uses modulo-3 arithmetic to decode the `u8` back into ternary digits.
-///     The number of digits to decode is determined by the number of bits
-///     remaining to be decoded, which correctly handles the final, partial chunk.
-/// 7.  Each ternary digit is mapped back to its original `(base_bit, fallback_bit)`
-///     pair and pushed to the respective output vectors.
-///
-/// # Errors
-/// Returns a `DecodeError` if:
-/// - The input byte slice is too short to contain a valid 2-byte length prefix (`InvalidLengthPrefix`).
-/// - The decoded length from the header exceeds the `max_len` parameter (`CorruptDataPayload`).
-/// - The data payload (after the length prefix) is not a multiple of the expected chunk size (`CorruptDataPayload`).
-#[allow(clippy::type_complexity)]
-pub fn decode(
+/// Decodes an encoded byte slice back into two byte vectors.
+pub fn decode_to_bytes(
     bytes: &[u8],
     max_len: usize,
-) -> Result<(BitVec<u8, Lsb0>, BitVec<u8, Lsb0>), DecodeError> {
+) -> Result<(Vec<u8>, Vec<u8>, usize), DecodeError> {
     if bytes.len() < 2 {
         return Err(DecodeError::InvalidLengthPrefix);
     }
@@ -175,46 +139,45 @@ pub fn decode(
     len_arr.copy_from_slice(&bytes[..2]);
     let total_bits = u16::from_le_bytes(len_arr) as usize;
 
-    // if the total bits exceeds the maximum allowed length, return with error early
     if total_bits > max_len {
         return Err(DecodeError::CorruptDataPayload);
     }
 
     let data_bytes = &bytes[2..];
 
-    // Calculate the expected number of chunks and the expected payload length
     let expected_num_chunks = total_bits
         .checked_add(BASE3_SYMBOL_PER_CHUNK - 1)
         .and_then(|n| n.checked_div(BASE3_SYMBOL_PER_CHUNK))
-        .ok_or(DecodeError::CorruptDataPayload)?; // Should not overflow due to max_len check
+        .ok_or(DecodeError::CorruptDataPayload)?;
 
     let expected_payload_len = expected_num_chunks
         .checked_mul(ENCODED_BYTES_PER_CHUNK)
         .ok_or(DecodeError::CorruptDataPayload)?;
 
-    // Check if the actual payload length matches the expected length
     if data_bytes.len() != expected_payload_len {
         return Err(DecodeError::CorruptDataPayload);
     }
 
-    let mut bit_vec_base = BitVec::with_capacity(total_bits);
-    let mut bit_vec_fallback = BitVec::with_capacity(total_bits);
+    let decoded_byte_len = total_bits
+        .checked_add(7)
+        .ok_or(DecodeError::ArithmeticOverflow)?
+        .checked_div(8)
+        .ok_or(DecodeError::ArithmeticOverflow)?;
+    let mut base_bytes = vec![0u8; decoded_byte_len];
+    let mut fallback_bytes = vec![0u8; decoded_byte_len];
 
     let mut bits_remaining = total_bits;
-    for block_bytes in data_bytes.chunks_exact(ENCODED_BYTES_PER_CHUNK) {
-        if bits_remaining == 0 {
-            break;
-        }
-
-        let mut block_arr = [0u8; ENCODED_BYTES_PER_CHUNK];
-        block_arr.copy_from_slice(block_bytes);
-        let mut block_num = u8::from_le_bytes(block_arr);
-
+    for (i, block_byte) in data_bytes.iter().enumerate() {
+        let mut block_num = *block_byte;
         let bits_in_this_chunk = bits_remaining.min(BASE3_SYMBOL_PER_CHUNK);
 
-        for _ in 0..bits_in_this_chunk {
-            let remainder = block_num.checked_rem(3).unwrap();
-            block_num = block_num.checked_div(3).unwrap();
+        for j in 0..bits_in_this_chunk {
+            let remainder = block_num % 3;
+            block_num /= 3;
+
+            let bit_index = i * BASE3_SYMBOL_PER_CHUNK + j;
+            let byte_idx = bit_index / 8;
+            let bit_idx = bit_index % 8;
 
             let (base_bit, fallback_bit) = match remainder {
                 0 => (false, false),
@@ -222,138 +185,202 @@ pub fn decode(
                 2 => (false, true),
                 _ => unreachable!(),
             };
-            bit_vec_base.push(base_bit);
-            bit_vec_fallback.push(fallback_bit);
-        }
 
-        bits_remaining = bits_remaining.checked_sub(bits_in_this_chunk).unwrap();
+            if base_bit {
+                base_bytes[byte_idx] |= 1 << bit_idx;
+            }
+            if fallback_bit {
+                fallback_bytes[byte_idx] |= 1 << bit_idx;
+            }
+        }
+        bits_remaining -= bits_in_this_chunk;
     }
 
-    bit_vec_base.truncate(total_bits);
-    bit_vec_fallback.truncate(total_bits);
+    Ok((base_bytes, fallback_bytes, total_bits))
+}
 
-    Ok((bit_vec_base, bit_vec_fallback))
+#[cfg(feature = "bitvec")]
+pub use bitvec_support::*;
+
+#[cfg(feature = "bitvec")]
+mod bitvec_support {
+    use super::*;
+    use bitvec::prelude::*;
+
+    /// A wrapper to encode two `BitVec`s into a single `Vec<u8>`.
+    pub fn encode(
+        bit_vec_base: &BitVec<u8, Lsb0>,
+        bit_vec_fallback: &BitVec<u8, Lsb0>,
+    ) -> Result<Vec<u8>, EncodeError> {
+        if bit_vec_base.len() != bit_vec_fallback.len() {
+            return Err(EncodeError::MismatchedLengths);
+        }
+        encode_from_bytes(
+            bit_vec_base.as_raw_slice(),
+            bit_vec_fallback.as_raw_slice(),
+            bit_vec_base.len(),
+        )
+    }
+
+    /// A wrapper to decode a byte vector back into two `BitVec`s.
+    #[allow(clippy::type_complexity)]
+    pub fn decode(
+        bytes: &[u8],
+        max_len: usize,
+    ) -> Result<(BitVec<u8, Lsb0>, BitVec<u8, Lsb0>), DecodeError> {
+        let (base_bytes, fallback_bytes, total_bits) = decode_to_bytes(bytes, max_len)?;
+
+        let mut base_vec = BitVec::from_vec(base_bytes);
+        base_vec.truncate(total_bits);
+
+        let mut fallback_vec = BitVec::from_vec(fallback_bytes);
+        fallback_vec.truncate(total_bits);
+
+        Ok((base_vec, fallback_vec))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn create_test_data(len: usize) -> (BitVec<u8, Lsb0>, BitVec<u8, Lsb0>) {
-        let mut base = BitVec::with_capacity(len);
-        let mut fallback = BitVec::with_capacity(len);
-        for i in 0..len {
-            match i % 3 {
-                0 => {
-                    // (false, false) -> 0
-                    base.push(false);
-                    fallback.push(false);
-                }
-                1 => {
-                    // (true, false) -> 1
-                    base.push(true);
-                    fallback.push(false);
-                }
-                _ => {
-                    // (false, true) -> 2
-                    base.push(false);
-                    fallback.push(true);
+    #[test]
+    fn test_bytes_round_trip_small() {
+        let num_bits = 10;
+        let base_bytes = vec![0b0100_1001, 0b0000_0001]; // Corresponds to bits [1,0,0,1,0,0,1,0,1,0]
+        let fallback_bytes = vec![0b1010_0110, 0b0000_0000]; // Corresponds to bits [0,1,1,0,0,1,0,1,0,0]
+
+        let encoded = encode_from_bytes(&base_bytes, &fallback_bytes, num_bits).unwrap();
+        let (decoded_base, decoded_fallback, decoded_bits) =
+            decode_to_bytes(&encoded, num_bits).unwrap();
+
+        assert_eq!(decoded_bits, num_bits);
+        assert_eq!(base_bytes, decoded_base);
+        assert_eq!(fallback_bytes, decoded_fallback); // Compare relevant part
+    }
+
+    #[cfg(feature = "bitvec")]
+    mod bitvec_tests {
+        use super::*;
+        use bitvec::prelude::*;
+
+        fn create_test_data(len: usize) -> (BitVec<u8, Lsb0>, BitVec<u8, Lsb0>) {
+            let mut base = BitVec::with_capacity(len);
+            let mut fallback = BitVec::with_capacity(len);
+            for i in 0..len {
+                match i % 3 {
+                    0 => {
+                        base.push(false);
+                        fallback.push(false);
+                    }
+                    1 => {
+                        base.push(true);
+                        fallback.push(false);
+                    }
+                    _ => {
+                        base.push(false);
+                        fallback.push(true);
+                    }
                 }
             }
+            (base, fallback)
         }
-        (base, fallback)
-    }
 
-    #[test]
-    fn test_round_trip_empty() {
-        let (base, fallback) = create_test_data(0);
-        let encoded = encode(&base, &fallback).unwrap();
-        assert_eq!(encoded, vec![0, 0]);
-        let (decoded_base, decoded_fallback) = decode(&encoded, 0).unwrap();
-        assert_eq!(base, decoded_base);
-        assert_eq!(fallback, decoded_fallback);
-    }
+        #[test]
+        fn test_bitvec_round_trip_empty() {
+            let (base, fallback) = create_test_data(0);
+            let encoded = encode(&base, &fallback).unwrap();
+            assert_eq!(encoded, vec![0, 0]);
+            let (decoded_base, decoded_fallback) = decode(&encoded, 0).unwrap();
+            assert_eq!(base, decoded_base);
+            assert_eq!(fallback, decoded_fallback);
+        }
 
-    #[test]
-    fn test_round_trip_small() {
-        let (base, fallback) = create_test_data(10);
-        let encoded = encode(&base, &fallback).unwrap();
-        let (decoded_base, decoded_fallback) = decode(&encoded, 10).unwrap();
-        assert_eq!(base, decoded_base);
-        assert_eq!(fallback, decoded_fallback);
-    }
+        #[test]
+        fn test_bitvec_round_trip_small() {
+            let (base, fallback) = create_test_data(10);
+            let encoded = encode(&base, &fallback).unwrap();
+            let (decoded_base, decoded_fallback) = decode(&encoded, 10).unwrap();
+            assert_eq!(base, decoded_base);
+            assert_eq!(fallback, decoded_fallback);
+        }
 
-    #[test]
-    fn test_round_trip_exact_chunk() {
-        let (base, fallback) = create_test_data(BASE3_SYMBOL_PER_CHUNK); // 5
-        let encoded = encode(&base, &fallback).unwrap();
-        let (decoded_base, decoded_fallback) = decode(&encoded, BASE3_SYMBOL_PER_CHUNK).unwrap();
-        assert_eq!(base, decoded_base);
-        assert_eq!(fallback, decoded_fallback);
-    }
+        #[test]
+        fn test_bitvec_round_trip_exact_chunk() {
+            let len = BASE3_SYMBOL_PER_CHUNK;
+            let (base, fallback) = create_test_data(len); // 5
+            let encoded = encode(&base, &fallback).unwrap();
+            let (decoded_base, decoded_fallback) = decode(&encoded, len).unwrap();
+            assert_eq!(base, decoded_base);
+            assert_eq!(fallback, decoded_fallback);
+        }
 
-    #[test]
-    fn test_round_trip_multi_chunk_partial() {
-        let (base, fallback) = create_test_data(7); // 1 full chunk, 1 partial
-        let encoded = encode(&base, &fallback).unwrap();
-        let (decoded_base, decoded_fallback) = decode(&encoded, 7).unwrap();
-        assert_eq!(base, decoded_base);
-        assert_eq!(fallback, decoded_fallback);
-    }
+        #[test]
+        fn test_bitvec_round_trip_multi_chunk_partial() {
+            let len = 7; // 1 full chunk, 1 partial
+            let (base, fallback) = create_test_data(len);
+            let encoded = encode(&base, &fallback).unwrap();
+            let (decoded_base, decoded_fallback) = decode(&encoded, len).unwrap();
+            assert_eq!(base, decoded_base);
+            assert_eq!(fallback, decoded_fallback);
+        }
 
-    #[test]
-    fn test_round_trip_multi_chunk_exact() {
-        let (base, fallback) = create_test_data(10); // 2 full chunks
-        let encoded = encode(&base, &fallback).unwrap();
-        let (decoded_base, decoded_fallback) = decode(&encoded, 10).unwrap();
-        assert_eq!(base, decoded_base);
-        assert_eq!(fallback, decoded_fallback);
-    }
+        #[test]
+        fn test_bitvec_round_trip_multi_chunk_exact() {
+            let len = 10; // 2 full chunks
+            let (base, fallback) = create_test_data(len);
+            let encoded = encode(&base, &fallback).unwrap();
+            let (decoded_base, decoded_fallback) = decode(&encoded, len).unwrap();
+            assert_eq!(base, decoded_base);
+            assert_eq!(fallback, decoded_fallback);
+        }
 
-    #[test]
-    fn test_encode_error_mismatched_lengths() {
-        let (base, _) = create_test_data(10);
-        let (_, fallback) = create_test_data(11);
-        let result = encode(&base, &fallback);
-        assert_eq!(result, Err(EncodeError::MismatchedLengths));
-    }
+        #[test]
+        fn test_bitvec_encode_error_mismatched_lengths() {
+            let (base, _) = create_test_data(10);
+            let (_, fallback) = create_test_data(11);
+            let result = encode(&base, &fallback);
+            assert_eq!(result, Err(EncodeError::MismatchedLengths));
+        }
 
-    #[test]
-    fn test_encode_error_invalid_combination() {
-        let mut base = BitVec::<u8, Lsb0>::new();
-        base.push(false);
-        base.push(true);
+        #[test]
+        fn test_bitvec_encode_error_invalid_combination() {
+            let mut base = BitVec::<u8, Lsb0>::new();
+            base.push(false);
+            base.push(true);
 
-        let mut fallback = BitVec::<u8, Lsb0>::new();
-        fallback.push(false);
-        fallback.push(true);
+            let mut fallback = BitVec::<u8, Lsb0>::new();
+            fallback.push(false);
+            fallback.push(true);
 
-        let result = encode(&base, &fallback);
-        assert_eq!(result, Err(EncodeError::InvalidBitCombination));
-    }
+            let result = encode(&base, &fallback);
+            assert_eq!(result, Err(EncodeError::InvalidBitCombination));
+        }
 
-    #[test]
-    fn test_decode_error_invalid_length_prefix() {
-        let bytes = vec![1];
-        let result = decode(&bytes, 0);
-        assert_eq!(result, Err(DecodeError::InvalidLengthPrefix));
-    }
+        #[test]
+        fn test_bitvec_decode_error_invalid_length_prefix() {
+            let bytes = vec![1];
+            let result = decode(&bytes, 0);
+            assert_eq!(result, Err(DecodeError::InvalidLengthPrefix));
+        }
 
-    #[test]
-    fn test_decode_error_corrupt_payload() {
-        let (base, fallback) = create_test_data(10);
-        let mut encoded = encode(&base, &fallback).unwrap();
-        encoded.pop(); // Make the payload an invalid length
-        let result = decode(&encoded, 10);
-        assert_eq!(result, Err(DecodeError::CorruptDataPayload));
-    }
+        #[test]
+        fn test_bitvec_decode_error_corrupt_payload() {
+            let len = 10;
+            let (base, fallback) = create_test_data(len);
+            let mut encoded = encode(&base, &fallback).unwrap();
+            encoded.pop(); // Make the payload an invalid length
+            let result = decode(&encoded, len);
+            assert_eq!(result, Err(DecodeError::CorruptDataPayload));
+        }
 
-    #[test]
-    fn test_decode_error_length_exceeds_max() {
-        let len = 10;
-        let (base, fallback) = create_test_data(len);
-        let encoded = encode(&base, &fallback).unwrap();
-        let result = decode(&encoded, len - 1); // Set max_len to be less than actual length
-        assert_eq!(result, Err(DecodeError::CorruptDataPayload));
+        #[test]
+        fn test_bitvec_decode_error_length_exceeds_max() {
+            let len = 10;
+            let (base, fallback) = create_test_data(len);
+            let encoded = encode(&base, &fallback).unwrap();
+            let result = decode(&encoded, len - 1);
+            assert_eq!(result, Err(DecodeError::CorruptDataPayload));
+        }
     }
 }

--- a/base3-encoding/src/lib.rs
+++ b/base3-encoding/src/lib.rs
@@ -99,7 +99,10 @@ pub fn encode(
     result.extend_from_slice(&(bit_vec_base.len() as u16).to_le_bytes());
 
     // Process the bits of `bit_vec_base` and `bit_vec_fallback` in chunks of 80 bits
-    for (base_chunk, fallback_chunk) in bit_vec_base.chunks(80).zip(bit_vec_fallback.chunks(80)) {
+    for (base_chunk, fallback_chunk) in bit_vec_base
+        .chunks(BASE3_SYMBOL_PER_CHUNK)
+        .zip(bit_vec_fallback.chunks(BASE3_SYMBOL_PER_CHUNK))
+    {
         let mut block_num: u128 = 0; // base10 number assigned for each chunk block
 
         // Iterate over corresponding bits in the chunk

--- a/base3-encoding/src/lib.rs
+++ b/base3-encoding/src/lib.rs
@@ -95,7 +95,7 @@ pub fn encode(
         .ok_or(EncodeError::ArithmeticOverflow)?;
     let mut result = Vec::with_capacity(capacity);
 
-    result.extend_from_slice(&(bit_vec_base.len() as u16).to_be_bytes());
+    result.extend_from_slice(&(bit_vec_base.len() as u16).to_le_bytes());
 
     // Process the bits of `bit_vec_base` and `bit_vec_fallback` in chunks of 80 bits
     for (base_chunk, fallback_chunk) in bit_vec_base.chunks(80).zip(bit_vec_fallback.chunks(80)) {
@@ -116,7 +116,7 @@ pub fn encode(
                 .ok_or(EncodeError::ArithmeticOverflow)?;
         }
 
-        result.extend_from_slice(&block_num.to_be_bytes());
+        result.extend_from_slice(&block_num.to_le_bytes());
     }
 
     Ok(result)
@@ -160,7 +160,7 @@ pub fn decode(bytes: &[u8]) -> Result<(BitVec<u8, Lsb0>, BitVec<u8, Lsb0>), Deco
     }
     let mut len_arr = [0u8; 2];
     len_arr.copy_from_slice(&bytes[..2]);
-    let total_bits = u16::from_be_bytes(len_arr) as usize;
+    let total_bits = u16::from_le_bytes(len_arr) as usize;
 
     let data_bytes = &bytes[2..];
     if data_bytes
@@ -183,7 +183,7 @@ pub fn decode(bytes: &[u8]) -> Result<(BitVec<u8, Lsb0>, BitVec<u8, Lsb0>), Deco
 
         let mut block_arr = [0u8; ENCODED_BYTES_PER_CHUNK];
         block_arr.copy_from_slice(block_bytes);
-        let mut block_num = u128::from_be_bytes(block_arr);
+        let mut block_num = u128::from_le_bytes(block_arr);
 
         let bits_in_this_chunk = bits_remaining.min(BASE3_SYMBOL_PER_CHUNK);
         let mut decoded_chunk_rev = Vec::with_capacity(bits_in_this_chunk);

--- a/base3-encoding/src/lib.rs
+++ b/base3-encoding/src/lib.rs
@@ -23,10 +23,10 @@
 //! # Encoded Format
 //!
 //! The resulting `Vec<u8>` has a simple structure:
-//! 1.  **Length Prefix (2 bytes)**: A `u16` in big-endian format storing the original
-//!     number of bits (i.e., the length of the input vectors).
+//! 1.  **Length Prefix (2 bytes)**: A `u16` in little-endian format storing the
+//!     original number of bits (i.e., the length of the input vectors).
 //! 2.  **Data Payload (N * 16 bytes)**: A sequence of 16-byte chunks, where each
-//!     chunk is the big-endian representation of a `u128` value containing the
+//!     chunk is the little-endian representation of a `u128` value containing the
 //!     encoded data.
 
 use bitvec::prelude::*;
@@ -55,12 +55,13 @@ const ENCODED_BYTES_PER_CHUNK: usize = 16; // std::mem::size_of::<u128>()
 /// # Algorithm
 /// 1.  Validates that the input vectors have the same length and do not exceed
 ///     `u16::MAX`.
-/// 2.  Writes the length of the vectors as a 2-byte big-endian `u16` to the
+/// 2.  Writes the length of the vectors as a 2-byte little-endian `u16` to the
 ///     output buffer.
 /// 3.  Iterates through the input vectors in chunks of 80 bits.
 /// 4.  For each chunk, it converts the 80 bit-pairs into 80 ternary digits and
 ///     constructs a `u128` number from them.
-/// 5.  This `u128` number is appended to the output buffer as 16 big-endian bytes.
+/// 5.  This `u128` number is appended to the output buffer as 16 little-endian
+///     bytes.
 ///
 /// # Errors
 /// Returns an `EncodeError` if:


### PR DESCRIPTION
This PR introduces the solana-base3-encoding crate, created to efficiently encode Alpenglow vote certificates.

Alpenglow certificates contain aggregate signatures, which don't specify individual signers. For simple certificate types like Finalize or Notarize, a bit vector is sufficient to identify the voters.

However, more complex certificates like NotarizeFallback or Skip can contain two different vote types. Using a separate bit vector for each type is not scalable. As the validator set grows to 4,000, the two bit vectors would exceed 1 KB, making certificates harder to fit in a single network packet. 

This crate provides a more compact encoding scheme. The design is tailored to the [CertificateMessage](https://github.com/solana-program/alpenglow-vote/blob/master/program/src/bls_message.rs#L32), taking two BitVec inputs and combining them into a base-3 representation.

This does seem to make the crate quite specific for alpenglow certificates, so maybe we can either have this crate in the `alpenglow-vote` repo or think of ways to make the interface more generic.