### PR TITLE
[bls-signature] Update the public key and signature aggregation function to be generic

### DIFF
--- a/bls-signatures/src/pubkey.rs
+++ b/bls-signatures/src/pubkey.rs
@@ -262,7 +262,7 @@ mod tests {
             signature::{Signature, SignatureCompressed},
         },
         core::str::FromStr,
-        std::{string::ToString, vec, vec::Vec},
+        std::{string::ToString, vec::Vec},
     };
 
     #[test]
@@ -362,7 +362,7 @@ mod tests {
         let pubkey_compressed: PubkeyCompressed = Pubkey::from(keypair1.public).try_into().unwrap();
 
         let dyn_pubkeys: Vec<&dyn AsPubkeyProjective> =
-            vec![&pubkey_projective, &pubkey_affine, &pubkey_compressed];
+            std::vec![&pubkey_projective, &pubkey_affine, &pubkey_compressed];
 
         let aggregate_from_dyn = PubkeyProjective::aggregate(dyn_pubkeys).unwrap();
         let pubkeys_for_baseline = [keypair0.public, keypair1.public, keypair1.public];

--- a/bls-signatures/src/pubkey.rs
+++ b/bls-signatures/src/pubkey.rs
@@ -106,29 +106,32 @@ impl PubkeyProjective {
 
     /// Aggregate a list of public keys into an existing aggregate
     #[allow(clippy::arithmetic_side_effects)]
-    pub fn aggregate_with<'a, I>(&mut self, pubkeys: I)
+    pub fn aggregate_with<'a, P: 'a + AsPubkeyProjective + ?Sized, I>(
+        &mut self,
+        pubkeys: I,
+    ) -> Result<(), BlsError>
     where
-        I: IntoIterator<Item = &'a PubkeyProjective>,
+        I: IntoIterator<Item = &'a P>,
     {
-        self.0 = pubkeys.into_iter().fold(self.0, |mut acc, pubkey| {
-            acc += &pubkey.0;
-            acc
-        });
+        for pubkey in pubkeys {
+            self.0 += &pubkey.try_as_projective()?.0;
+        }
+        Ok(())
     }
 
     /// Aggregate a list of public keys
     #[allow(clippy::arithmetic_side_effects)]
-    pub fn aggregate<'a, I>(pubkeys: I) -> Result<PubkeyProjective, BlsError>
+    pub fn aggregate<'a, P: 'a + AsPubkeyProjective + ?Sized, I>(
+        pubkeys: I,
+    ) -> Result<PubkeyProjective, BlsError>
     where
-        I: IntoIterator<Item = &'a PubkeyProjective>,
+        I: IntoIterator<Item = &'a P>,
     {
         let mut iter = pubkeys.into_iter();
-        if let Some(acc) = iter.next() {
-            let aggregate_point = iter.fold(acc.0, |mut acc, pubkey| {
-                acc += &pubkey.0;
-                acc
-            });
-            Ok(Self(aggregate_point))
+        if let Some(first) = iter.next() {
+            let mut aggregate = first.try_as_projective()?;
+            aggregate.aggregate_with(iter)?;
+            Ok(aggregate)
         } else {
             Err(BlsError::EmptyAggregation)
         }
@@ -258,7 +261,7 @@ mod tests {
             signature::{Signature, SignatureCompressed},
         },
         core::str::FromStr,
-        std::string::ToString,
+        std::{string::ToString, vec, vec::Vec},
     };
 
     #[test]
@@ -346,6 +349,25 @@ mod tests {
         assert!(pubkey_compressed
             .verify_proof_of_possession(&proof_compressed)
             .unwrap());
+    }
+
+    #[test]
+    fn test_pubkey_aggregate_dyn() {
+        let keypair0 = Keypair::new();
+        let keypair1 = Keypair::new();
+
+        let pubkey_projective = keypair0.public;
+        let pubkey_affine: Pubkey = keypair1.public.into();
+        let pubkey_compressed: PubkeyCompressed = Pubkey::from(keypair1.public).try_into().unwrap();
+
+        let dyn_pubkeys: Vec<&dyn AsPubkeyProjective> =
+            vec![&pubkey_projective, &pubkey_affine, &pubkey_compressed];
+
+        let aggregate_from_dyn = PubkeyProjective::aggregate(dyn_pubkeys).unwrap();
+        let pubkeys_for_baseline = [keypair0.public, keypair1.public, keypair1.public];
+        let baseline_aggregate = PubkeyProjective::aggregate(&pubkeys_for_baseline).unwrap();
+
+        assert_eq!(aggregate_from_dyn, baseline_aggregate);
     }
 
     #[test]

--- a/bls-signatures/src/pubkey.rs
+++ b/bls-signatures/src/pubkey.rs
@@ -72,14 +72,15 @@ pub trait VerifiablePubkey: AsPubkeyProjective {
 pub struct PubkeyProjective(pub(crate) G1Projective);
 
 #[cfg(not(target_os = "solana"))]
-impl Default for PubkeyProjective {
-    fn default() -> Self {
+impl PubkeyProjective {
+    /// Creates the identity element, which is the starting point for aggregation
+    ///
+    /// The identity element is not a valid public key and it should only be used
+    /// for the purpose of aggregation
+    pub fn identity() -> Self {
         Self(G1Projective::identity())
     }
-}
 
-#[cfg(not(target_os = "solana"))]
-impl PubkeyProjective {
     /// Verify a signature and a message against a public key
     pub(crate) fn _verify_signature(
         &self,

--- a/bls-signatures/src/signature.rs
+++ b/bls-signatures/src/signature.rs
@@ -55,14 +55,15 @@ pub trait VerifiableSignature: AsSignatureProjective {
 pub struct SignatureProjective(pub(crate) G2Projective);
 
 #[cfg(not(target_os = "solana"))]
-impl Default for SignatureProjective {
-    fn default() -> Self {
+impl SignatureProjective {
+    /// Creates the identity element, which is the starting point for aggregation
+    ///
+    /// The identity element is not a valid signature and it should only be used
+    /// for the purpose of aggregation
+    pub fn identity() -> Self {
         Self(G2Projective::identity())
     }
-}
 
-#[cfg(not(target_os = "solana"))]
-impl SignatureProjective {
     /// Aggregate a list of signatures into an existing aggregate
     #[allow(clippy::arithmetic_side_effects)]
     pub fn aggregate_with<'a, S: 'a + AsSignatureProjective + ?Sized, I>(

--- a/bls-signatures/src/signature.rs
+++ b/bls-signatures/src/signature.rs
@@ -218,7 +218,7 @@ mod tests {
             pubkey::{Pubkey, PubkeyCompressed},
         },
         core::str::FromStr,
-        std::{string::ToString, vec, vec::Vec},
+        std::{string::ToString, vec::Vec},
     };
 
     #[test]
@@ -307,8 +307,8 @@ mod tests {
 
         // basic case
         assert!(SignatureProjective::aggregate_verify(
-            vec![&keypair0.public, &keypair1.public],
-            vec![&signature0, &signature1],
+            std::vec![&keypair0.public, &keypair1.public],
+            std::vec![&signature0, &signature1],
             test_message,
         )
         .unwrap());
@@ -319,8 +319,8 @@ mod tests {
         let signature0_affine: Signature = signature0.into();
         let signature1_affine: Signature = signature1.into();
         assert!(SignatureProjective::aggregate_verify(
-            vec![&pubkey0_affine, &pubkey1_affine],
-            vec![&signature0_affine, &signature1_affine],
+            std::vec![&pubkey0_affine, &pubkey1_affine],
+            std::vec![&signature0_affine, &signature1_affine],
             test_message,
         )
         .unwrap());
@@ -329,8 +329,8 @@ mod tests {
         let aggregate_signature =
             SignatureProjective::aggregate([&signature0, &signature1]).unwrap();
         assert!(SignatureProjective::aggregate_verify(
-            vec![&keypair0.public, &keypair1.public],
-            vec![&aggregate_signature],
+            std::vec![&keypair0.public, &keypair1.public],
+            std::vec![&aggregate_signature],
             test_message,
         )
         .unwrap());
@@ -339,24 +339,24 @@ mod tests {
         let aggregate_pubkey =
             PubkeyProjective::aggregate([&keypair0.public, &keypair1.public]).unwrap();
         assert!(SignatureProjective::aggregate_verify(
-            vec![&aggregate_pubkey],
-            vec![&signature0, &signature1],
+            std::vec![&aggregate_pubkey],
+            std::vec![&signature0, &signature1],
             test_message,
         )
         .unwrap());
 
         // empty set of public keys or signatures
         let err = SignatureProjective::aggregate_verify(
-            vec![] as Vec<&PubkeyProjective>,
-            vec![&signature0, &signature1],
+            std::vec![] as Vec<&PubkeyProjective>,
+            std::vec![&signature0, &signature1],
             test_message,
         )
         .unwrap_err();
         assert_eq!(err, BlsError::EmptyAggregation);
 
         let err = SignatureProjective::aggregate_verify(
-            vec![&keypair0.public, &keypair1.public],
-            vec![] as Vec<&SignatureProjective>,
+            std::vec![&keypair0.public, &keypair1.public],
+            std::vec![] as Vec<&SignatureProjective>,
             test_message,
         )
         .unwrap_err();
@@ -386,9 +386,9 @@ mod tests {
             Signature::from(signature2_projective).try_into().unwrap(); // Compressed
 
         let dyn_pubkeys: Vec<&dyn AsPubkeyProjective> =
-            vec![&pubkey0, &pubkey1_affine, &pubkey2_compressed];
+            std::vec![&pubkey0, &pubkey1_affine, &pubkey2_compressed];
         let dyn_signatures: Vec<&dyn AsSignatureProjective> =
-            vec![&signature0, &signature1_affine, &signature2_compressed];
+            std::vec![&signature0, &signature1_affine, &signature2_compressed];
 
         assert!(
             SignatureProjective::aggregate_verify(dyn_pubkeys, dyn_signatures, test_message)
@@ -397,9 +397,9 @@ mod tests {
 
         let wrong_message = b"this is not the correct message";
         let dyn_pubkeys_fail: Vec<&dyn AsPubkeyProjective> =
-            vec![&pubkey0, &pubkey1_affine, &pubkey2_compressed];
+            std::vec![&pubkey0, &pubkey1_affine, &pubkey2_compressed];
         let dyn_signatures_fail: Vec<&dyn AsSignatureProjective> =
-            vec![&signature0, &signature1_affine, &signature2_compressed];
+            std::vec![&signature0, &signature1_affine, &signature2_compressed];
         assert!(!SignatureProjective::aggregate_verify(
             dyn_pubkeys_fail,
             dyn_signatures_fail,

--- a/bls-signatures/src/signature.rs
+++ b/bls-signatures/src/signature.rs
@@ -4,7 +4,7 @@ use bytemuck::{Pod, PodInOption, Zeroable, ZeroableInOption};
 use {
     crate::{
         error::BlsError,
-        pubkey::{PubkeyProjective, VerifiablePubkey},
+        pubkey::{AsPubkeyProjective, PubkeyProjective, VerifiablePubkey},
     },
     blstrs::{G2Affine, G2Projective},
     group::Group,
@@ -65,43 +65,52 @@ impl Default for SignatureProjective {
 impl SignatureProjective {
     /// Aggregate a list of signatures into an existing aggregate
     #[allow(clippy::arithmetic_side_effects)]
-    pub fn aggregate_with<'a, I>(&mut self, signatures: I)
+    pub fn aggregate_with<'a, S: 'a + AsSignatureProjective + ?Sized, I>(
+        &mut self,
+        signatures: I,
+    ) -> Result<(), BlsError>
     where
-        I: IntoIterator<Item = &'a SignatureProjective>,
+        I: IntoIterator<Item = &'a S>,
     {
-        self.0 = signatures.into_iter().fold(self.0, |mut acc, signature| {
-            acc += &signature.0;
-            acc
-        });
+        for signature in signatures {
+            self.0 += &signature.try_as_projective()?.0;
+        }
+        Ok(())
     }
 
     /// Aggregate a list of public keys
     #[allow(clippy::arithmetic_side_effects)]
-    pub fn aggregate<'a, I>(signatures: I) -> Result<SignatureProjective, BlsError>
+    pub fn aggregate<'a, S: 'a + AsSignatureProjective + ?Sized, I>(
+        signatures: I,
+    ) -> Result<SignatureProjective, BlsError>
     where
-        I: IntoIterator<Item = &'a SignatureProjective>,
+        I: IntoIterator<Item = &'a S>,
     {
         let mut iter = signatures.into_iter();
-        if let Some(acc) = iter.next() {
-            let aggregate_point = iter.fold(acc.0, |mut acc, signature| {
-                acc += &signature.0;
-                acc
-            });
-            Ok(Self(aggregate_point))
+        if let Some(first) = iter.next() {
+            let mut aggregate = first.try_as_projective()?;
+            aggregate.aggregate_with(iter)?;
+            Ok(aggregate)
         } else {
             Err(BlsError::EmptyAggregation)
         }
     }
 
     /// Verify a list of signatures against a message and a list of public keys
-    pub fn aggregate_verify<'a, I, J>(
+    pub fn aggregate_verify<
+        'a,
+        P: 'a + AsPubkeyProjective + ?Sized,
+        S: 'a + AsSignatureProjective + ?Sized,
+        I,
+        J,
+    >(
         public_keys: I,
         signatures: J,
         message: &[u8],
     ) -> Result<bool, BlsError>
     where
-        I: IntoIterator<Item = &'a PubkeyProjective>,
-        J: IntoIterator<Item = &'a SignatureProjective>,
+        I: IntoIterator<Item = &'a P>,
+        J: IntoIterator<Item = &'a S>,
     {
         let aggregate_pubkey = PubkeyProjective::aggregate(public_keys)?;
         let aggregate_signature = SignatureProjective::aggregate(signatures)?;
@@ -208,7 +217,7 @@ mod tests {
             pubkey::{Pubkey, PubkeyCompressed},
         },
         core::str::FromStr,
-        std::{string::ToString, vec},
+        std::{string::ToString, vec, vec::Vec},
     };
 
     #[test]
@@ -264,12 +273,15 @@ mod tests {
         let test_message = b"test message";
         let keypair1 = Keypair::new();
         let signature1 = keypair1.sign(test_message);
+        let signature1_affine: Signature = signature1.into();
 
         let aggregate_signature =
             SignatureProjective::aggregate([&signature0, &signature1]).unwrap();
 
         let mut aggregate_signature_with = signature0;
-        aggregate_signature_with.aggregate_with([&signature1]);
+        aggregate_signature_with
+            .aggregate_with([&signature1_affine])
+            .unwrap();
 
         assert_eq!(aggregate_signature, aggregate_signature_with);
     }
@@ -300,6 +312,18 @@ mod tests {
         )
         .unwrap());
 
+        // verify with affine and compressed types
+        let pubkey0_affine: Pubkey = keypair0.public.into();
+        let pubkey1_affine: Pubkey = keypair1.public.into();
+        let signature0_affine: Signature = signature0.into();
+        let signature1_affine: Signature = signature1.into();
+        assert!(SignatureProjective::aggregate_verify(
+            vec![&pubkey0_affine, &pubkey1_affine],
+            vec![&signature0_affine, &signature1_affine],
+            test_message,
+        )
+        .unwrap());
+
         // pre-aggregate the signatures
         let aggregate_signature =
             SignatureProjective::aggregate([&signature0, &signature1]).unwrap();
@@ -322,7 +346,7 @@ mod tests {
 
         // empty set of public keys or signatures
         let err = SignatureProjective::aggregate_verify(
-            vec![],
+            vec![] as Vec<&PubkeyProjective>,
             vec![&signature0, &signature1],
             test_message,
         )
@@ -331,11 +355,56 @@ mod tests {
 
         let err = SignatureProjective::aggregate_verify(
             vec![&keypair0.public, &keypair1.public],
-            vec![],
+            vec![] as Vec<&SignatureProjective>,
             test_message,
         )
         .unwrap_err();
         assert_eq!(err, BlsError::EmptyAggregation);
+    }
+
+    #[test]
+    fn test_aggregate_verify_dyn() {
+        let test_message = b"test message for dyn verify";
+
+        let keypair0 = Keypair::new();
+        let keypair1 = Keypair::new();
+        let keypair2 = Keypair::new();
+
+        let signature0_projective = keypair0.sign(test_message);
+        let signature1_projective = keypair1.sign(test_message);
+        let signature2_projective = keypair2.sign(test_message);
+
+        let pubkey0 = keypair0.public; // Projective
+        let pubkey1_affine: Pubkey = keypair1.public.into(); // Affine
+        let pubkey2_compressed: PubkeyCompressed =
+            Pubkey::from(keypair2.public).try_into().unwrap(); // Compressed
+
+        let signature0 = signature0_projective; // Projective
+        let signature1_affine: Signature = signature1_projective.into(); // Affine
+        let signature2_compressed: SignatureCompressed =
+            Signature::from(signature2_projective).try_into().unwrap(); // Compressed
+
+        let dyn_pubkeys: Vec<&dyn AsPubkeyProjective> =
+            vec![&pubkey0, &pubkey1_affine, &pubkey2_compressed];
+        let dyn_signatures: Vec<&dyn AsSignatureProjective> =
+            vec![&signature0, &signature1_affine, &signature2_compressed];
+
+        assert!(
+            SignatureProjective::aggregate_verify(dyn_pubkeys, dyn_signatures, test_message)
+                .unwrap()
+        );
+
+        let wrong_message = b"this is not the correct message";
+        let dyn_pubkeys_fail: Vec<&dyn AsPubkeyProjective> =
+            vec![&pubkey0, &pubkey1_affine, &pubkey2_compressed];
+        let dyn_signatures_fail: Vec<&dyn AsSignatureProjective> =
+            vec![&signature0, &signature1_affine, &signature2_compressed];
+        assert!(!SignatureProjective::aggregate_verify(
+            dyn_pubkeys_fail,
+            dyn_signatures_fail,
+            wrong_message
+        )
+        .unwrap());
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
The signature and proof of possession verification interface was made more generic and flexible in https://github.com/anza-xyz/solana-sdk/pull/202, but the public key and signature aggregation still only works for the `PubkeyProjective` and `SignatureProjective` types.

#### Summary of Changes

I made two improvements to the BLS aggregation interface:

[1736017](https://github.com/anza-xyz/solana-sdk/pull/213/commits/17360174ed800deb2bdc1fba7deedd3abdeea0b3): The `aggregate` and `aggregate_with` functions for `PubkeyProjective` and `SignatureProjective` have been updated to support any of projective, affine, and compressed types. I added a `?Sized` bound to also support `Vec<&dyn AsPubkeyProjective>` and `Vec<&dun AsSignatureProjective>` input as well, so this should be quite ergonomic and flexible to use now.

https://github.com/anza-xyz/solana-sdk/pull/213/commits/91f32b59a162042ab309e4446cbe446e6e077fb3: The `impl Default` for `PubkeyProjective` and `SignatureProjective` has been removed. I originally added the Default implementation to work as a starting point for aggregation: a user can run `let mut agg = PubkeyProjective::default()` and then start aggregating public keys from there. But `Default` is a bit misleading because the identity element of the group is not actually a valid public key or signature and should not really be treated as a "default". Instead, I added a new `identity()` constructor on both types to make the intent clear that this function should only be used as a starting point for aggregation.