### PR TITLE
message / transaction: Remove dependency on solana-system-interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4122,7 +4122,6 @@ dependencies = [
  "borsh",
  "serde",
  "serde_derive",
- "solana-bincode",
  "solana-example-mocks",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3426,7 +3426,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-address-lookup-table-interface",
- "solana-bincode",
  "solana-example-mocks",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",

--- a/client-traits/Cargo.toml
+++ b/client-traits/Cargo.toml
@@ -23,6 +23,6 @@ solana-message = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }
-solana-system-interface = { workspace = true }
+solana-system-interface = { workspace = true, features = ["bincode"] }
 solana-transaction = { workspace = true, features = ["bincode"] }
 solana-transaction-error = { workspace = true }

--- a/message/Cargo.toml
+++ b/message/Cargo.toml
@@ -17,8 +17,6 @@ rustdoc-args = ["--cfg=docsrs"]
 [features]
 bincode = [
     "dep:bincode",
-    "dep:solana-bincode",
-    "dep:solana-system-interface",
     "serde",
 ]
 blake3 = ["dep:blake3"]
@@ -45,7 +43,6 @@ blake3 = { workspace = true, features = ["traits-preview"], optional = true }
 lazy_static = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-solana-bincode = { workspace = true, optional = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-hash = { workspace = true }
@@ -55,9 +52,6 @@ solana-pubkey = { workspace = true }
 solana-sanitize = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-short-vec = { workspace = true, optional = true }
-solana-system-interface = { workspace = true, optional = true, features = [
-    "bincode",
-] }
 solana-transaction-error = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -70,11 +64,13 @@ borsh = { workspace = true }
 itertools = { workspace = true }
 serde_json = { workspace = true }
 solana-address-lookup-table-interface = { workspace = true, features = ["bincode", "bytemuck"] }
+solana-bincode = { workspace = true }
 solana-example-mocks = { path = "../example-mocks" }
 solana-instruction = { workspace = true, features = ["borsh"] }
 solana-instruction-error = { workspace = true, features = ["std"] }
 solana-message = { path = ".", features = ["dev-context-only-utils"] }
 solana-nonce = { workspace = true }
+solana-system-interface = { workspace = true, features = ["bincode"] }
 static_assertions = { workspace = true }
 
 [lints]

--- a/message/Cargo.toml
+++ b/message/Cargo.toml
@@ -61,7 +61,6 @@ borsh = { workspace = true }
 itertools = { workspace = true }
 serde_json = { workspace = true }
 solana-address-lookup-table-interface = { workspace = true, features = ["bincode", "bytemuck"] }
-solana-bincode = { workspace = true }
 solana-example-mocks = { path = "../example-mocks" }
 solana-instruction = { workspace = true, features = ["borsh"] }
 solana-instruction-error = { workspace = true, features = ["std"] }

--- a/message/Cargo.toml
+++ b/message/Cargo.toml
@@ -15,10 +15,7 @@ all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
 [features]
-bincode = [
-    "dep:bincode",
-    "serde",
-]
+bincode = ["dep:bincode", "serde"]
 blake3 = ["dep:blake3"]
 dev-context-only-utils = ["bincode", "blake3"]
 frozen-abi = [

--- a/message/src/inline_nonce.rs
+++ b/message/src/inline_nonce.rs
@@ -1,0 +1,66 @@
+//! Inlined nonce instruction information to avoid a dependency on bincode and
+//! solana-system-interface
+use {
+    solana_instruction::{AccountMeta, Instruction},
+    solana_pubkey::Pubkey,
+    solana_sdk_ids::{system_program, sysvar},
+};
+
+/// Inlined `SystemInstruction::AdvanceNonceAccount` instruction data to avoid
+/// solana_system_interface and bincode deps
+const ADVANCE_NONCE_DATA: [u8; 4] = [4, 0, 0, 0];
+
+/// Check if the given instruction data is the same as
+/// `SystemInstruction::AdvanceNonceAccount`.
+///
+/// NOTE: It's possible for additional data to exist after the 4th byte, but
+/// users of this function only look at the first 4 bytes.
+pub fn is_advance_nonce_instruction_data(data: &[u8]) -> bool {
+    data.get(0..4) == Some(&ADVANCE_NONCE_DATA)
+}
+
+/// Inlined `advance_nonce_account` instruction creator to avoid
+/// solana_system_interface and bincode deps
+pub(crate) fn advance_nonce_account_instruction(
+    nonce_pubkey: &Pubkey,
+    nonce_authority_pubkey: &Pubkey,
+) -> Instruction {
+    Instruction::new_with_bytes(
+        system_program::id(),
+        &ADVANCE_NONCE_DATA,
+        vec![
+            AccountMeta::new(*nonce_pubkey, false),
+            #[allow(deprecated)]
+            AccountMeta::new_readonly(sysvar::recent_blockhashes::id(), false),
+            AccountMeta::new_readonly(*nonce_authority_pubkey, true),
+        ],
+    )
+}
+
+#[cfg(test)]
+mod test {
+    use {
+        super::*,
+        solana_system_interface::instruction::{advance_nonce_account, SystemInstruction},
+    };
+
+    #[test]
+    fn inline_instruction_data_matches_program() {
+        let nonce = Pubkey::new_unique();
+        let nonce_authority = Pubkey::new_unique();
+        assert_eq!(
+            advance_nonce_account_instruction(&nonce, &nonce_authority),
+            advance_nonce_account(&nonce, &nonce_authority),
+        );
+    }
+
+    #[test]
+    fn test_advance_nonce_ix_prefix() {
+        let advance_nonce_ix: SystemInstruction = solana_bincode::limited_deserialize(
+            &ADVANCE_NONCE_DATA[..],
+            4, /* serialized size of AdvanceNonceAccount */
+        )
+        .unwrap();
+        assert_eq!(advance_nonce_ix, SystemInstruction::AdvanceNonceAccount);
+    }
+}

--- a/message/src/inline_nonce.rs
+++ b/message/src/inline_nonce.rs
@@ -56,11 +56,8 @@ mod test {
 
     #[test]
     fn test_advance_nonce_ix_prefix() {
-        let advance_nonce_ix: SystemInstruction = solana_bincode::limited_deserialize(
-            &ADVANCE_NONCE_DATA[..],
-            4, /* serialized size of AdvanceNonceAccount */
-        )
-        .unwrap();
+        let advance_nonce_ix: SystemInstruction =
+            bincode::deserialize(&ADVANCE_NONCE_DATA).unwrap();
         assert_eq!(advance_nonce_ix, SystemInstruction::AdvanceNonceAccount);
     }
 }

--- a/message/src/legacy.rs
+++ b/message/src/legacy.rs
@@ -19,7 +19,8 @@ use solana_frozen_abi_macro::{frozen_abi, AbiExample};
 use wasm_bindgen::prelude::wasm_bindgen;
 use {
     crate::{
-        compiled_instruction::CompiledInstruction, compiled_keys::CompiledKeys, MessageHeader,
+        compiled_instruction::CompiledInstruction, compiled_keys::CompiledKeys,
+        inline_nonce::advance_nonce_account_instruction, MessageHeader,
     },
     solana_hash::Hash,
     solana_instruction::Instruction,
@@ -430,17 +431,14 @@ impl Message {
     /// # create_offline_initialize_tx(&client, program_id, &payer)?;
     /// # Ok::<(), anyhow::Error>(())
     /// ```
-    #[cfg(feature = "bincode")]
     pub fn new_with_nonce(
         mut instructions: Vec<Instruction>,
         payer: Option<&Pubkey>,
         nonce_account_pubkey: &Pubkey,
         nonce_authority_pubkey: &Pubkey,
     ) -> Self {
-        let nonce_ix = solana_system_interface::instruction::advance_nonce_account(
-            nonce_account_pubkey,
-            nonce_authority_pubkey,
-        );
+        let nonce_ix =
+            advance_nonce_account_instruction(nonce_account_pubkey, nonce_authority_pubkey);
         instructions.insert(0, nonce_ix);
         Self::new(&instructions, payer)
     }

--- a/message/src/lib.rs
+++ b/message/src/lib.rs
@@ -41,6 +41,7 @@
 
 pub mod compiled_instruction;
 mod compiled_keys;
+pub mod inline_nonce;
 pub mod inner_instruction;
 pub mod legacy;
 #[cfg(feature = "serde")]

--- a/message/src/sanitized.rs
+++ b/message/src/sanitized.rs
@@ -324,14 +324,7 @@ impl SanitizedMessage {
                     _ => false,
                 },
             )
-            .filter(|ix| {
-                matches!(
-                    solana_bincode::limited_deserialize(
-                        &ix.data, 4 /* serialized size of AdvanceNonceAccount */
-                    ),
-                    Ok(solana_system_interface::instruction::SystemInstruction::AdvanceNonceAccount)
-                )
-            })
+            .filter(|ix| crate::inline_nonce::is_advance_nonce_instruction_data(&ix.data))
             .and_then(|ix| {
                 ix.accounts.first().and_then(|idx| {
                     let idx = *idx as usize;

--- a/message/src/sanitized.rs
+++ b/message/src/sanitized.rs
@@ -15,7 +15,6 @@ use {
 };
 
 // inlined to avoid solana_nonce dep
-#[cfg(feature = "bincode")]
 const NONCED_TX_MARKER_IX_INDEX: u8 = 0;
 #[cfg(test)]
 static_assertions::const_assert_eq!(
@@ -313,7 +312,6 @@ impl SanitizedMessage {
             })
     }
 
-    #[cfg(feature = "bincode")]
     /// If the message uses a durable nonce, return the pubkey of the nonce account
     pub fn get_durable_nonce(&self) -> Option<&Pubkey> {
         self.instructions()

--- a/transaction/Cargo.toml
+++ b/transaction/Cargo.toml
@@ -17,9 +17,7 @@ rustdoc-args = ["--cfg=docsrs"]
 [features]
 bincode = [
     "dep:bincode",
-    "dep:solana-bincode",
     "dep:solana-signer",
-    "dep:solana-system-interface",
     "serde",
     "solana-message/bincode",
 ]
@@ -43,7 +41,6 @@ verify = ["blake3", "solana-signature/verify"]
 bincode = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-solana-bincode = { workspace = true, optional = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-hash = { workspace = true }
@@ -56,7 +53,6 @@ solana-sdk-ids = { workspace = true }
 solana-short-vec = { workspace = true, optional = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true, optional = true }
-solana-system-interface = { workspace = true, optional = true, features = ["bincode"] }
 solana-transaction-error = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -76,6 +72,7 @@ solana-packet = { workspace = true }
 solana-presigner = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-sha256-hasher = { workspace = true }
+solana-system-interface = { workspace = true, features = ["bincode"] }
 solana-transaction = { path = ".", features = ["dev-context-only-utils"] }
 solana-vote-interface = { workspace = true, features = ["bincode"] }
 static_assertions = { workspace = true }

--- a/transaction/src/lib.rs
+++ b/transaction/src/lib.rs
@@ -120,17 +120,17 @@ use {
 #[cfg(feature = "bincode")]
 use {
     solana_hash::Hash,
-    solana_message::{
-        compiled_instruction::CompiledInstruction, inline_nonce::is_advance_nonce_instruction_data,
-    },
-    solana_sdk_ids::system_program,
     solana_signer::{signers::Signers, SignerError},
 };
 use {
     solana_instruction::Instruction,
-    solana_message::Message,
+    solana_message::{
+        compiled_instruction::CompiledInstruction, inline_nonce::is_advance_nonce_instruction_data,
+        Message,
+    },
     solana_pubkey::Pubkey,
     solana_sanitize::{Sanitize, SanitizeError},
+    solana_sdk_ids::system_program,
     solana_signature::Signature,
     solana_transaction_error::{TransactionError, TransactionResult as Result},
     std::result,
@@ -154,7 +154,6 @@ static_assertions::const_assert_eq!(
     NONCED_TX_MARKER_IX_INDEX,
     solana_nonce::NONCED_TX_MARKER_IX_INDEX
 );
-#[cfg(feature = "bincode")]
 const NONCED_TX_MARKER_IX_INDEX: u8 = 0;
 
 /// An atomically-committed sequence of instructions.

--- a/transaction/src/lib.rs
+++ b/transaction/src/lib.rs
@@ -119,12 +119,12 @@ use {
 };
 #[cfg(feature = "bincode")]
 use {
-    solana_bincode::limited_deserialize,
     solana_hash::Hash,
-    solana_message::compiled_instruction::CompiledInstruction,
+    solana_message::{
+        compiled_instruction::CompiledInstruction, inline_nonce::is_advance_nonce_instruction_data,
+    },
     solana_sdk_ids::system_program,
     solana_signer::{signers::Signers, SignerError},
-    solana_system_interface::instruction::SystemInstruction,
 };
 use {
     solana_instruction::Instruction,
@@ -156,11 +156,6 @@ static_assertions::const_assert_eq!(
 );
 #[cfg(feature = "bincode")]
 const NONCED_TX_MARKER_IX_INDEX: u8 = 0;
-// inlined to avoid solana-packet dep
-#[cfg(test)]
-static_assertions::const_assert_eq!(PACKET_DATA_SIZE, solana_packet::PACKET_DATA_SIZE);
-#[cfg(feature = "bincode")]
-const PACKET_DATA_SIZE: usize = 1280 - 40 - 8;
 
 /// An atomically-committed sequence of instructions.
 ///
@@ -1122,12 +1117,7 @@ pub fn uses_durable_nonce(tx: &Transaction) -> Option<&CompiledInstruction> {
             matches!(
                 message.account_keys.get(instruction.program_id_index as usize),
                 Some(program_id) if system_program::check_id(program_id)
-            )
-            // Is a nonce advance instruction
-            && matches!(
-                limited_deserialize(&instruction.data, PACKET_DATA_SIZE as u64),
-                Ok(SystemInstruction::AdvanceNonceAccount)
-            )
+            ) && is_advance_nonce_instruction_data(&instruction.data)
         })
 }
 

--- a/transaction/src/lib.rs
+++ b/transaction/src/lib.rs
@@ -1105,7 +1105,6 @@ impl Transaction {
     }
 }
 
-#[cfg(feature = "bincode")]
 /// Returns true if transaction begins with an advance nonce instruction.
 pub fn uses_durable_nonce(tx: &Transaction) -> Option<&CompiledInstruction> {
     let message = tx.message();

--- a/transaction/src/versioned/mod.rs
+++ b/transaction/src/versioned/mod.rs
@@ -1,19 +1,19 @@
 //! Defines a transaction which supports multiple versions of messages.
 
+#[cfg(feature = "bincode")]
+use solana_signer::{signers::Signers, SignerError};
 use {
-    crate::Transaction, solana_message::VersionedMessage, solana_sanitize::SanitizeError,
-    solana_signature::Signature, std::cmp::Ordering,
+    crate::Transaction,
+    solana_message::{inline_nonce::is_advance_nonce_instruction_data, VersionedMessage},
+    solana_sanitize::SanitizeError,
+    solana_sdk_ids::system_program,
+    solana_signature::Signature,
+    std::cmp::Ordering,
 };
 #[cfg(feature = "serde")]
 use {
     serde_derive::{Deserialize, Serialize},
     solana_short_vec as short_vec,
-};
-#[cfg(feature = "bincode")]
-use {
-    solana_message::inline_nonce::is_advance_nonce_instruction_data,
-    solana_sdk_ids::system_program,
-    solana_signer::{signers::Signers, SignerError},
 };
 
 pub mod sanitized;

--- a/transaction/src/versioned/mod.rs
+++ b/transaction/src/versioned/mod.rs
@@ -203,7 +203,6 @@ impl VersionedTransaction {
             .collect()
     }
 
-    #[cfg(feature = "bincode")]
     /// Returns true if transaction begins with an advance nonce instruction.
     pub fn uses_durable_nonce(&self) -> bool {
         let message = &self.message;

--- a/transaction/src/versioned/mod.rs
+++ b/transaction/src/versioned/mod.rs
@@ -11,10 +11,9 @@ use {
 };
 #[cfg(feature = "bincode")]
 use {
-    solana_bincode::limited_deserialize,
+    solana_message::inline_nonce::is_advance_nonce_instruction_data,
     solana_sdk_ids::system_program,
     solana_signer::{signers::Signers, SignerError},
-    solana_system_interface::instruction::SystemInstruction,
 };
 
 pub mod sanitized;
@@ -216,12 +215,7 @@ impl VersionedTransaction {
                 matches!(
                     message.static_account_keys().get(instruction.program_id_index as usize),
                     Some(program_id) if system_program::check_id(program_id)
-                )
-                // Is a nonce advance instruction
-                && matches!(
-                    limited_deserialize(&instruction.data, crate::PACKET_DATA_SIZE as u64,),
-                    Ok(SystemInstruction::AdvanceNonceAccount)
-                )
+                ) && is_advance_nonce_instruction_data(&instruction.data)
             })
             .is_some()
     }


### PR DESCRIPTION
#### Problem

While debugging changes to the wasm-js build, I noticed that `solana-transaction` and `solana-message` were pulling in `solana-system-interface` in a lot of situations, even though there's a lot of code in place to make sure that doesn't happen.

#### Summary of changes

Totally remove the dependency on solana-system-interface by inlining some nonce-related code in solana-message.