### PR TITLE
{instruction,program}error!: remove unused std features

### DIFF
--- a/instruction-error/Cargo.toml
+++ b/instruction-error/Cargo.toml
@@ -20,11 +20,9 @@ frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
     "serde",
-    "std",
 ]
 num-traits = ["dep:num-traits"]
 serde = ["dep:serde", "dep:serde_derive"]
-std = []
 
 [dependencies]
 num-traits = { workspace = true, optional = true }

--- a/instruction-error/src/lib.rs
+++ b/instruction-error/src/lib.rs
@@ -5,8 +5,6 @@ use core::fmt;
 use num_traits::ToPrimitive;
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::{AbiEnumVisitor, AbiExample};
-#[cfg(feature = "std")]
-extern crate std;
 use solana_program_error::ProgramError;
 pub use solana_program_error::{
     ACCOUNT_ALREADY_INITIALIZED, ACCOUNT_BORROW_FAILED, ACCOUNT_DATA_TOO_SMALL,

--- a/instruction-error/src/lib.rs
+++ b/instruction-error/src/lib.rs
@@ -1,11 +1,9 @@
 #![no_std]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
-use core::fmt;
 #[cfg(feature = "num-traits")]
 use num_traits::ToPrimitive;
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::{AbiEnumVisitor, AbiExample};
-use solana_program_error::ProgramError;
 pub use solana_program_error::{
     ACCOUNT_ALREADY_INITIALIZED, ACCOUNT_BORROW_FAILED, ACCOUNT_DATA_TOO_SMALL,
     ACCOUNT_NOT_RENT_EXEMPT, ARITHMETIC_OVERFLOW, BORSH_IO_ERROR,
@@ -16,6 +14,7 @@ pub use solana_program_error::{
     MAX_INSTRUCTION_TRACE_LENGTH_EXCEEDED, MAX_SEED_LENGTH_EXCEEDED, MISSING_REQUIRED_SIGNATURES,
     NOT_ENOUGH_ACCOUNT_KEYS, UNINITIALIZED_ACCOUNT, UNSUPPORTED_SYSVAR,
 };
+use {core::fmt, solana_program_error::ProgramError};
 
 /// Reasons the runtime might have rejected an instruction.
 ///

--- a/instruction-error/src/lib.rs
+++ b/instruction-error/src/lib.rs
@@ -4,6 +4,8 @@
 use num_traits::ToPrimitive;
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::{AbiEnumVisitor, AbiExample};
+#[cfg(feature = "frozen-abi")]
+extern crate std;
 pub use solana_program_error::{
     ACCOUNT_ALREADY_INITIALIZED, ACCOUNT_BORROW_FAILED, ACCOUNT_DATA_TOO_SMALL,
     ACCOUNT_NOT_RENT_EXEMPT, ARITHMETIC_OVERFLOW, BORSH_IO_ERROR,

--- a/message/Cargo.toml
+++ b/message/Cargo.toml
@@ -61,7 +61,7 @@ serde_json = { workspace = true }
 solana-address-lookup-table-interface = { workspace = true, features = ["bincode", "bytemuck"] }
 solana-example-mocks = { path = "../example-mocks" }
 solana-instruction = { workspace = true, features = ["borsh"] }
-solana-instruction-error = { workspace = true, features = ["std"] }
+solana-instruction-error = { workspace = true }
 solana-message = { path = ".", features = ["dev-context-only-utils"] }
 solana-nonce = { workspace = true }
 solana-system-interface = { workspace = true, features = ["bincode"] }

--- a/program-error/Cargo.toml
+++ b/program-error/Cargo.toml
@@ -18,7 +18,6 @@ rustdoc-args = ["--cfg=docsrs"]
 [features]
 borsh = ["dep:borsh"]
 serde = ["dep:serde", "dep:serde_derive"]
-std = []
 
 [dependencies]
 borsh = { workspace = true, optional = true }

--- a/program-error/src/lib.rs
+++ b/program-error/src/lib.rs
@@ -3,8 +3,6 @@
 #![allow(clippy::arithmetic_side_effects)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![no_std]
-#[cfg(feature = "std")]
-extern crate std;
 #[cfg(feature = "borsh")]
 use borsh::io::Error as BorshIoError;
 use core::{convert::TryFrom, fmt};


### PR DESCRIPTION
The instruction-error and program-error crates have `std` features in Cargo.toml that don't do anything