### PR TITLE
Up the version for solana-quic-definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3658,7 +3658,7 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-definitions"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "solana-keypair",
 ]

--- a/quic-definitions/Cargo.toml
+++ b/quic-definitions/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-quic-definitions"
 description = "Definitions related to Solana over QUIC."
 documentation = "https://docs.rs/solana-quic-definitions"
-version = "2.3.0"
+version = "2.3.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }


### PR DESCRIPTION
Update solana-quic-definitions to 2.3.1 from 2.3.0 for the QUIC keep-alive change (https://github.com/anza-xyz/solana-sdk/pull/201)