### PR TITLE
rent-collector: Deprecate the crate

### DIFF
--- a/rent-collector/src/lib.rs
+++ b/rent-collector/src/lib.rs
@@ -1,6 +1,10 @@
 //! Calculate and collect rent from accounts.
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
+#![deprecated(
+    since = "2.3.0",
+    note = "Use Rent directly, or solana_runtime::rent_collector"
+)]
 
 use {
     solana_account::{AccountSharedData, ReadableAccount, WritableAccount},


### PR DESCRIPTION
#### Problem

As noted in #226, the rent collector crate and struct are no longer needed, and with https://github.com/anza-xyz/agave/pull/7297, will no longer be used.

#### Summary of changes

Mark the crate as deprecated, so that we can backport and release the change, then delete the crate entirely.