### PR TITLE
keypair: re-export types used in public API

### DIFF
--- a/keypair/src/lib.rs
+++ b/keypair/src/lib.rs
@@ -3,15 +3,17 @@
 use {
     ed25519_dalek::Signer as DalekSigner,
     rand::rngs::OsRng,
-    solana_pubkey::Pubkey,
     solana_seed_phrase::generate_seed_from_seed_phrase_and_passphrase,
-    solana_signature::{error::Error as SignatureError, Signature},
-    solana_signer::{EncodableKey, EncodableKeypair, Signer, SignerError},
     std::{
         error,
         io::{Read, Write},
         path::Path,
     },
+};
+pub use {
+    solana_pubkey::Pubkey,
+    solana_signature::{error::Error as SignatureError, Signature},
+    solana_signer::{EncodableKey, EncodableKeypair, Signer, SignerError},
 };
 
 #[cfg(feature = "seed-derivable")]

--- a/keypair/src/lib.rs
+++ b/keypair/src/lib.rs
@@ -4,6 +4,7 @@ use {
     ed25519_dalek::Signer as DalekSigner,
     rand::rngs::OsRng,
     solana_seed_phrase::generate_seed_from_seed_phrase_and_passphrase,
+    solana_signer::SignerError,
     std::{
         error,
         io::{Read, Write},
@@ -13,7 +14,7 @@ use {
 pub use {
     solana_pubkey::Pubkey,
     solana_signature::{error::Error as SignatureError, Signature},
-    solana_signer::{EncodableKey, EncodableKeypair, Signer, SignerError},
+    solana_signer::{EncodableKey, EncodableKeypair, Signer},
 };
 
 #[cfg(feature = "seed-derivable")]


### PR DESCRIPTION
These types are returned or used by public code in solana-keypair, so re-exporting them adds convenience and helps avoid confusion over version mismatches without increasing the API surface area