### PR TITLE
signature: add optional bytemuck support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3885,6 +3885,8 @@ version = "3.0.0"
 dependencies = [
  "bincode",
  "bs58",
+ "bytemuck",
+ "bytemuck_derive",
  "curve25519-dalek",
  "ed25519-dalek",
  "five8",

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -18,6 +18,7 @@ rustdoc-args = ["--cfg=docsrs"]
 [features]
 default = ["std", "alloc"]
 alloc = []
+bytemuck = ["dep:bytemuck", "dep:bytemuck_derive"]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "std"]
 rand = ["dep:rand"]
 serde = ["dep:serde", "dep:serde_derive", "dep:serde-big-array"]
@@ -25,6 +26,8 @@ std = ["alloc"]
 verify = ["dep:ed25519-dalek"]
 
 [dependencies]
+bytemuck = { workspace = true, optional = true }
+bytemuck_derive = { workspace = true, optional = true }
 ed25519-dalek = { workspace = true, optional = true }
 five8 = { workspace = true }
 rand = { workspace = true, optional = true }

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -31,6 +31,10 @@ const MAX_BASE58_SIGNATURE_LEN: usize = 88;
 #[repr(transparent)]
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(
+    feature = "bytemuck",
+    derive(bytemuck_derive::Pod, bytemuck_derive::Zeroable)
+)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Signature(
     #[cfg_attr(feature = "serde", serde(with = "BigArray"))] [u8; SIGNATURE_BYTES],


### PR DESCRIPTION
I currently find myself converting to the raw bytes to use bytemuck, so this would be nice to have