### PR TITLE
vote-interface: enable parser on not(solana)

### DIFF
--- a/vote-interface/src/state/vote_state_0_23_5.rs
+++ b/vote-interface/src/state/vote_state_0_23_5.rs
@@ -38,6 +38,12 @@ pub struct VoteState0_23_5 {
     pub last_timestamp: BlockTimestamp,
 }
 
+impl VoteState0_23_5 {
+    pub fn is_uninitialized(&self) -> bool {
+        self.authorized_voter == Pubkey::default()
+    }
+}
+
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(test, derive(Arbitrary))]

--- a/vote-interface/src/state/vote_state_1_14_11.rs
+++ b/vote-interface/src/state/vote_state_1_14_11.rs
@@ -56,6 +56,10 @@ impl VoteState1_14_11 {
         3731 // see test_vote_state_size_of
     }
 
+    pub fn is_uninitialized(&self) -> bool {
+        self.authorized_voters.is_empty()
+    }
+
     pub fn is_correct_size_and_initialized(data: &[u8]) -> bool {
         const VERSION_OFFSET: usize = 4;
         const DEFAULT_PRIOR_VOTERS_END: usize = VERSION_OFFSET + DEFAULT_PRIOR_VOTERS_OFFSET;

--- a/vote-interface/src/state/vote_state_v4.rs
+++ b/vote-interface/src/state/vote_state_v4.rs
@@ -79,18 +79,9 @@ impl VoteStateV4 {
 
     #[cfg(any(target_os = "solana", feature = "bincode"))]
     pub fn deserialize(input: &[u8], vote_pubkey: &Pubkey) -> Result<Self, InstructionError> {
-        #[cfg(not(target_os = "solana"))]
-        {
-            bincode::deserialize::<VoteStateVersions>(input)
-                .map_err(|_| InstructionError::InvalidAccountData)
-                .and_then(|versioned| versioned.try_convert_to_v4(vote_pubkey))
-        }
-        #[cfg(target_os = "solana")]
-        {
-            let mut vote_state = Self::default();
-            Self::deserialize_into(input, &mut vote_state, vote_pubkey)?;
-            Ok(vote_state)
-        }
+        let mut vote_state = Self::default();
+        Self::deserialize_into(input, &mut vote_state, vote_pubkey)?;
+        Ok(vote_state)
     }
 
     /// Deserializes the input `VoteStateVersions` buffer directly into the provided `VoteStateV4`.


### PR DESCRIPTION
* use the custom `VoteState` parser for all targets
* add `is_uninitialized()` to `VoteState` structs, for agave code that skips `VoteStateVersions`
* fix a bug where `(0, Pubkey::default())` was added to `AuthorizedVoters`