### PR TITLE
sdk-wasm-js: Make wrapper types public

### DIFF
--- a/sdk-wasm-js/src/hash.rs
+++ b/sdk-wasm-js/src/hash.rs
@@ -7,7 +7,7 @@ use {
 
 #[wasm_bindgen]
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct Hash(pub(crate) solana_hash::Hash);
+pub struct Hash(pub solana_hash::Hash);
 
 #[allow(non_snake_case)]
 #[wasm_bindgen]

--- a/sdk-wasm-js/src/instruction.rs
+++ b/sdk-wasm-js/src/instruction.rs
@@ -10,7 +10,7 @@ use {crate::pubkey::Pubkey, wasm_bindgen::prelude::*};
 /// is fixed. This must not diverge from the regular non-wasm Instruction struct.
 #[wasm_bindgen]
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct Instruction(pub(crate) solana_instruction::Instruction);
+pub struct Instruction(pub solana_instruction::Instruction);
 
 #[wasm_bindgen]
 impl Instruction {
@@ -35,7 +35,7 @@ impl Instruction {
 
 #[wasm_bindgen]
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct AccountMeta(pub(crate) solana_instruction::AccountMeta);
+pub struct AccountMeta(pub solana_instruction::AccountMeta);
 
 #[wasm_bindgen]
 impl AccountMeta {

--- a/sdk-wasm-js/src/keypair.rs
+++ b/sdk-wasm-js/src/keypair.rs
@@ -2,7 +2,7 @@ use {crate::pubkey::Pubkey, solana_signer::Signer, wasm_bindgen::prelude::*};
 
 #[wasm_bindgen]
 #[derive(Debug)]
-pub struct Keypair(pub(crate) solana_keypair::Keypair);
+pub struct Keypair(pub solana_keypair::Keypair);
 
 #[allow(non_snake_case)]
 #[wasm_bindgen]

--- a/sdk-wasm-js/src/message.rs
+++ b/sdk-wasm-js/src/message.rs
@@ -2,4 +2,4 @@ use wasm_bindgen::prelude::wasm_bindgen;
 
 #[wasm_bindgen]
 #[derive(Default, Debug, PartialEq, Eq, Clone)]
-pub struct Message(pub(crate) solana_message::Message);
+pub struct Message(pub solana_message::Message);

--- a/sdk-wasm-js/src/pubkey.rs
+++ b/sdk-wasm-js/src/pubkey.rs
@@ -8,7 +8,7 @@ use {
 
 #[wasm_bindgen]
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct Pubkey(pub(crate) solana_pubkey::Pubkey);
+pub struct Pubkey(pub solana_pubkey::Pubkey);
 
 fn js_value_to_seeds_vec(array_of_uint8_arrays: &[JsValue]) -> Result<Vec<Vec<u8>>, JsValue> {
     let vec_vec_u8 = array_of_uint8_arrays

--- a/sdk-wasm-js/src/transaction.rs
+++ b/sdk-wasm-js/src/transaction.rs
@@ -12,7 +12,7 @@ use {
 /// is fixed. This must not diverge from the regular non-wasm Transaction struct.
 #[wasm_bindgen]
 #[derive(Debug, PartialEq, Default, Eq, Clone)]
-pub struct Transaction(pub(crate) solana_transaction::Transaction);
+pub struct Transaction(pub solana_transaction::Transaction);
 
 #[wasm_bindgen]
 impl Transaction {


### PR DESCRIPTION
#### Problem

While working on extracting the wasm js code from solana-system-interface, I noticed that it's impossible to create the wrapper types, since we don't expose any constructors.

#### Summary of changes

Make the wrapped type `pub` instead of `pub(crate)` so that other wasm-js crates can properly create types compatible with wasm_bindgen.