### PR TITLE
program-entrypoint: Add a BumpAllocator constructor

### DIFF
--- a/program-entrypoint/src/lib.rs
+++ b/program-entrypoint/src/lib.rs
@@ -221,10 +221,10 @@ macro_rules! custom_heap_default {
     () => {
         #[cfg(all(not(feature = "custom-heap"), target_os = "solana"))]
         #[global_allocator]
-        static A: $crate::BumpAllocator = $crate::BumpAllocator {
-            start: $crate::HEAP_START_ADDRESS as usize,
-            len: $crate::HEAP_LENGTH,
-        };
+        static A: $crate::BumpAllocator = $crate::BumpAllocator::new_with_fixed_address_range(
+            $crate::HEAP_START_ADDRESS as usize,
+            $crate::HEAP_LENGTH,
+        );
     };
 }
 
@@ -332,6 +332,19 @@ impl BumpAllocator {
             start: pos_ptr as usize,
             len: arena.len(),
         }
+    }
+
+    /// Creates the allocator tied to specific range of addresses.
+    ///
+    /// # Safety
+    /// This is unsafe in most situations, unless you are totally sure that the
+    /// provided start address and length can be written to by the allocator,
+    /// and that the memory will be usable for the lifespan of the allocator.
+    ///
+    /// For Solana on-chain programs, a certain address range is reserved, so
+    /// the allocator can be given those addresses.
+    pub unsafe fn new_with_fixed_address_range(start: usize, len: usize) -> Self {
+        Self { start, len }
     }
 }
 


### PR DESCRIPTION
#### Problem

The current version of program-entrypoint doesn't work because the allocator can't be instantiated in the macros. The start and len fields are private, and so can't be written to in the macro, which exists in the scope of the program.

#### Summary of changes

Add a new constructor that can be used by the macro.