### PR TITLE
deps: Unpin array-bytes and ed25519-dalek

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ ark-bn254 = "0.4.0"
 ark-ec = "0.4.0"
 ark-ff = "0.4.0"
 ark-serialize = "0.4.0"
-array-bytes = "=1.4.1"
+array-bytes = "1.4.1"
 assert_matches = "1.5.0"
 base64 = "0.22.1"
 bincode = "1.3.3"
@@ -158,7 +158,7 @@ curve25519-dalek = { version = "4.1.3", features = ["digest", "rand_core"] }
 dashmap = { version = "5.5.3", features = ["serde"] }
 derivation-path = { version = "0.2.0", default-features = false }
 digest = "0.10.7"
-ed25519-dalek = "=2.1.1"
+ed25519-dalek = "2.1.1"
 ed25519-dalek-bip32 = "0.3.0"
 env_logger = "0.11.0"
 ff = "0.13.1"


### PR DESCRIPTION
#### Problem

The SDK repo provides libraries, which should allow downstream users some flexibility when choosing what dependencies they want to use. However, we currently pin two dependencies: array-bytes and ed25519-dalek.

#### Summary of changes

Unpin both of them!

array-bytes is only used in tests, so it shouldn't have any impact. ed25519-dalek is definitely more sensitive, but Agave and other downstream users should decide what version they want to use, and we shouldn't force that at the library level.