### PR TITLE
Add base3-encoding to `patch-crates-functions.sh`

### DIFF
--- a/scripts/patch-crates-functions.sh
+++ b/scripts/patch-crates-functions.sh
@@ -10,6 +10,7 @@ crate_dirs=(
   account-info
   address-lookup-table-interface
   atomic-u64
+  base3-encoding
   big-mod-exp
   bincode
   blake3-hasher


### PR DESCRIPTION
#### Problem

Base3 encoding crate was added in https://github.com/anza-xyz/solana-sdk/commit/50dfbd088c51b7229c67d432d8c8801dafaa7904, but I forgot to add it the patch crates script.

#### Summary of Changes

Add it to the script.