### PR TITLE
[backport maintenance/v2.x] CI: Run main workflow on PRs targeting maintenance too

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,13 @@ name: Main
 
 on:
   push:
-    branches: [master]
+    branches:
+      - 'master'
+      - 'maintenance/**'
   pull_request:
+    branches:
+      - 'master'
+      - 'maintenance/**'
 
 jobs:
   sanity:


### PR DESCRIPTION
#### Problem

PRs against the maintenance branches don't trigger CI, which is an issue for checking backport PRs.

#### Summary of changes

Add the maintenance branches to CI.

NOTE: The backport job failed, so I just did this by hand