### PR TITLE
rent-collector: Deprecate everything except the struct

### DIFF
--- a/rent-collector/src/lib.rs
+++ b/rent-collector/src/lib.rs
@@ -40,10 +40,12 @@ impl Default for RentCollector {
 /// When rent is collected from an exempt account, rent_epoch is set to this
 /// value. The idea is to have a fixed, consistent value for rent_epoch for all accounts that do not collect rent.
 /// This enables us to get rid of the field completely.
+#[deprecated(since = "2.3.0", note = "Redefine this constant elsewhere")]
 pub const RENT_EXEMPT_RENT_EPOCH: Epoch = Epoch::MAX;
 
 /// when rent is collected for this account, this is the action to apply to the account
 #[derive(Debug)]
+#[deprecated(since = "2.3.0", note = "Redefine this struct elsewhere if needed")]
 enum RentResult {
     /// this account will never have rent collected from it
     Exempt,
@@ -79,6 +81,7 @@ impl RentCollector {
     }
 
     /// true if it is easy to determine this account should consider having rent collected from it
+    #[deprecated(since = "2.3.0", note = "Redefine this logic elsewhere if needed")]
     pub fn should_collect_rent(&self, address: &Pubkey, executable: bool) -> bool {
         !(executable // executable accounts must be rent-exempt balance
             || *address == incinerator::id())
@@ -86,6 +89,7 @@ impl RentCollector {
 
     /// given an account that 'should_collect_rent'
     /// returns (amount rent due, is_exempt_from_rent)
+    #[deprecated(since = "2.3.0", note = "Redefine this logic elsewhere if needed")]
     pub fn get_rent_due(
         &self,
         lamports: u64,
@@ -119,6 +123,8 @@ impl RentCollector {
     // This is NOT thread safe at some level. If we try to collect from the same account in
     // parallel, we may collect twice.
     #[must_use = "add to Bank::collected_rent"]
+    #[deprecated(since = "2.3.0", note = "Redefine this logic elsewhere if needed")]
+    #[allow(deprecated)]
     pub fn collect_from_existing_account(
         &self,
         address: &Pubkey,
@@ -155,6 +161,7 @@ impl RentCollector {
 
     /// determine what should happen to collect rent from this account
     #[must_use]
+    #[allow(deprecated)]
     fn calculate_rent_result(
         &self,
         address: &Pubkey,
@@ -190,6 +197,7 @@ impl RentCollector {
 
 /// Information computed during rent collection
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+#[deprecated(since = "2.3.0", note = "Redefine this logic elsewhere if needed")]
 pub struct CollectedInfo {
     /// Amount of rent collected from account
     pub rent_amount: u64,
@@ -197,6 +205,7 @@ pub struct CollectedInfo {
     pub account_data_len_reclaimed: u64,
 }
 
+#[allow(deprecated)]
 impl std::ops::Add for CollectedInfo {
     type Output = Self;
     fn add(self, other: Self) -> Self {
@@ -209,14 +218,16 @@ impl std::ops::Add for CollectedInfo {
     }
 }
 
+#[allow(deprecated)]
+#[allow(clippy::arithmetic_side_effects)]
 impl std::ops::AddAssign for CollectedInfo {
-    #![allow(clippy::arithmetic_side_effects)]
     fn add_assign(&mut self, other: Self) {
         *self = *self + other;
     }
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use {
         super::*, assert_matches::assert_matches, solana_account::Account, solana_sdk_ids::sysvar,


### PR DESCRIPTION
#### Problem

The rent collector is still being used in Agave to hold onto the `Rent` for the cluster, but is otherwise unused.

#### Summary of changes

Deprecate all functions and constants that should be redefined elsewhere.

I decided to not deprecate the whole thing since Agave still needs the `RentCollector` struct, but full deprecation is also an option.

This will be backported to maintenance/v2.x. If we decide on full deprecation, then we can also remove the crate entirely.