### PR TITLE
Increase quic heartbeat interval to 45 second to reduce overhead

### DIFF
--- a/quic-definitions/src/lib.rs
+++ b/quic-definitions/src/lib.rs
@@ -22,9 +22,7 @@ pub const QUIC_MAX_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// To avoid idle timeout, the QUIC endpoint sends a ping every
 /// QUIC_KEEP_ALIVE. This shouldn't be too low to avoid unnecessary ping traffic.
-/// For upgrade purpose, we keep the original one. Once the network is upgraded
-/// to the one having higher QUIC_MAX_TIMEOUT, this value can be increased.
-pub const QUIC_KEEP_ALIVE: Duration = Duration::from_secs(1);
+pub const QUIC_KEEP_ALIVE: Duration = Duration::from_secs(45);
 
 // Disable Quic send fairness.
 // When set to false, streams are still scheduled based on priority,


### PR DESCRIPTION
As the change to increase QUIC connection timeout has been released. Now we can afford to reduce the frequency to send QUIC keep-alive messages.

The interval is changed from 1 s to 45 seconds

This to follow up on https://github.com/anza-xyz/solana-sdk/pull/29.
