### PR TITLE
doc: update modified rust std lib link

### DIFF
--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -8,7 +8,7 @@
 //! [`solana-sdk`] crate, which reexports all modules from `solana-program`.
 //!
 //! [std]: https://doc.rust-lang.org/stable/std/
-//! [sstd]: https://solana.com/docs/programs/lang-rust#restrictions
+//! [sstd]: https://solana.com/docs/programs/limitations#rust-libraries
 //! [`solana-sdk`]: https://docs.rs/solana-sdk/latest/solana_sdk/
 //!
 //! This library defines


### PR DESCRIPTION
The initial [link](https://solana.com/docs/programs/lang-rust#restrictions) is broken
This PR updates the link to use [this](https://solana.com/docs/programs/limitations#rust-libraries) which seems to be the correct one