### PR TITLE
CI: Add backport workflow and info

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,26 @@
+name: Backport
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    name: Backport
+    runs-on: ubuntu-latest
+    # Only react to merged PRs for security reasons.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
+      )
+    steps:
+      - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ To patch all of the crates in this repo for Agave, just run:
 
 ### Publishing a crate from this repository
 
+NOTE: The repo currently contains unpublished breaking changes, so please
+double-check before publishing any crates!
+
 Unlike Agave, the solana-sdk crates are versioned independently, and published
 as needed.
 
@@ -136,6 +139,14 @@ Simply type in the path to the crate directory you want to release, ie.
 The publish job will run checks, bump the crate version, commit and tag the
 bump, publish the crate to crates.io, and finally create GitHub Release with
 a simple changelog of all commits to the crate since the previous release.
+
+### Backports
+
+If you would like to backport a pull request, simply add the appropriate label,
+named `backport <BRANCH_NAME>`.
+
+For example, to create a backport to the `maintenance/v2.x` branch, just add the
+`backport maintenance/v2.x` label.
 
 ## Testing
 


### PR DESCRIPTION
#### Problem

There's a maintenance branch for v2 crates in the SDK repo called `maintenance/v2.x`, but there's no way to automatically backport PRs to that branch.

#### Summary of changes

Copy / paste how Kit does things and include a backporting job.

There's also some new info about the maintenance branch and how to perform backports.