### PR TITLE
Create `InvalidAccountAliasing` error

### DIFF
--- a/instruction-error/src/lib.rs
+++ b/instruction-error/src/lib.rs
@@ -200,6 +200,9 @@ pub enum InstructionError {
 
     /// Builtin programs must consume compute units
     BuiltinProgramsMustConsumeComputeUnits,
+
+    /// The instruction cannot work with the two aliased accounts received
+    InvalidAccountAliasing,
     // Note: For any new error added here an equivalent ProgramError and its
     // conversions must also be added
 }
@@ -340,6 +343,9 @@ impl fmt::Display for InstructionError {
             }
             InstructionError::BuiltinProgramsMustConsumeComputeUnits => {
                 f.write_str("Builtin programs must consume compute units")
+            }
+            InstructionError::InvalidAccountAliasing => {
+                f.write_str("The instruction does not allow one or more account aliasing")
             }
         }
     }


### PR DESCRIPTION
**Problem**

Program runtime relies on Rust's `RefCell::try_borrow_mut` function to determine if an instruction is borrowing the same account twice. That might happen when, for instance, two accounts are aliasing each other and the instruction wants them to be different.

The borrow checker adds complexity to the program runtime, so an active approach to detecting aliases with the Pubkey would help us remove the `RefCell`. There is no proper error to replace `AccountBorrowFailed` or `AccountBorrowOutstading` in the repository.


**Solution**

Create error `InvalidAccountAliasing` to throw where the borrow is failing.