### PR TITLE
sdk!: Don't enable debug-signature feature on transaction-context

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -32,7 +32,6 @@ default = [
 full = [
     "serde_json",
     "solana-signature",
-    "solana-transaction-context/debug-signature",
     "solana-pubkey/rand",
     "dep:solana-client-traits",
     "dep:solana-cluster-type",


### PR DESCRIPTION
#### Problem

The debug-signature feature on solana-transaction-context was removed in https://github.com/anza-xyz/agave/pull/6647, but the sdk still depends on it, which breaks builds, as mentioned at
https://github.com/anza-xyz/mollusk/issues/136.

#### Summary of changes

Just remove enabling the debug-signature feature. This is technically a breaking change, but if it's really needed, users can import `solana-transaction-context` separately and enable the debug-signature feature, if they're using a compatible version.