### PR TITLE
address!: Remove num-traits impls from AddressError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2752,7 +2752,6 @@ dependencies = [
  "curve25519-dalek",
  "five8",
  "five8_const",
- "num-traits",
  "rand",
  "serde",
  "serde_derive",

--- a/address/Cargo.toml
+++ b/address/Cargo.toml
@@ -17,7 +17,7 @@ bytemuck = ["dep:bytemuck", "dep:bytemuck_derive"]
 curve25519 = ["dep:curve25519-dalek", "error", "sha2"]
 decode = ["dep:five8", "dep:five8_const", "error"]
 dev-context-only-utils = ["dep:arbitrary", "rand"]
-error = ["dep:num-traits", "dep:solana-program-error"]
+error = ["dep:solana-program-error"]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
@@ -38,7 +38,6 @@ bytemuck = { workspace = true, optional = true }
 bytemuck_derive = { workspace = true, optional = true }
 five8 = { workspace = true, optional = true }
 five8_const = { workspace = true, optional = true }
-num-traits = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }

--- a/address/src/error.rs
+++ b/address/src/error.rs
@@ -2,13 +2,9 @@
 use serde_derive::Serialize;
 use {
     core::{convert::Infallible, fmt},
-    num_traits::{FromPrimitive, ToPrimitive},
     solana_program_error::ProgramError,
 };
 
-// Use strum when testing to ensure our FromPrimitive
-// impl is exhaustive
-#[cfg_attr(test, derive(strum_macros::FromRepr, strum_macros::EnumIter))]
 #[cfg_attr(feature = "serde", derive(serde_derive::Serialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AddressError {
@@ -16,40 +12,6 @@ pub enum AddressError {
     MaxSeedLengthExceeded,
     InvalidSeeds,
     IllegalOwner,
-}
-
-impl ToPrimitive for AddressError {
-    #[inline]
-    fn to_i64(&self) -> Option<i64> {
-        Some(match *self {
-            AddressError::MaxSeedLengthExceeded => AddressError::MaxSeedLengthExceeded as i64,
-            AddressError::InvalidSeeds => AddressError::InvalidSeeds as i64,
-            AddressError::IllegalOwner => AddressError::IllegalOwner as i64,
-        })
-    }
-    #[inline]
-    fn to_u64(&self) -> Option<u64> {
-        self.to_i64().map(|x| x as u64)
-    }
-}
-
-impl FromPrimitive for AddressError {
-    #[inline]
-    fn from_i64(n: i64) -> Option<Self> {
-        if n == AddressError::MaxSeedLengthExceeded as i64 {
-            Some(AddressError::MaxSeedLengthExceeded)
-        } else if n == AddressError::InvalidSeeds as i64 {
-            Some(AddressError::InvalidSeeds)
-        } else if n == AddressError::IllegalOwner as i64 {
-            Some(AddressError::IllegalOwner)
-        } else {
-            None
-        }
-    }
-    #[inline]
-    fn from_u64(n: u64) -> Option<Self> {
-        Self::from_i64(n as i64)
-    }
 }
 
 impl core::error::Error for AddressError {}
@@ -89,45 +51,11 @@ impl From<AddressError> for ProgramError {
     }
 }
 
-// Use strum when testing to ensure our FromPrimitive
-// impl is exhaustive
-#[cfg_attr(test, derive(strum_macros::FromRepr, strum_macros::EnumIter))]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ParseAddressError {
     WrongSize,
     Invalid,
-}
-
-impl ToPrimitive for ParseAddressError {
-    #[inline]
-    fn to_i64(&self) -> Option<i64> {
-        Some(match *self {
-            ParseAddressError::WrongSize => ParseAddressError::WrongSize as i64,
-            ParseAddressError::Invalid => ParseAddressError::Invalid as i64,
-        })
-    }
-    #[inline]
-    fn to_u64(&self) -> Option<u64> {
-        self.to_i64().map(|x| x as u64)
-    }
-}
-
-impl FromPrimitive for ParseAddressError {
-    #[inline]
-    fn from_i64(n: i64) -> Option<Self> {
-        if n == ParseAddressError::WrongSize as i64 {
-            Some(ParseAddressError::WrongSize)
-        } else if n == ParseAddressError::Invalid as i64 {
-            Some(ParseAddressError::Invalid)
-        } else {
-            None
-        }
-    }
-    #[inline]
-    fn from_u64(n: u64) -> Option<Self> {
-        Self::from_i64(n as i64)
-    }
 }
 
 impl core::error::Error for ParseAddressError {}

--- a/address/src/lib.rs
+++ b/address/src/lib.rs
@@ -331,10 +331,7 @@ macro_rules! address {
 
 #[cfg(test)]
 mod tests {
-    use {
-        super::*, core::str::from_utf8, num_traits::FromPrimitive, std::string::String,
-        strum::IntoEnumIterator,
-    };
+    use {super::*, core::str::from_utf8, std::string::String};
 
     fn encode_address(address: &[u8; 32]) -> String {
         let mut buffer = [0u8; 44];
@@ -587,29 +584,6 @@ mod tests {
             Err(AddressError::IllegalOwner)
         );
         assert!(address_from_seed_by_marker(&PDA_MARKER[1..]).is_ok());
-    }
-
-    #[test]
-    fn test_address_error_from_primitive_exhaustive() {
-        for variant in AddressError::iter() {
-            let variant_i64 = variant.clone() as i64;
-            assert_eq!(
-                AddressError::from_repr(variant_i64 as usize),
-                AddressError::from_i64(variant_i64)
-            );
-            assert_eq!(AddressError::from(variant_i64 as u64), variant);
-        }
-    }
-
-    #[test]
-    fn test_parse_address_error_from_primitive_exhaustive() {
-        for variant in ParseAddressError::iter() {
-            let variant_i64 = variant as i64;
-            assert_eq!(
-                ParseAddressError::from_repr(variant_i64 as usize),
-                ParseAddressError::from_i64(variant_i64)
-            );
-        }
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

`AddressError` implements the num-traits primitives, but they probably aren't needed.

#### Summary of changes

Remove the implementations.