### PR TITLE
v2: CI: Fixup git-cliff step for non-master branches

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -190,7 +190,7 @@ jobs:
         uses: orhun/git-cliff-action@v4
         with:
           config: "scripts/cliff.toml"
-          args: ${{ steps.publish.outputs.old_git_tag }}..master --include-path "${{ inputs.package_path }}/**" --github-repo ${{ github.repository }}
+          args: ${{ steps.publish.outputs.old_git_tag }}..HEAD --include-path "${{ inputs.package_path }}/**" --github-repo ${{ github.repository }}
         env:
           OUTPUT: TEMP_CHANGELOG.md
           GITHUB_REPO: ${{ github.repository }}


### PR DESCRIPTION
#### Problem

The publish job against maintenance/v2.x failed to generate a changelog because we look for changes to `master`, but we really want changes up to the current HEAD.

#### Summary of changes

Use `HEAD` instead of `master`.