### PR TITLE
wasm-js!: Remove system program dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3811,10 +3811,13 @@ version = "1.0.0"
 dependencies = [
  "console_error_panic_hook",
  "console_log",
+ "getrandom 0.1.16",
  "log",
+ "solana-hash",
  "solana-instruction",
- "solana-program",
- "solana-sdk",
+ "solana-keypair",
+ "solana-pubkey",
+ "solana-transaction",
  "wasm-bindgen",
 ]
 

--- a/instruction/src/account_meta.rs
+++ b/instruction/src/account_meta.rs
@@ -17,8 +17,7 @@ use solana_pubkey::Pubkey;
 ///
 /// [`Instruction`]: crate::Instruction
 #[repr(C)]
-#[cfg(all(feature = "std", target_arch = "wasm32"))]
-#[wasm_bindgen::prelude::wasm_bindgen]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
 #[cfg_attr(
     feature = "serde",
     derive(serde_derive::Serialize, serde_derive::Deserialize)

--- a/instruction/src/account_meta.rs
+++ b/instruction/src/account_meta.rs
@@ -17,6 +17,8 @@ use solana_pubkey::Pubkey;
 ///
 /// [`Instruction`]: crate::Instruction
 #[repr(C)]
+#[cfg(all(feature = "std", target_arch = "wasm32"))]
+#[wasm_bindgen::prelude::wasm_bindgen]
 #[cfg_attr(
     feature = "serde",
     derive(serde_derive::Serialize, serde_derive::Deserialize)

--- a/instruction/src/wasm.rs
+++ b/instruction/src/wasm.rs
@@ -1,7 +1,12 @@
 //! The `Instructions` struct is a legacy workaround
 //! from when wasm-bindgen lacked Vec<T> support
 //! (ref: https://github.com/rustwasm/wasm-bindgen/issues/111)
-use {crate::Instruction, wasm_bindgen::prelude::*};
+#![allow(non_snake_case)]
+use {
+    crate::{AccountMeta, Instruction},
+    solana_pubkey::Pubkey,
+    wasm_bindgen::prelude::*,
+};
 
 #[wasm_bindgen]
 #[derive(Default)]
@@ -24,5 +29,32 @@ impl Instructions {
 impl From<Instructions> for std::vec::Vec<Instruction> {
     fn from(instructions: Instructions) -> Self {
         instructions.instructions
+    }
+}
+
+#[wasm_bindgen]
+impl Instruction {
+    /// Create a new `Instruction`
+    #[wasm_bindgen(constructor)]
+    pub fn constructor(program_id: Pubkey, data: &[u8]) -> Self {
+        Instruction::new_with_bytes(program_id, data, std::vec::Vec::new())
+    }
+
+    pub fn pushAccount(mut self, account_meta: AccountMeta) -> Self {
+        self.accounts.push(account_meta);
+        self
+    }
+}
+
+#[wasm_bindgen]
+impl AccountMeta {
+    /// Create a new writable `AccountMeta`
+    pub fn newWritable(pubkey: Pubkey, is_signer: bool) -> Self {
+        AccountMeta::new(pubkey, is_signer)
+    }
+
+    /// Create a new readonly `AccountMeta`
+    pub fn newReadonly(pubkey: Pubkey, is_signer: bool) -> Self {
+        AccountMeta::new_readonly(pubkey, is_signer)
     }
 }

--- a/instruction/src/wasm.rs
+++ b/instruction/src/wasm.rs
@@ -36,13 +36,16 @@ impl From<Instructions> for std::vec::Vec<Instruction> {
 impl Instruction {
     /// Create a new `Instruction`
     #[wasm_bindgen(constructor)]
-    pub fn constructor(program_id: Pubkey, data: &[u8]) -> Self {
-        Instruction::new_with_bytes(program_id, data, std::vec::Vec::new())
+    pub fn constructor(program_id: Pubkey) -> Self {
+        Instruction::new_with_bytes(program_id, &[], std::vec::Vec::new())
     }
 
-    pub fn pushAccount(mut self, account_meta: AccountMeta) -> Self {
+    pub fn setData(&mut self, data: &[u8]) {
+        self.data = data.to_vec();
+    }
+
+    pub fn addAccount(&mut self, account_meta: AccountMeta) {
         self.accounts.push(account_meta);
-        self
     }
 }
 

--- a/sdk-wasm-js/Cargo.toml
+++ b/sdk-wasm-js/Cargo.toml
@@ -18,13 +18,16 @@ rustdoc-args = ["--cfg=docsrs"]
 crate-type = ["cdylib"]
 
 [dependencies]
+solana-hash = { workspace = true }
 solana-instruction = { workspace = true, features = ["std"] }
-solana-program = { workspace = true }
-solana-sdk = { workspace = true }
+solana-keypair = { workspace = true }
+solana-pubkey = { workspace = true, features = ["curve25519", "sha2"] }
+solana-transaction = { workspace = true, features = ["bincode", "verify"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = { workspace = true }
 console_log = { workspace = true }
+getrandom = { version = "0.1.1", features = ["wasm-bindgen"] }
 log = { workspace = true }
 wasm-bindgen = { workspace = true }
 

--- a/sdk-wasm-js/src/lib.rs
+++ b/sdk-wasm-js/src/lib.rs
@@ -1,23 +1,12 @@
 //! solana-program Javascript interface
 #![cfg(target_arch = "wasm32")]
+
 #[deprecated(since = "2.2.0", note = "Use solana_instruction::wasm instead.")]
 pub use solana_instruction::wasm as instructions;
 use {::log::Level, wasm_bindgen::prelude::*};
 pub use {
-    solana_program::*,
-    solana_sdk::{
-        // These imports exist in both solana_sdk and solana_program, so we use
-        // direct imports to suppress ambiguous re-export warnings.
-        declare_deprecated_id,
-        declare_id,
-        entrypoint,
-        entrypoint_deprecated,
-        example_mocks,
-        hash,
-        program_stubs,
-        pubkey,
-        *,
-    },
+    solana_hash::*, solana_instruction::*, solana_keypair::*, solana_pubkey::*,
+    solana_transaction::*,
 };
 
 // This module is intentionally left empty. The wasm system instruction impl can be

--- a/sdk-wasm-js/tests/transaction.mjs
+++ b/sdk-wasm-js/tests/transaction.mjs
@@ -1,17 +1,18 @@
 import { expect } from "chai";
 import {
   solana_program_init,
+  AccountMeta,
   Pubkey,
   Keypair,
   Hash,
-  SystemInstruction,
+  Instruction,
   Instructions,
   Transaction,
 } from "crate";
 solana_program_init();
 
 describe("Transaction", function () {
-  it("SystemInstruction::Transfer", () => {
+  it("Instruction", () => {
     const payer = Keypair.fromBytes(
       new Uint8Array([
         241, 230, 222, 64, 184, 48, 232, 92, 156, 210, 229, 183, 154, 251, 5,
@@ -32,20 +33,24 @@ describe("Transaction", function () {
       ])
     );
 
+    const programId = new Pubkey("11111111111111111111111111111111");
     const dst = new Pubkey("11111111111111111111111111111112");
+    const instructionData = new Uint8Array([2, 0, 0, 0, 123, 0, 0, 0, 0, 0, 0, 0]);
 
-    const recent_blockhash = new Hash(
+    const recentBlockhash = new Hash(
       "EETubP5AKHgjPAhzPAFcb8BAY1hMH639CWCFTqi3hq1k"
     );
 
     let instructions = new Instructions();
     instructions.push(
-      SystemInstruction.transfer(src.pubkey(), dst, BigInt(123))
+      new Instruction(programId, instructionData)
+        .pushAccount(AccountMeta.newWritable(src.pubkey(), true))
+        .pushAccount(AccountMeta.newWritable(dst, false))
     );
 
     let transaction = new Transaction(instructions, payer.pubkey());
-    transaction.partialSign(payer, recent_blockhash);
-    transaction.partialSign(src, recent_blockhash);
+    transaction.partialSign(payer, recentBlockhash);
+    transaction.partialSign(src, recentBlockhash);
     expect(transaction.isSigned()).to.be.true;
     transaction.verify();
 

--- a/sdk-wasm-js/tests/transaction.mjs
+++ b/sdk-wasm-js/tests/transaction.mjs
@@ -42,11 +42,11 @@ describe("Transaction", function () {
     );
 
     let instructions = new Instructions();
-    instructions.push(
-      new Instruction(programId, instructionData)
-        .pushAccount(AccountMeta.newWritable(src.pubkey(), true))
-        .pushAccount(AccountMeta.newWritable(dst, false))
-    );
+    let instruction = new Instruction(programId);
+    instruction.setData(instructionData);
+    instruction.addAccount(AccountMeta.newWritable(src.pubkey(), true))
+    instruction.addAccount(AccountMeta.newWritable(dst, false))
+    instructions.push(instruction);
 
     let transaction = new Transaction(instructions, payer.pubkey());
     transaction.partialSign(payer, recentBlockhash);


### PR DESCRIPTION
#### Problem

While working on the refactor of all wasm-js logic into sdk-wasm-js, I noticed that no matter what I did, `SystemInstruction` still made it into the final build. That made it impossible to build the package with breaking changes.

#### Summary of changes

Remove the usage of `SystemInstruction` in the tests. This required exposing `Instruction` and `AccountMeta` through wasm-bindgen to be able to create instructions.

The API doesn't need to be perfect, just usable, so I went with a builder pattern for adding `AccountMeta`s to an `Instruction`, which hugely simplifies the logic. Otherwise we'd need to perform conversions between JS arrays and `Vec<AccountMeta>`, which I was too lazy to do properly because wasm-js crate is more of a proof-of-concept.

While doing that, I moved the wasm-js deps to the component crates that were required for the tests.