### PR TITLE
Bump Rust to 1.88, nightly to 2025-06-29

### DIFF
--- a/account-info/src/lib.rs
+++ b/account-info/src/lib.rs
@@ -106,25 +106,25 @@ impl<'a> AccountInfo<'a> {
         Ok(self.try_borrow_data()?.is_empty())
     }
 
-    pub fn try_borrow_lamports(&self) -> Result<Ref<&mut u64>, ProgramError> {
+    pub fn try_borrow_lamports(&self) -> Result<Ref<'_, &mut u64>, ProgramError> {
         self.lamports
             .try_borrow()
             .map_err(|_| ProgramError::AccountBorrowFailed)
     }
 
-    pub fn try_borrow_mut_lamports(&self) -> Result<RefMut<&'a mut u64>, ProgramError> {
+    pub fn try_borrow_mut_lamports(&self) -> Result<RefMut<'_, &'a mut u64>, ProgramError> {
         self.lamports
             .try_borrow_mut()
             .map_err(|_| ProgramError::AccountBorrowFailed)
     }
 
-    pub fn try_borrow_data(&self) -> Result<Ref<&mut [u8]>, ProgramError> {
+    pub fn try_borrow_data(&self) -> Result<Ref<'_, &mut [u8]>, ProgramError> {
         self.data
             .try_borrow()
             .map_err(|_| ProgramError::AccountBorrowFailed)
     }
 
-    pub fn try_borrow_mut_data(&self) -> Result<RefMut<&'a mut [u8]>, ProgramError> {
+    pub fn try_borrow_mut_data(&self) -> Result<RefMut<'_, &'a mut [u8]>, ProgramError> {
         self.data
             .try_borrow_mut()
             .map_err(|_| ProgramError::AccountBorrowFailed)

--- a/epoch-rewards-hasher/src/lib.rs
+++ b/epoch-rewards-hasher/src/lib.rs
@@ -123,11 +123,7 @@ mod tests {
                 // size is same or 1 less
                 assert!(
                     len == expected_len_of_partition || len + 1 == expected_len_of_partition,
-                    "{}, {}, {}, {}",
-                    expected_len_of_partition,
-                    len,
-                    partition,
-                    partitions
+                    "{expected_len_of_partition}, {len}, {partition}, {partitions}",
                 );
             }
         }

--- a/hard-forks/src/lib.rs
+++ b/hard-forks/src/lib.rs
@@ -29,7 +29,7 @@ impl HardForks {
     }
 
     // Returns a sorted-by-slot iterator over the registered hark forks
-    pub fn iter(&self) -> std::slice::Iter<(u64, usize)> {
+    pub fn iter(&self) -> std::slice::Iter<'_, (u64, usize)> {
         self.hard_forks.iter()
     }
 

--- a/instructions-sysvar/src/lib.rs
+++ b/instructions-sysvar/src/lib.rs
@@ -326,7 +326,7 @@ mod tests {
         is_writable: bool,
     }
 
-    fn make_borrowed_instruction(params: &MakeInstructionParams) -> BorrowedInstruction {
+    fn make_borrowed_instruction(params: &MakeInstructionParams) -> BorrowedInstruction<'_> {
         let MakeInstructionParams {
             program_id,
             account_key,

--- a/keypair/src/signable.rs
+++ b/keypair/src/signable.rs
@@ -17,7 +17,7 @@ pub trait Signable {
     }
 
     fn pubkey(&self) -> Pubkey;
-    fn signable_data(&self) -> Cow<[u8]>;
+    fn signable_data(&self) -> Cow<'_, [u8]>;
     fn get_signature(&self) -> Signature;
     fn set_signature(&mut self, signature: Signature);
 }

--- a/message/src/compiled_keys.rs
+++ b/message/src/compiled_keys.rs
@@ -35,8 +35,7 @@ impl fmt::Display for CompileError {
                 f.write_str("address lookup table index overflowed during compilation")
             }
             CompileError::UnknownInstructionKey(key) => f.write_fmt(format_args!(
-                "encountered unknown account key `{0}` during instruction compilation",
-                key,
+                "encountered unknown account key `{key}` during instruction compilation",
             )),
         }
     }

--- a/message/src/sanitized.rs
+++ b/message/src/sanitized.rs
@@ -68,7 +68,7 @@ impl LegacyMessage<'_> {
     }
 
     /// Returns the full list of account keys.
-    pub fn account_keys(&self) -> AccountKeys {
+    pub fn account_keys(&self) -> AccountKeys<'_> {
         AccountKeys::new(&self.message.account_keys, None)
     }
 
@@ -197,7 +197,7 @@ impl SanitizedMessage {
     }
 
     /// Returns the list of account keys that are loaded for this message.
-    pub fn account_keys(&self) -> AccountKeys {
+    pub fn account_keys(&self) -> AccountKeys<'_> {
         match self {
             Self::Legacy(message) => message.account_keys(),
             Self::V0(message) => message.account_keys(),
@@ -285,7 +285,7 @@ impl SanitizedMessage {
     }
 
     /// Decompile message instructions without cloning account keys
-    pub fn decompile_instructions(&self) -> Vec<BorrowedInstruction> {
+    pub fn decompile_instructions(&self) -> Vec<BorrowedInstruction<'_>> {
         let account_keys = self.account_keys();
         self.program_instructions_iter()
             .map(|(program_id, instruction)| {

--- a/message/src/versions/v0/loaded.rs
+++ b/message/src/versions/v0/loaded.rs
@@ -98,7 +98,7 @@ impl<'a> LoadedMessage<'a> {
     }
 
     /// Returns the full list of static and dynamic account keys that are loaded for this message.
-    pub fn account_keys(&self) -> AccountKeys {
+    pub fn account_keys(&self) -> AccountKeys<'_> {
         AccountKeys::new(&self.message.account_keys, Some(&self.loaded_addresses))
     }
 

--- a/native-token/src/lib.rs
+++ b/native-token/src/lib.rs
@@ -38,7 +38,7 @@ pub fn sol_str_to_lamports(sol_str: &str) -> Option<u64> {
         let lamports = if lamports.is_empty() {
             0
         } else {
-            format!("{:0<9}", lamports)[..SOL_DECIMALS].parse().ok()?
+            format!("{lamports:0<9}")[..SOL_DECIMALS].parse().ok()?
         };
         LAMPORTS_PER_SOL
             .checked_mul(sol)

--- a/program/src/program.rs
+++ b/program/src/program.rs
@@ -244,7 +244,7 @@ pub fn check_type_assumptions() {
         assert_eq!(offset_of!(AccountInfo, data), 16);
         let data_ptr = (account_info_addr + 16) as *const Rc<RefCell<&mut [u8]>>;
         unsafe {
-            assert_eq!((*(*data_ptr).as_ptr())[..], data[..]);
+            assert_eq!((&(*(*data_ptr).as_ptr()))[..], data[..]);
         }
 
         // owner

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.85.1"
+channel = "1.88.0"

--- a/scripts/rust-version.sh
+++ b/scripts/rust-version.sh
@@ -38,7 +38,7 @@ fi
 if [[ -n $RUST_NIGHTLY_VERSION ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2025-04-01
+  nightly_version=2025-06-29
 fi
 
 export rust_stable="$stable_version"

--- a/signature/src/error.rs
+++ b/signature/src/error.rs
@@ -54,7 +54,7 @@ impl Debug for Error {
         f.write_str("signature::Error { source: ")?;
 
         if let Some(source) = &self.source {
-            write!(f, "Some({})", source)?;
+            write!(f, "Some({source})")?;
         } else {
             f.write_str("None")?;
         }

--- a/transaction/src/sanitized.rs
+++ b/transaction/src/sanitized.rs
@@ -216,13 +216,13 @@ impl SanitizedTransaction {
     pub fn get_account_locks(
         &self,
         tx_account_lock_limit: usize,
-    ) -> Result<TransactionAccountLocks> {
+    ) -> Result<TransactionAccountLocks<'_>> {
         Self::validate_account_locks(self.message(), tx_account_lock_limit)?;
         Ok(self.get_account_locks_unchecked())
     }
 
     /// Return the list of accounts that must be locked during processing this transaction.
-    pub fn get_account_locks_unchecked(&self) -> TransactionAccountLocks {
+    pub fn get_account_locks_unchecked(&self) -> TransactionAccountLocks<'_> {
         let message = &self.message;
         let account_keys = message.account_keys();
         let num_readonly_accounts = message.num_readonly_accounts();

--- a/vote-interface/src/authorized_voters.rs
+++ b/vote-interface/src/authorized_voters.rs
@@ -80,7 +80,7 @@ impl AuthorizedVoters {
         self.authorized_voters.contains_key(&epoch)
     }
 
-    pub fn iter(&self) -> std::collections::btree_map::Iter<Epoch, Pubkey> {
+    pub fn iter(&self) -> std::collections::btree_map::Iter<'_, Epoch, Pubkey> {
         self.authorized_voters.iter()
     }
 


### PR DESCRIPTION
#### Problem

Rust has been upgrading, but not the version used in the sdk repo. Also, with the upcoming breaking changes to the sdk, it's a good time to bump the rust edition to 2024, but we should upgrade to the newest Rust first.

#### Summary of changes

Bump the version in rust-toolchain.toml and scripts/rust-version.sh, then fix any issues reported.