### PR TITLE
sha256-hasher: Remove `extend_and_hash`

### DIFF
--- a/program/src/hash.rs
+++ b/program/src/hash.rs
@@ -3,8 +3,6 @@
 //! [SHA-256]: https://en.wikipedia.org/wiki/SHA-2
 //! [`Hash`]: struct@Hash
 
-#[allow(deprecated)]
-pub use solana_sha256_hasher::extend_and_hash;
 #[cfg(not(target_os = "solana"))]
 pub use solana_sha256_hasher::Hasher;
 pub use {

--- a/sha256-hasher/src/lib.rs
+++ b/sha256-hasher/src/lib.rs
@@ -65,11 +65,3 @@ pub fn hashv(vals: &[&[u8]]) -> Hash {
 pub fn hash(val: &[u8]) -> Hash {
     hashv(&[val])
 }
-
-/// Return the hash of the given hash extended with the given value.
-#[deprecated(since = "2.3.0", note = "Use `hashv(&[hash.as_ref(), val])` directly")]
-pub fn extend_and_hash(id: &Hash, val: &[u8]) -> Hash {
-    let mut hash_data = id.as_ref().to_vec();
-    hash_data.extend_from_slice(val);
-    hash(&hash_data)
-}


### PR DESCRIPTION
#### Problem

As mentioned in anza-xyz/agave#7028, the `extend_and_hash` function is unnecessary and creates another allocation, so we inlined it in Agave.

#### Summary of changes

Since it's been properly marked as deprecated, remove it.