### PR TITLE
[bls-signatures] Use affine for `Keypair` and signature verification

### DIFF
--- a/bls-signatures/benches/bls_signatures.rs
+++ b/bls-signatures/benches/bls_signatures.rs
@@ -2,13 +2,19 @@ use {
     criterion::{criterion_group, criterion_main, Criterion},
     solana_bls_signatures::{
         keypair::Keypair,
-        pubkey::{Pubkey, PubkeyProjective, VerifiablePubkey},
-        signature::{Signature, SignatureProjective},
+        pubkey::{PubkeyProjective, VerifiablePubkey},
+        signature::SignatureProjective,
     },
     std::hint::black_box,
 };
 #[cfg(feature = "parallel")]
-use {solana_bls_signatures::signature::VerificationOptions, std::collections::HashSet};
+use {
+    solana_bls_signatures::{
+        pubkey::Pubkey,
+        signature::{Signature, VerificationOptions},
+    },
+    std::collections::HashSet,
+};
 
 // Benchmark for verifying a single signature
 fn bench_single_signature(c: &mut Criterion) {
@@ -250,11 +256,11 @@ fn bench_batch_verification(c: &mut Criterion) {
                         )
                         .unwrap(),
                     );
-                    for i in 0..*num_validators {
+                    for (i, &is_valid) in results.iter().enumerate() {
                         if invalid_indices.contains(&i) {
-                            assert!(!results[i]);
+                            assert!(!is_valid);
                         } else {
-                            assert!(results[i]);
+                            assert!(is_valid);
                         }
                     }
                 });
@@ -274,11 +280,11 @@ fn bench_batch_verification(c: &mut Criterion) {
                         )
                         .unwrap(),
                     );
-                    for i in 0..*num_validators {
+                    for (i, &is_valid) in results.iter().enumerate() {
                         if invalid_indices.contains(&i) {
-                            assert!(!results[i]);
+                            assert!(!is_valid);
                         } else {
-                            assert!(results[i]);
+                            assert!(is_valid);
                         }
                     }
                 });

--- a/bls-signatures/src/macros.rs
+++ b/bls-signatures/src/macros.rs
@@ -32,8 +32,9 @@ macro_rules! impl_from_str {
 /// * `$affine`: The identifier for the affine (uncompressed) representation struct (e.g., `Pubkey`).
 /// * `$compressed`: The identifier for the compressed representation struct (e.g., `PubkeyCompressed`).
 /// * `$point_type`: The underlying `blstrs` affine point type (e.g., `G1Affine` or `G2Affine`).
-/// * `$error_type`: The error type to be used for fallible conversions (e.g., `BlsError`).
-/// * `$as_trait`: The identifier for the custom conversion trait (e.g., `AsPubkeyProjective`).
+/// * `$as_projective_trait`: The identifier for the custom projective conversion trait (e.g.,
+/// `AsPubkeyProjective`).
+/// * `$as_affine_trait`: The identifier for the custom affine conversion trait (e.g., `AsPubkey`).
 #[cfg(not(target_os = "solana"))]
 macro_rules! impl_bls_conversions {
     (
@@ -41,7 +42,8 @@ macro_rules! impl_bls_conversions {
         $affine:ident,
         $compressed:ident,
         $point_type:ty,
-        $as_trait:ident
+        $as_projective_trait:ident,
+        $as_affine_trait:ident
     ) => {
         // ---
         // infallible conversions from the projective type.
@@ -141,21 +143,42 @@ macro_rules! impl_bls_conversions {
             }
         }
 
-        impl $as_trait for $projective {
+        impl $as_projective_trait for $projective {
             fn try_as_projective(&self) -> Result<$projective, BlsError> {
                 Ok(*self)
             }
         }
 
-        impl $as_trait for $affine {
+        impl $as_projective_trait for $affine {
             fn try_as_projective(&self) -> Result<$projective, BlsError> {
                 $projective::try_from(self)
             }
         }
 
-        impl $as_trait for $compressed {
+        impl $as_projective_trait for $compressed {
             fn try_as_projective(&self) -> Result<$projective, BlsError> {
                 $projective::try_from(self)
+            }
+        }
+
+        impl $as_affine_trait for $projective {
+            fn try_as_affine(&self) -> Result<$affine, BlsError> {
+                // Uses the `From<&$projective>` for `$affine` conversion defined above.
+                Ok(self.into())
+            }
+        }
+
+        impl $as_affine_trait for $affine {
+            fn try_as_affine(&self) -> Result<$affine, BlsError> {
+                // Trivial case: already in the correct format.
+                Ok(*self)
+            }
+        }
+
+        impl $as_affine_trait for $compressed {
+            fn try_as_affine(&self) -> Result<$affine, BlsError> {
+                // Uses the `TryFrom<&$compressed>` for `$affine` conversion defined above.
+                $affine::try_from(self)
             }
         }
     };

--- a/bls-signatures/src/macros.rs
+++ b/bls-signatures/src/macros.rs
@@ -32,8 +32,7 @@ macro_rules! impl_from_str {
 /// * `$affine`: The identifier for the affine (uncompressed) representation struct (e.g., `Pubkey`).
 /// * `$compressed`: The identifier for the compressed representation struct (e.g., `PubkeyCompressed`).
 /// * `$point_type`: The underlying `blstrs` affine point type (e.g., `G1Affine` or `G2Affine`).
-/// * `$as_projective_trait`: The identifier for the custom projective conversion trait (e.g.,
-/// `AsPubkeyProjective`).
+/// * `$as_projective_trait`: The identifier for the custom projective conversion trait (e.g.,`AsPubkeyProjective`).
 /// * `$as_affine_trait`: The identifier for the custom affine conversion trait (e.g., `AsPubkey`).
 #[cfg(not(target_os = "solana"))]
 macro_rules! impl_bls_conversions {

--- a/bls-signatures/src/proof_of_possession.rs
+++ b/bls-signatures/src/proof_of_possession.rs
@@ -163,7 +163,7 @@ mod tests {
         super::*,
         crate::{
             keypair::Keypair,
-            pubkey::{Pubkey, PubkeyCompressed},
+            pubkey::{Pubkey, PubkeyCompressed, PubkeyProjective},
         },
         core::str::FromStr,
         std::string::ToString,
@@ -174,8 +174,8 @@ mod tests {
         let keypair = Keypair::new();
         let proof_projective = keypair.proof_of_possession();
 
-        let pubkey_projective = keypair.public;
-        let pubkey_affine: Pubkey = pubkey_projective.into();
+        let pubkey_projective: PubkeyProjective = (&keypair.public).try_into().unwrap();
+        let pubkey_affine: Pubkey = keypair.public;
         let pubkey_compressed: PubkeyCompressed = pubkey_affine.try_into().unwrap();
 
         let proof_affine: ProofOfPossession = proof_projective.into();

--- a/bls-signatures/src/proof_of_possession.rs
+++ b/bls-signatures/src/proof_of_possession.rs
@@ -39,6 +39,13 @@ pub trait AsProofOfPossessionProjective {
     fn try_as_projective(&self) -> Result<ProofOfPossessionProjective, BlsError>;
 }
 
+/// A trait for types that can be converted into a `ProofOfPossession` (affine).
+#[cfg(not(target_os = "solana"))]
+pub trait AsProofOfPossession {
+    /// Attempt to convert the type into a `ProofOfPossession`.
+    fn try_as_affine(&self) -> Result<ProofOfPossession, BlsError>;
+}
+
 /// A trait that provides verification methods to any convertible proof of possession type.
 #[cfg(not(target_os = "solana"))]
 pub trait VerifiableProofOfPossession: AsProofOfPossessionProjective {
@@ -63,7 +70,8 @@ impl_bls_conversions!(
     ProofOfPossession,
     ProofOfPossessionCompressed,
     G2Affine,
-    AsProofOfPossessionProjective
+    AsProofOfPossessionProjective,
+    AsProofOfPossession
 );
 
 /// A serialized BLS signature in a compressed point representation

--- a/bls-signatures/src/signature.rs
+++ b/bls-signatures/src/signature.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "bytemuck")]
 use bytemuck::{Pod, PodInOption, Zeroable, ZeroableInOption};
+#[cfg(all(feature = "parallel", not(target_os = "solana")))]
+use {crate::pubkey::Pubkey, alloc::vec::Vec, core::num::NonZeroUsize, rayon::prelude::*};
 #[cfg(not(target_os = "solana"))]
 use {
     crate::{
@@ -9,8 +11,6 @@ use {
     blstrs::{G2Affine, G2Projective},
     group::Group,
 };
-#[cfg(all(feature = "parallel", not(target_os = "solana")))]
-use {alloc::vec::Vec, core::num::NonZeroUsize, rayon::prelude::*};
 use {
     base64::{prelude::BASE64_STANDARD, Engine},
     core::fmt,
@@ -54,6 +54,13 @@ impl Default for VerificationOptions {
 pub trait AsSignatureProjective {
     /// Attempt to convert the type into a `SignatureProjective`.
     fn try_as_projective(&self) -> Result<SignatureProjective, BlsError>;
+}
+
+/// A trait for types that can be converted into a `Signature` (affine).
+#[cfg(not(target_os = "solana"))]
+pub trait AsSignature {
+    /// Attempt to convert the type into a `Signature`.
+    fn try_as_affine(&self) -> Result<Signature, BlsError>;
 }
 
 /// A trait that provides verification methods to any convertible signature type.
@@ -117,7 +124,7 @@ impl SignatureProjective {
         let aggregate_pubkey = PubkeyProjective::aggregate(public_keys)?;
         let aggregate_signature = SignatureProjective::aggregate(signatures)?;
 
-        Ok(aggregate_pubkey._verify_signature(&aggregate_signature, message))
+        aggregate_pubkey.verify_signature(&aggregate_signature, message)
     }
 
     /// Aggregate a list of signatures into an existing aggregate
@@ -164,8 +171,8 @@ impl SignatureProjective {
     /// to identify the valid and invalid ones.
     #[cfg(feature = "parallel")]
     pub fn par_verify_batch(
-        public_keys: &[&PubkeyProjective],
-        signatures: &[&SignatureProjective],
+        public_keys: &[&Pubkey],
+        signatures: &[&Signature],
         message: &[u8],
     ) -> Result<Vec<bool>, BlsError> {
         if public_keys.len() != signatures.len() {
@@ -184,11 +191,11 @@ impl SignatureProjective {
             Ok(alloc::vec![true; public_keys.len()])
         } else {
             // Use Rayon's parallel iterator to verify each signature concurrently.
-            public_keys
+            Ok(public_keys
                 .par_iter()
                 .zip(signatures.par_iter())
-                .map(|(pubkey, signature)| Ok(pubkey._verify_signature(signature, message)))
-                .collect()
+                .map(|(pubkey, signature)| pubkey._verify_signature(signature, message))
+                .collect())
         }
     }
 
@@ -209,7 +216,7 @@ impl SignatureProjective {
         );
         let aggregate_pubkey = aggregate_pubkey_res?;
         let aggregate_signature = aggregate_signature_res?;
-        Ok(aggregate_pubkey._verify_signature(&aggregate_signature, message))
+        aggregate_pubkey.verify_signature(&aggregate_signature, message)
     }
 
     /// Verify a list of signatures against a message and a list of public keys,
@@ -219,8 +226,8 @@ impl SignatureProjective {
     /// to efficiently identify invalid signatures in the batch (O(k log N) pairings).
     #[cfg(feature = "parallel")]
     pub fn par_verify_batch_binary_search(
-        public_keys: &[&PubkeyProjective],
-        signatures: &[&SignatureProjective],
+        public_keys: &[&Pubkey],
+        signatures: &[&Signature],
         message: &[u8],
         options: &VerificationOptions,
     ) -> Result<Vec<bool>, BlsError> {
@@ -233,7 +240,11 @@ impl SignatureProjective {
         let inputs: Result<Vec<(PubkeyProjective, SignatureProjective)>, BlsError> = public_keys
             .par_iter()
             .zip(signatures.par_iter())
-            .map(|(pk, sig)| Ok((**pk, **sig)))
+            .map(|(pk, sig)| {
+                let pk_proj = PubkeyProjective::try_from(*pk)?;
+                let sig_proj = SignatureProjective::try_from(*sig)?;
+                Ok((pk_proj, sig_proj))
+            })
             .collect();
 
         let inputs = inputs?;
@@ -300,7 +311,9 @@ impl SignatureProjective {
             )
         };
 
-        let is_valid = aggregate_pubkey._verify_signature(&aggregate_signature, message);
+        let is_valid = aggregate_pubkey
+            .verify_signature(&aggregate_signature, message)
+            .unwrap_or(false);
 
         if is_valid {
             // Success: Mark all in this batch as valid (in parallel).
@@ -354,7 +367,8 @@ impl_bls_conversions!(
     Signature,
     SignatureCompressed,
     G2Affine,
-    AsSignatureProjective
+    AsSignatureProjective,
+    AsSignature
 );
 
 /// A serialized BLS signature in a compressed point representation
@@ -452,7 +466,7 @@ mod tests {
         let test_message = b"test message";
         let signature_projective = keypair.sign(test_message);
 
-        let pubkey_projective = keypair.public;
+        let pubkey_projective: PubkeyProjective = (&keypair.public).try_into().unwrap();
         let pubkey_affine: Pubkey = pubkey_projective.into();
         let pubkey_compressed: PubkeyCompressed = pubkey_affine.try_into().unwrap();
 
@@ -600,7 +614,7 @@ mod tests {
         let signature1_projective = keypair1.sign(test_message);
         let signature2_projective = keypair2.sign(test_message);
 
-        let pubkey0 = keypair0.public; // Projective
+        let pubkey0 = PubkeyProjective::try_from(keypair0.public).unwrap(); // Projective
         let pubkey1_affine: Pubkey = keypair1.public.into(); // Affine
         let pubkey2_compressed: PubkeyCompressed =
             Pubkey::from(keypair2.public).try_into().unwrap(); // Compressed
@@ -680,7 +694,10 @@ mod tests {
     fn test_parallel_aggregate_verify() {
         let message = b"test message";
         let keypairs: Vec<_> = (0..5).map(|_| Keypair::new()).collect();
-        let pubkeys: Vec<_> = keypairs.iter().map(|kp| kp.public).collect();
+        let pubkeys: Vec<_> = keypairs
+            .iter()
+            .map(|kp| PubkeyProjective::try_from(&kp.public).unwrap())
+            .collect();
         let pubkey_refs: Vec<_> = pubkeys.iter().collect();
         let signatures: Vec<_> = keypairs.iter().map(|kp| kp.sign(message)).collect();
         let signature_refs: Vec<_> = signatures.iter().collect();
@@ -719,19 +736,26 @@ mod tests {
 
         // Generate keypairs, public keys, and signatures
         let keypairs: Vec<_> = (0..NUM_SIGNATURES).map(|_| Keypair::new()).collect();
-        let pubkeys: Vec<_> = keypairs.iter().map(|kp| &kp.public).collect();
-        let signatures: Vec<_> = keypairs.iter().map(|kp| kp.sign(message)).collect();
-        let sig_refs: Vec<_> = signatures.iter().collect();
+        let pubkeys_affine: Vec<_> = keypairs.iter().map(|kp| kp.public).collect();
+        let pubkeys: Vec<_> = pubkeys_affine.iter().collect();
+        let signatures_proj: Vec<_> = keypairs.iter().map(|kp| kp.sign(message)).collect();
+        let signatures_affine: Vec<_> =
+            signatures_proj.iter().map(|s| Signature::from(s)).collect();
+        let sig_refs: Vec<_> = signatures_affine.iter().collect();
 
         // All signatures are valid
         let results = SignatureProjective::par_verify_batch(&pubkeys, &sig_refs, message).unwrap();
         assert_eq!(results, std::vec![true; NUM_SIGNATURES]);
 
         // One signature is invalid (wrong message)
-        let mut bad_signatures = signatures.clone();
+        let mut bad_signatures_proj = signatures_proj.clone();
         let bad_sig = keypairs[3].sign(b"a different message");
-        bad_signatures[3] = bad_sig;
-        let bad_sig_refs: Vec<_> = bad_signatures.iter().collect();
+        bad_signatures_proj[3] = bad_sig;
+        let bad_signatures_affine: Vec<_> = bad_signatures_proj
+            .iter()
+            .map(|s| Signature::from(s))
+            .collect();
+        let bad_sig_refs: Vec<_> = bad_signatures_affine.iter().collect();
 
         let results =
             SignatureProjective::par_verify_batch(&pubkeys, &bad_sig_refs, message).unwrap();
@@ -746,8 +770,8 @@ mod tests {
         assert_eq!(err, BlsError::InputLengthMismatch);
 
         // Empty inputs
-        let empty_pubkeys: &[&PubkeyProjective] = &[];
-        let empty_sigs: &[&SignatureProjective] = &[];
+        let empty_pubkeys: &[&Pubkey] = &[];
+        let empty_sigs: &[&Signature] = &[];
         let results =
             SignatureProjective::par_verify_batch(empty_pubkeys, empty_sigs, message).unwrap();
         assert!(results.is_empty());
@@ -761,9 +785,12 @@ mod tests {
 
         // Generate keypairs, public keys, and valid signatures
         let keypairs: Vec<_> = (0..NUM_SIGNATURES).map(|_| Keypair::new()).collect();
-        let pubkeys: Vec<_> = keypairs.iter().map(|kp| &kp.public).collect();
-        let signatures: Vec<_> = keypairs.iter().map(|kp| kp.sign(message)).collect();
-        let sig_refs: Vec<_> = signatures.iter().collect();
+        let pubkeys_affine: Vec<_> = keypairs.iter().map(|kp| kp.public).collect();
+        let pubkeys: Vec<_> = pubkeys_affine.iter().collect();
+        let signatures_proj: Vec<_> = keypairs.iter().map(|kp| kp.sign(message)).collect();
+        let signatures_affine: Vec<_> =
+            signatures_proj.iter().map(|s| Signature::from(s)).collect();
+        let sig_refs: Vec<_> = signatures_affine.iter().collect();
 
         // Create some invalid signatures for testing
         let invalid_sig_wrong_msg = keypairs[0].sign(b"wrong message");
@@ -787,9 +814,13 @@ mod tests {
 
         // One signature is invalid
         for options in [&options_small_thresh, &options_large_thresh] {
-            let mut bad_signatures = signatures.clone();
-            bad_signatures[25] = invalid_sig_wrong_msg;
-            let bad_sig_refs: Vec<_> = bad_signatures.iter().collect();
+            let mut bad_signatures_proj = signatures_proj.clone();
+            bad_signatures_proj[25] = invalid_sig_wrong_msg;
+            let bad_signatures_affine: Vec<_> = bad_signatures_proj
+                .iter()
+                .map(|s| Signature::from(s))
+                .collect();
+            let bad_sig_refs: Vec<_> = bad_signatures_affine.iter().collect();
 
             let results = SignatureProjective::par_verify_batch_binary_search(
                 &pubkeys,
@@ -805,11 +836,15 @@ mod tests {
 
         // Multiple signatures are invalid
         for options in [&options_small_thresh, &options_large_thresh] {
-            let mut bad_signatures = signatures.clone();
-            bad_signatures[5] = invalid_sig_wrong_key;
-            bad_signatures[15] = invalid_sig_wrong_msg;
-            bad_signatures[45] = invalid_sig_wrong_key;
-            let bad_sig_refs: Vec<_> = bad_signatures.iter().collect();
+            let mut bad_signatures_proj = signatures_proj.clone();
+            bad_signatures_proj[5] = invalid_sig_wrong_key;
+            bad_signatures_proj[15] = invalid_sig_wrong_msg;
+            bad_signatures_proj[45] = invalid_sig_wrong_key;
+            let bad_signatures_affine: Vec<_> = bad_signatures_proj
+                .iter()
+                .map(|s| Signature::from(s))
+                .collect();
+            let bad_sig_refs: Vec<_> = bad_signatures_affine.iter().collect();
 
             let results = SignatureProjective::par_verify_batch_binary_search(
                 &pubkeys,
@@ -827,9 +862,13 @@ mod tests {
 
         // All signatures are invalid
         for options in [&options_small_thresh, &options_large_thresh] {
-            let bad_signatures: Vec<_> =
+            let bad_signatures_proj: Vec<_> =
                 (0..NUM_SIGNATURES).map(|_| invalid_sig_wrong_msg).collect();
-            let bad_sig_refs: Vec<_> = bad_signatures.iter().collect();
+            let bad_signatures_affine: Vec<_> = bad_signatures_proj
+                .iter()
+                .map(|s| Signature::from(s))
+                .collect();
+            let bad_sig_refs: Vec<_> = bad_signatures_affine.iter().collect();
 
             let results = SignatureProjective::par_verify_batch_binary_search(
                 &pubkeys,
@@ -853,8 +892,8 @@ mod tests {
         assert_eq!(err, BlsError::InputLengthMismatch);
 
         // Empty inputs
-        let empty_pubkeys: &[&PubkeyProjective] = &[];
-        let empty_sigs: &[&SignatureProjective] = &[];
+        let empty_pubkeys: &[&Pubkey] = &[];
+        let empty_sigs: &[&Signature] = &[];
         let results = SignatureProjective::par_verify_batch_binary_search(
             empty_pubkeys,
             empty_sigs,

--- a/bls-signatures/src/signature.rs
+++ b/bls-signatures/src/signature.rs
@@ -553,8 +553,8 @@ mod tests {
         .unwrap());
 
         // verify with affine and compressed types
-        let pubkey0_affine: Pubkey = keypair0.public.into();
-        let pubkey1_affine: Pubkey = keypair1.public.into();
+        let pubkey0_affine: Pubkey = keypair0.public;
+        let pubkey1_affine: Pubkey = keypair1.public;
         let signature0_affine: Signature = signature0.into();
         let signature1_affine: Signature = signature1.into();
         assert!(SignatureProjective::aggregate_verify(
@@ -615,9 +615,8 @@ mod tests {
         let signature2_projective = keypair2.sign(test_message);
 
         let pubkey0 = PubkeyProjective::try_from(keypair0.public).unwrap(); // Projective
-        let pubkey1_affine: Pubkey = keypair1.public.into(); // Affine
-        let pubkey2_compressed: PubkeyCompressed =
-            Pubkey::from(keypair2.public).try_into().unwrap(); // Compressed
+        let pubkey1_affine: Pubkey = keypair1.public; // Affine
+        let pubkey2_compressed: PubkeyCompressed = keypair2.public.try_into().unwrap(); // Compressed
 
         let signature0 = signature0_projective; // Projective
         let signature1_affine: Signature = signature1_projective.into(); // Affine
@@ -739,8 +738,7 @@ mod tests {
         let pubkeys_affine: Vec<_> = keypairs.iter().map(|kp| kp.public).collect();
         let pubkeys: Vec<_> = pubkeys_affine.iter().collect();
         let signatures_proj: Vec<_> = keypairs.iter().map(|kp| kp.sign(message)).collect();
-        let signatures_affine: Vec<_> =
-            signatures_proj.iter().map(|s| Signature::from(s)).collect();
+        let signatures_affine: Vec<_> = signatures_proj.iter().map(Signature::from).collect();
         let sig_refs: Vec<_> = signatures_affine.iter().collect();
 
         // All signatures are valid
@@ -751,10 +749,8 @@ mod tests {
         let mut bad_signatures_proj = signatures_proj.clone();
         let bad_sig = keypairs[3].sign(b"a different message");
         bad_signatures_proj[3] = bad_sig;
-        let bad_signatures_affine: Vec<_> = bad_signatures_proj
-            .iter()
-            .map(|s| Signature::from(s))
-            .collect();
+        let bad_signatures_affine: Vec<_> =
+            bad_signatures_proj.iter().map(Signature::from).collect();
         let bad_sig_refs: Vec<_> = bad_signatures_affine.iter().collect();
 
         let results =
@@ -788,8 +784,7 @@ mod tests {
         let pubkeys_affine: Vec<_> = keypairs.iter().map(|kp| kp.public).collect();
         let pubkeys: Vec<_> = pubkeys_affine.iter().collect();
         let signatures_proj: Vec<_> = keypairs.iter().map(|kp| kp.sign(message)).collect();
-        let signatures_affine: Vec<_> =
-            signatures_proj.iter().map(|s| Signature::from(s)).collect();
+        let signatures_affine: Vec<_> = signatures_proj.iter().map(Signature::from).collect();
         let sig_refs: Vec<_> = signatures_affine.iter().collect();
 
         // Create some invalid signatures for testing
@@ -816,10 +811,8 @@ mod tests {
         for options in [&options_small_thresh, &options_large_thresh] {
             let mut bad_signatures_proj = signatures_proj.clone();
             bad_signatures_proj[25] = invalid_sig_wrong_msg;
-            let bad_signatures_affine: Vec<_> = bad_signatures_proj
-                .iter()
-                .map(|s| Signature::from(s))
-                .collect();
+            let bad_signatures_affine: Vec<_> =
+                bad_signatures_proj.iter().map(Signature::from).collect();
             let bad_sig_refs: Vec<_> = bad_signatures_affine.iter().collect();
 
             let results = SignatureProjective::par_verify_batch_binary_search(
@@ -840,10 +833,8 @@ mod tests {
             bad_signatures_proj[5] = invalid_sig_wrong_key;
             bad_signatures_proj[15] = invalid_sig_wrong_msg;
             bad_signatures_proj[45] = invalid_sig_wrong_key;
-            let bad_signatures_affine: Vec<_> = bad_signatures_proj
-                .iter()
-                .map(|s| Signature::from(s))
-                .collect();
+            let bad_signatures_affine: Vec<_> =
+                bad_signatures_proj.iter().map(Signature::from).collect();
             let bad_sig_refs: Vec<_> = bad_signatures_affine.iter().collect();
 
             let results = SignatureProjective::par_verify_batch_binary_search(
@@ -864,10 +855,8 @@ mod tests {
         for options in [&options_small_thresh, &options_large_thresh] {
             let bad_signatures_proj: Vec<_> =
                 (0..NUM_SIGNATURES).map(|_| invalid_sig_wrong_msg).collect();
-            let bad_signatures_affine: Vec<_> = bad_signatures_proj
-                .iter()
-                .map(|s| Signature::from(s))
-                .collect();
+            let bad_signatures_affine: Vec<_> =
+                bad_signatures_proj.iter().map(Signature::from).collect();
             let bad_sig_refs: Vec<_> = bad_signatures_affine.iter().collect();
 
             let results = SignatureProjective::par_verify_batch_binary_search(


### PR DESCRIPTION
#### Problem
The current signature verification function takes in the projective form of the public key and signatures. This is a bit inefficient since the public keys and signatures are typically going to be sent over the network in their affine form. In order to invoke the verification function, we have to currently convert them to their projective form just to call the verification function. The verification function would then immediately convert them back to affine internally before performing the pairing operation.

#### Summary of Changes
I made the following changes:
- Updated verification API: The core verification functions, including `verify_signature` and the parallel batch verifiers, now directly accept the more efficient affine types (`Pubkey`, `Signature`). This removes the needless conversions and make the API more intuitive.
- `Keypair`: This is unrelated to the issue above, but I also updated `Keypair` to hold `Pubkey` (affine rep) instead of `PubkeyProjective` to reduce its in-memory footprint.

In the process, I added new conversion traits like `AsPubkey` and `AsSignature` to work with affine types.