### PR TITLE
sha256-hasher: Deprecate `extend_and_hash`

### DIFF
--- a/program/src/hash.rs
+++ b/program/src/hash.rs
@@ -3,9 +3,11 @@
 //! [SHA-256]: https://en.wikipedia.org/wiki/SHA-2
 //! [`Hash`]: struct@Hash
 
+#[allow(deprecated)]
+pub use solana_sha256_hasher::extend_and_hash;
 #[cfg(not(target_os = "solana"))]
 pub use solana_sha256_hasher::Hasher;
 pub use {
     solana_hash::{Hash, ParseHashError, HASH_BYTES},
-    solana_sha256_hasher::{extend_and_hash, hash, hashv},
+    solana_sha256_hasher::{hash, hashv},
 };

--- a/sha256-hasher/src/lib.rs
+++ b/sha256-hasher/src/lib.rs
@@ -67,6 +67,7 @@ pub fn hash(val: &[u8]) -> Hash {
 }
 
 /// Return the hash of the given hash extended with the given value.
+#[deprecated(since = "2.3.0", note = "Use `hashv(&[hash.as_ref(), val])` directly")]
 pub fn extend_and_hash(id: &Hash, val: &[u8]) -> Hash {
     let mut hash_data = id.as_ref().to_vec();
     hash_data.extend_from_slice(val);

--- a/shred-version/src/lib.rs
+++ b/shred-version/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! [shred]: https://solana.com/docs/terminology#shred
 
-use {solana_hard_forks::HardForks, solana_hash::Hash, solana_sha256_hasher::extend_and_hash};
+use {solana_hard_forks::HardForks, solana_hash::Hash, solana_sha256_hasher::hashv};
 
 pub fn version_from_hash(hash: &Hash) -> u16 {
     let hash = hash.as_ref();
@@ -27,7 +27,7 @@ pub fn compute_shred_version(genesis_hash: &Hash, hard_forks: Option<&HardForks>
     if let Some(hard_forks) = hard_forks {
         for &(slot, count) in hard_forks.iter() {
             let buf = [slot.to_le_bytes(), (count as u64).to_le_bytes()].concat();
-            hash = extend_and_hash(&hash, &buf);
+            hash = hashv(&[hash.as_ref(), &buf]);
         }
     }
 


### PR DESCRIPTION
#### Problem

As noted in https://github.com/anza-xyz/agave/pull/7028, the `extend_and_hash` function is unnecessary and creates another allocation, so we inlined it in Agave.

#### Summary of changes

Deprecate it formally in the crate. This PR will be backported to v2.x and published, so we can remove the function in a follow-up PR.