### PR TITLE
CI: Don't run clippy during publish

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -77,6 +77,7 @@ jobs:
     name: Clippy
     needs: [sanity]
     runs-on: ubuntu-latest
+    if: false
     steps:
       - name: Git Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
#### Problem

Since we're starting to release v3 crates, the repo is in a half-upgraded state, which means that the circular dependencies like solana-system-interface and solana-stake-interface will fail to build due to the patches.

#### Summary of changes

Keep things simple, and don't run the repo-wide clippy before publish.