### PR TITLE
[base3-encoding] Add benches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2799,6 +2799,7 @@ name = "solana-base3-encoding"
 version = "0.1.0"
 dependencies = [
  "bitvec",
+ "criterion",
 ]
 
 [[package]]

--- a/base3-encoding/Cargo.toml
+++ b/base3-encoding/Cargo.toml
@@ -17,6 +17,17 @@ default = []
 bitvec = { version = "1.0.1", optional = true }
 
 [dev-dependencies]
+bitvec = "1.0.1"
+criterion = { workspace = true }
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "bytes"
+harness = false
+
+[[bench]]
+name = "bitvec"
+harness = false
+required-features = ["bitvec"]

--- a/base3-encoding/benches/bitvec.rs
+++ b/base3-encoding/benches/bitvec.rs
@@ -1,0 +1,46 @@
+use {
+    bitvec::prelude::*,
+    criterion::{criterion_group, criterion_main, BenchmarkId, Criterion},
+    solana_base3_encoding::{decode, encode},
+};
+
+fn create_test_data_bitvec(len: usize) -> (BitVec<u8, Lsb0>, BitVec<u8, Lsb0>) {
+    let mut base = BitVec::with_capacity(len);
+    let mut fallback = BitVec::with_capacity(len);
+    for i in 0..len {
+        match i % 3 {
+            0 => {
+                base.push(false);
+                fallback.push(false);
+            }
+            1 => {
+                base.push(true);
+                fallback.push(false);
+            }
+            _ => {
+                base.push(false);
+                fallback.push(true);
+            }
+        }
+    }
+    (base, fallback)
+}
+
+fn bench_bitvec(c: &mut Criterion) {
+    let mut group = c.benchmark_group("BitVec");
+    for size in [256, 512, 1024, 2048, 4096, 8192].iter() {
+        let (base, fallback) = create_test_data_bitvec(*size);
+        let encoded = encode(&base, &fallback).unwrap();
+
+        group.bench_with_input(BenchmarkId::new("encode", size), size, |b, _| {
+            b.iter(|| encode(&base, &fallback).unwrap());
+        });
+        group.bench_with_input(BenchmarkId::new("decode", size), size, |b, _| {
+            b.iter(|| decode(&encoded, *size).unwrap());
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_bitvec);
+criterion_main!(benches);

--- a/base3-encoding/benches/bytes.rs
+++ b/base3-encoding/benches/bytes.rs
@@ -4,8 +4,8 @@ use {
 };
 
 fn create_test_data_bytes(len: usize) -> (Vec<u8>, Vec<u8>) {
-    let mut base = vec![0u8; (len + 7) / 8];
-    let mut fallback = vec![0u8; (len + 7) / 8];
+    let mut base = vec![0u8; len.div_ceil(8)];
+    let mut fallback = vec![0u8; len.div_ceil(8)];
     for i in 0..len {
         match i % 3 {
             0 => { /* (false, false) */ }

--- a/base3-encoding/benches/bytes.rs
+++ b/base3-encoding/benches/bytes.rs
@@ -1,0 +1,36 @@
+use {
+    criterion::{criterion_group, criterion_main, BenchmarkId, Criterion},
+    solana_base3_encoding::{decode_to_bytes, encode_from_bytes},
+};
+
+fn create_test_data_bytes(len: usize) -> (Vec<u8>, Vec<u8>) {
+    let mut base = vec![0u8; (len + 7) / 8];
+    let mut fallback = vec![0u8; (len + 7) / 8];
+    for i in 0..len {
+        match i % 3 {
+            0 => { /* (false, false) */ }
+            1 => base[i / 8] |= 1 << (i % 8),
+            _ => fallback[i / 8] |= 1 << (i % 8),
+        }
+    }
+    (base, fallback)
+}
+
+fn bench_bytes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Bytes");
+    for size in [256, 512, 1024, 2048, 4096, 8192].iter() {
+        let (base_bytes, fallback_bytes) = create_test_data_bytes(*size);
+        let encoded = encode_from_bytes(&base_bytes, &fallback_bytes, *size).unwrap();
+
+        group.bench_with_input(BenchmarkId::new("encode", size), size, |b, _| {
+            b.iter(|| encode_from_bytes(&base_bytes, &fallback_bytes, *size).unwrap());
+        });
+        group.bench_with_input(BenchmarkId::new("decode", size), size, |b, _| {
+            b.iter(|| decode_to_bytes(&encoded, *size).unwrap());
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_bytes);
+criterion_main!(benches);


### PR DESCRIPTION
Adding benches for the `base3-encoding` crate.

The following is the result of running benches on my m1 mac.

```
BitVec/encode/256       time:   [302.23 ns 302.43 ns 302.69 ns]
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) high mild
  9 (9.00%) high severe
BitVec/decode/256       time:   [205.48 ns 205.56 ns 205.66 ns]
Found 15 outliers among 100 measurements (15.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  10 (10.00%) high severe
BitVec/encode/512       time:   [579.18 ns 579.46 ns 579.85 ns]
Found 16 outliers among 100 measurements (16.00%)
  8 (8.00%) high mild
  8 (8.00%) high severe
BitVec/decode/512       time:   [375.45 ns 375.79 ns 376.29 ns]
Found 15 outliers among 100 measurements (15.00%)
  2 (2.00%) high mild
  13 (13.00%) high severe
BitVec/encode/1024      time:   [1.1601 µs 1.1613 µs 1.1626 µs]
Found 11 outliers among 100 measurements (11.00%)
  9 (9.00%) high mild
  2 (2.00%) high severe
BitVec/decode/1024      time:   [707.96 ns 708.80 ns 709.84 ns]
Found 18 outliers among 100 measurements (18.00%)
  8 (8.00%) high mild
  10 (10.00%) high severe
BitVec/encode/2048      time:   [2.3101 µs 2.3121 µs 2.3150 µs]
Found 13 outliers among 100 measurements (13.00%)
  3 (3.00%) high mild
  10 (10.00%) high severe
BitVec/decode/2048      time:   [1.3879 µs 1.3882 µs 1.3884 µs]
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  6 (6.00%) high severe
BitVec/encode/4096      time:   [4.5750 µs 4.5772 µs 4.5801 µs]
Found 16 outliers among 100 measurements (16.00%)
  3 (3.00%) high mild
  13 (13.00%) high severe
BitVec/decode/4096      time:   [2.8084 µs 2.8104 µs 2.8130 µs]
Found 14 outliers among 100 measurements (14.00%)
  4 (4.00%) high mild
  10 (10.00%) high severe
BitVec/encode/8192      time:   [9.0509 µs 9.0529 µs 9.0555 µs]
Found 15 outliers among 100 measurements (15.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild
  8 (8.00%) high severe
```

```
Bytes/encode/256        time:   [305.42 ns 306.97 ns 308.99 ns]
                        change: [+3.8621% +4.7966% +5.6081%] (p = 0.00 < 0.05)
                        Performance has regressed.
Bytes/decode/256        time:   [204.40 ns 204.68 ns 205.04 ns]
                        change: [-0.3170% -0.1565% +0.0253%] (p = 0.08 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe
Bytes/encode/512        time:   [585.54 ns 587.85 ns 590.49 ns]
                        change: [-1.0180% -0.1918% +0.6011%] (p = 0.65 > 0.05)
                        No change in performance detected.
Found 29 outliers among 100 measurements (29.00%)
  12 (12.00%) low mild
  9 (9.00%) high mild
  8 (8.00%) high severe
Bytes/decode/512        time:   [373.47 ns 373.81 ns 374.37 ns]
                        change: [-0.4187% -0.2483% -0.0685%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe
Bytes/encode/1024       time:   [1.1508 µs 1.1520 µs 1.1535 µs]
                        change: [-0.4588% -0.0359% +0.3426%] (p = 0.86 > 0.05)
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) low mild
Bytes/decode/1024       time:   [708.60 ns 709.41 ns 710.36 ns]
                        change: [-0.9547% -0.6271% -0.3027%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 14 outliers among 100 measurements (14.00%)
  4 (4.00%) high mild
  10 (10.00%) high severe
Bytes/encode/2048       time:   [2.3193 µs 2.3226 µs 2.3257 µs]
                        change: [-0.7226% -0.4635% -0.2164%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 18 outliers among 100 measurements (18.00%)
  12 (12.00%) high mild
  6 (6.00%) high severe
Bytes/decode/2048       time:   [1.3891 µs 1.3900 µs 1.3915 µs]
                        change: [-1.0922% -0.8817% -0.6898%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 13 outliers among 100 measurements (13.00%)
  3 (3.00%) high mild
  10 (10.00%) high severe
Bytes/encode/4096       time:   [4.5762 µs 4.5785 µs 4.5816 µs]
                        change: [-0.8755% -0.5349% -0.1978%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 13 outliers among 100 measurements (13.00%)
  5 (5.00%) high mild
  8 (8.00%) high severe
Bytes/decode/4096       time:   [2.8103 µs 2.8133 µs 2.8176 µs]
                        change: [-0.4533% -0.2762% -0.0922%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 14 outliers among 100 measurements (14.00%)
  7 (7.00%) high mild
  7 (7.00%) high severe
Bytes/encode/8192       time:   [9.0809 µs 9.0905 µs 9.1023 µs]
                        change: [-1.0959% -0.7799% -0.4530%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
Bytes/decode/8192       time:   [5.5225 µs 5.5303 µs 5.5395 µs]
                        change: [+0.0990% +0.2623% +0.4404%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  8 (8.00%) high severe
```

Seems like there is minimum overhead when it comes to byte-array/bitvec conversion.