### PR TITLE
secp256k1-program: Fix doc tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -405,8 +405,14 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup
         with:
-          cargo-cache-key: cargo-stable-doc
-          cargo-cache-fallback-key: cargo-stable
+          nightly-toolchain: true
+          cargo-cache-key: cargo-nightly-doc
+          cargo-cache-fallback-key: cargo-nightly
+
+      - name: Install cargo-hack
+        uses: taiki-e/cache-cargo-install-action@v2
+        with:
+          tool: cargo-hack
 
       - name: Run doc tests
         run: ./scripts/test-doc.sh

--- a/scripts/test-doc.sh
+++ b/scripts/test-doc.sh
@@ -5,4 +5,4 @@ here="$(dirname "$0")"
 src_root="$(readlink -f "${here}/..")"
 cd "${src_root}"
 
-cargo test --all --doc -- --nocapture
+./cargo nightly hack test --doc -- --nocapture

--- a/sdk-wasm-js/Cargo.toml
+++ b/sdk-wasm-js/Cargo.toml
@@ -15,7 +15,7 @@ all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 solana-hash = { workspace = true }

--- a/secp256k1-program/Cargo.toml
+++ b/secp256k1-program/Cargo.toml
@@ -43,7 +43,7 @@ solana-account-info = { workspace = true }
 solana-example-mocks = { path = "../example-mocks" }
 solana-instruction = { workspace = true }
 solana-instructions-sysvar = { workspace = true }
-solana-keccak-hasher = { workspace = true }
+solana-keccak-hasher = { workspace = true, features = ["sha3"] }
 solana-msg = { workspace = true }
 solana-program-error = { workspace = true }
 solana-secp256k1-program = { path = ".", features = ["bincode"] }


### PR DESCRIPTION
#### Problem

The doctests for secp256k1-program fail when run on the crate individually because of a missing feature declaration on `solana-keccak-hasher`.

#### Summary of changes

Add the feature. At the same time, run the doctests with `cargo-hack` to catch these in the future.

The sdk-wasm-js package fails to run doctests because it doesn't have an rlib target, so add that too.