### PR TITLE
deps: Bump tokio to 1.43.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4389,9 +4389,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "492a604e2fd7f814268a378409e6c92b5525d747d10db9a229723f55a417958c"
 dependencies = [
  "backtrace",
  "bytes",


### PR DESCRIPTION
#### Problem

The SDK depends on tokio v1.43.0, which has a small security issue. Although this isn't directly an issue since this repo only has libraries, there's no reason to keep around the issue.

#### Summary of changes

Simply bump to 1.43.1.