### PR TITLE
system-wasm-js: Introduce crate for exposing wasm-js instructions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3996,6 +3996,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-system-wasm-js"
+version = "1.0.0"
+dependencies = [
+ "js-sys",
+ "solana-sdk-wasm-js",
+ "solana-system-interface",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "solana-sysvar"
 version = "3.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,9 @@ members = [
     "slot-hashes",
     "slot-history",
     "stable-layout",
+    "system-interface",
     "system-transaction",
+    "system-wasm-js",
     "sysvar",
     "sysvar-id",
     "time-utils",
@@ -299,6 +301,7 @@ solana-slot-history = { path = "slot-history", version = "3.0.0" }
 solana-stable-layout = { path = "stable-layout", version = "3.0.0" }
 solana-system-interface = { path = "system-interface", version = "2.0" }
 solana-system-transaction = { path = "system-transaction", version = "2.2.1" }
+solana-system-wasm-js = { path = "system-wasm-js", version = "1.0" }
 solana-sysvar = { path = "sysvar", version = "3.0.0" }
 solana-sysvar-id = { path = "sysvar-id", version = "3.0.0" }
 solana-time-utils = { path = "time-utils", version = "3.0.0" }

--- a/scripts/build-sbf.sh
+++ b/scripts/build-sbf.sh
@@ -22,6 +22,7 @@ build_sbf_excludes=(
   --exclude solana-secp256k1-program
   --exclude solana-secp256r1-program
   --exclude solana-system-transaction
+  --exclude solana-system-wasm-js
   --exclude solana-transaction
   --exclude solana-sdk
 )

--- a/scripts/test-wasm.sh
+++ b/scripts/test-wasm.sh
@@ -16,3 +16,8 @@ cd "${src_root}"
   npm install
   npm test
 )
+
+(
+  cd system-wasm-js
+  npm install
+)

--- a/system-interface/Cargo.toml
+++ b/system-interface/Cargo.toml
@@ -15,6 +15,21 @@ targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
+[lib]
+crate-type = ["rlib"]
+
+[features]
+bincode = ["dep:solana-instruction", "serde"]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "dep:solana-logger",
+    "serde",
+    "solana-pubkey/frozen-abi",
+    "solana-pubkey/std",
+]
+serde = ["dep:serde", "dep:serde_derive", "solana-pubkey/serde"]
+
 [dependencies]
 num-traits = { workspace = true }
 serde = { workspace = true, optional = true }
@@ -43,18 +58,3 @@ solana-sysvar-id = { workspace = true }
 static_assertions = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
-
-[features]
-bincode = ["dep:solana-instruction", "serde"]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "dep:solana-logger",
-    "serde",
-    "solana-pubkey/frozen-abi",
-    "solana-pubkey/std"
-]
-serde = ["dep:serde", "dep:serde_derive", "solana-pubkey/serde"]
-
-[lib]
-crate-type = ["rlib"]

--- a/system-wasm-js/.gitignore
+++ b/system-wasm-js/.gitignore
@@ -1,0 +1,2 @@
+/node_modules/
+/package-lock.json

--- a/system-wasm-js/Cargo.toml
+++ b/system-wasm-js/Cargo.toml
@@ -22,8 +22,8 @@ solana-sdk-wasm-js = { workspace = true }
 solana-system-interface = { workspace = true, features = ["bincode"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys = "0.3.72"
-wasm-bindgen = "0.2"
+js-sys = { workspace = true }
+wasm-bindgen = { workspace = true }
 
 [lints]
 workspace = true

--- a/system-wasm-js/Cargo.toml
+++ b/system-wasm-js/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "solana-system-wasm-js"
+description = "Solana System Wasm JS"
+documentation = "https://docs.rs/solana-system-wasm-js"
+version = "1.0.0"
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["wasm32-unknown-unknown"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+solana-sdk-wasm-js = { workspace = true }
+solana-system-interface = { workspace = true, features = ["bincode"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = "0.3.72"
+wasm-bindgen = "0.2"
+
+[lints]
+workspace = true

--- a/system-wasm-js/package.json
+++ b/system-wasm-js/package.json
@@ -1,0 +1,6 @@
+{
+  "scripts": {
+    "postinstall": "npm run build",
+    "build": "wasm-pack build --target nodejs --dev --out-dir node_modules/crate --out-name crate"
+  }
+}

--- a/system-wasm-js/src/lib.rs
+++ b/system-wasm-js/src/lib.rs
@@ -1,0 +1,116 @@
+//! `SystemInstruction` Javascript interface
+#![cfg(target_arch = "wasm32")]
+#![allow(non_snake_case)]
+use {
+    solana_sdk_wasm_js::{address::Address, instruction::Instruction},
+    solana_system_interface::instruction::{
+        advance_nonce_account, allocate, allocate_with_seed, assign, assign_with_seed,
+        authorize_nonce_account, create_account, create_account_with_seed, create_nonce_account,
+        transfer, transfer_with_seed, withdraw_nonce_account,
+    },
+    wasm_bindgen::prelude::*,
+};
+
+#[wasm_bindgen]
+struct SystemInstruction;
+
+#[wasm_bindgen]
+impl SystemInstruction {
+    pub fn createAccount(
+        from: &Address,
+        to: &Address,
+        lamports: u64,
+        space: u64,
+        owner: &Address,
+    ) -> Instruction {
+        create_account(from, to, lamports, space, owner).into()
+    }
+
+    pub fn createAccountWithSeed(
+        from: &Address,
+        to: &Address,
+        base: &Address,
+        seed: &str,
+        lamports: u64,
+        space: u64,
+        owner: &Address,
+    ) -> Instruction {
+        create_account_with_seed(from, to, base, seed, lamports, space, owner).into()
+    }
+
+    pub fn assign(address: &Address, owner: &Address) -> Instruction {
+        assign(address, owner).into()
+    }
+
+    pub fn assignWithSeed(
+        address: &Address,
+        base: &Address,
+        seed: &str,
+        owner: &Address,
+    ) -> Instruction {
+        assign_with_seed(address, base, seed, owner).into()
+    }
+
+    pub fn transfer(from: &Address, to: &Address, lamports: u64) -> Instruction {
+        transfer(from, to, lamports).into()
+    }
+
+    pub fn transferWithSeed(
+        from: &Address,
+        from_base: &Address,
+        from_seed: String,
+        from_owner: &Address,
+        to: &Address,
+        lamports: u64,
+    ) -> Instruction {
+        transfer_with_seed(from, from_base, from_seed, from_owner, to, lamports).into()
+    }
+
+    pub fn allocate(address: &Address, space: u64) -> Instruction {
+        allocate(address, space).into()
+    }
+
+    pub fn allocateWithSeed(
+        address: &Address,
+        base: &Address,
+        seed: &str,
+        space: u64,
+        owner: &Address,
+    ) -> Instruction {
+        allocate_with_seed(address, base, seed, space, owner).into()
+    }
+
+    pub fn createNonceAccount(
+        from: &Address,
+        nonce: &Address,
+        authority: &Address,
+        lamports: u64,
+    ) -> js_sys::Array {
+        let instructions = create_nonce_account(from, nonce, authority, lamports);
+        instructions
+            .into_iter()
+            .map(|x| JsValue::from(Instruction::from(x)))
+            .collect()
+    }
+
+    pub fn advanceNonceAccount(nonce: &Address, authorized: &Address) -> Instruction {
+        advance_nonce_account(nonce, authorized).into()
+    }
+
+    pub fn withdrawNonceAccount(
+        nonce: &Address,
+        authorized: &Address,
+        to: &Address,
+        lamports: u64,
+    ) -> Instruction {
+        withdraw_nonce_account(nonce, authorized, to, lamports).into()
+    }
+
+    pub fn authorizeNonceAccount(
+        nonce: &Address,
+        authorized: &Address,
+        new_authority: &Address,
+    ) -> Instruction {
+        authorize_nonce_account(nonce, authorized, new_authority).into()
+    }
+}

--- a/system-wasm-js/src/lib.rs
+++ b/system-wasm-js/src/lib.rs
@@ -12,7 +12,7 @@ use {
 };
 
 #[wasm_bindgen]
-struct SystemInstruction;
+pub struct SystemInstruction;
 
 #[wasm_bindgen]
 impl SystemInstruction {


### PR DESCRIPTION
#### Problem

The system interface used to include wasm-js bindings for the instruction creators, which was a problem for non-JS wasm builds, as described at https://github.com/solana-program/system/issues/47.

#### Summary of changes

Add the wasm-js bindings as an external crate, similar to the work done with sdk-wasm-js.

Fixes https://github.com/solana-program/system/issues/47
Closes https://github.com/solana-program/system/pull/48