### PR TITLE
[bls-signatures] Add batch signature verification functions on different messages

### DIFF
--- a/bls-signatures/benches/bls_signatures.rs
+++ b/bls-signatures/benches/bls_signatures.rs
@@ -74,7 +74,7 @@ fn bench_aggregate(c: &mut Criterion) {
             |b| {
                 b.iter(|| {
                     let verification_result = black_box(
-                        SignatureProjective::aggregate_verify(
+                        SignatureProjective::verify_aggregate(
                             &pubkey_refs,
                             &signature_refs,
                             message,
@@ -92,7 +92,7 @@ fn bench_aggregate(c: &mut Criterion) {
             |b| {
                 b.iter(|| {
                     let verification_result = black_box(
-                        SignatureProjective::par_aggregate_verify(
+                        SignatureProjective::par_verify_aggregate(
                             &pubkey_refs,
                             &signature_refs,
                             message,
@@ -156,7 +156,7 @@ fn bench_batch_verification(c: &mut Criterion) {
             |b| {
                 b.iter(|| {
                     let verification_result = black_box(
-                        SignatureProjective::batch_verify(
+                        SignatureProjective::verify_distinct(
                             &pubkey_refs,
                             &signature_refs,
                             &message_refs,
@@ -174,7 +174,7 @@ fn bench_batch_verification(c: &mut Criterion) {
             |b| {
                 b.iter(|| {
                     let verification_result = black_box(
-                        SignatureProjective::par_batch_verify(
+                        SignatureProjective::par_verify_distinct(
                             &pubkey_refs,
                             &signature_refs,
                             &message_refs,

--- a/bls-signatures/benches/bls_signatures.rs
+++ b/bls-signatures/benches/bls_signatures.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "parallel")]
+use solana_bls_signatures::{pubkey::Pubkey, signature::Signature};
 use {
     criterion::{criterion_group, criterion_main, Criterion},
     solana_bls_signatures::{
@@ -6,14 +8,6 @@ use {
         signature::SignatureProjective,
     },
     std::hint::black_box,
-};
-#[cfg(feature = "parallel")]
-use {
-    solana_bls_signatures::{
-        pubkey::Pubkey,
-        signature::{Signature, VerificationOptions},
-    },
-    std::collections::HashSet,
 };
 
 // Benchmark for verifying a single signature
@@ -137,166 +131,65 @@ fn bench_proof_of_possession(c: &mut Criterion) {
 }
 
 // Benchmark for batch verification functions
-#[cfg(feature = "parallel")]
 fn bench_batch_verification(c: &mut Criterion) {
     let mut group = c.benchmark_group("batch_verify");
-    let options = VerificationOptions {
-        aggregation_threshold: std::num::NonZero::new(32).unwrap(),
-    };
 
     for num_validators in [64, 128, 256, 512, 1024, 2048].iter() {
-        let message = b"test_message";
         let keypairs: Vec<Keypair> = (0..*num_validators).map(|_| Keypair::new()).collect();
         let pubkeys: Vec<Pubkey> = keypairs.iter().map(|kp| kp.public).collect();
         let pubkey_refs: Vec<&Pubkey> = pubkeys.iter().collect();
 
-        // All signatures are valid
-        let signatures: Vec<Signature> =
-            keypairs.iter().map(|kp| kp.sign(message).into()).collect();
+        // Create a unique message for each validator
+        let messages: Vec<Vec<u8>> = (0..*num_validators)
+            .map(|i| format!("message_{}", i).into_bytes())
+            .collect();
+        let message_refs: Vec<&[u8]> = messages.iter().map(|m| m.as_slice()).collect();
+
+        // Create a signature for each message
+        let signatures: Vec<Signature> = keypairs
+            .iter()
+            .zip(message_refs.iter())
+            .map(|(kp, msg)| kp.sign(msg).into())
+            .collect();
         let signature_refs: Vec<&Signature> = signatures.iter().collect();
 
         group.bench_function(
-            format!("{num_validators} par_verify_batch (all valid)"),
+            format!("{num_validators} sequential batch verification"),
             |b| {
                 b.iter(|| {
-                    let results = black_box(
-                        SignatureProjective::par_verify_batch(
+                    let verification_result = black_box(
+                        SignatureProjective::batch_verify(
                             &pubkey_refs,
                             &signature_refs,
-                            message,
+                            &message_refs,
                         )
                         .unwrap(),
                     );
-                    assert!(results.iter().all(|&v| v));
+                    assert!(verification_result);
                 });
             },
         );
 
+        #[cfg(feature = "parallel")]
         group.bench_function(
-            format!("{num_validators} par_verify_batch_binary_search (all valid)"),
+            format!("{num_validators} parallel batch verification"),
             |b| {
                 b.iter(|| {
-                    let results = black_box(
-                        SignatureProjective::par_verify_batch_binary_search(
+                    let verification_result = black_box(
+                        SignatureProjective::par_batch_verify(
                             &pubkey_refs,
                             &signature_refs,
-                            message,
-                            &options,
+                            &message_refs,
                         )
                         .unwrap(),
                     );
-                    assert!(results.iter().all(|&v| v));
-                });
-            },
-        );
-
-        // --- Scenario 2: One signature is invalid ---
-        let mut bad_signatures_one = signatures.clone();
-        let invalid_sig_idx = num_validators / 2;
-        bad_signatures_one[invalid_sig_idx] =
-            keypairs[invalid_sig_idx].sign(b"wrong message").into();
-        let bad_signature_refs_one: Vec<&Signature> = bad_signatures_one.iter().collect();
-
-        group.bench_function(
-            format!("{num_validators} par_verify_batch (one invalid)"),
-            |b| {
-                b.iter(|| {
-                    let results = black_box(
-                        SignatureProjective::par_verify_batch(
-                            &pubkey_refs,
-                            &bad_signature_refs_one,
-                            message,
-                        )
-                        .unwrap(),
-                    );
-                    assert!(!results[invalid_sig_idx]);
-                });
-            },
-        );
-
-        group.bench_function(
-            format!("{num_validators} par_verify_batch_binary_search (one invalid)"),
-            |b| {
-                b.iter(|| {
-                    let results = black_box(
-                        SignatureProjective::par_verify_batch_binary_search(
-                            &pubkey_refs,
-                            &bad_signature_refs_one,
-                            message,
-                            &options,
-                        )
-                        .unwrap(),
-                    );
-                    assert!(!results[invalid_sig_idx]);
-                });
-            },
-        );
-
-        // --- Scenario 3: 10% of signatures are invalid ---
-        let mut bad_signatures_10_percent = signatures.clone();
-        let num_invalid = num_validators / 10;
-        let mut invalid_indices = HashSet::new();
-        for i in 0..num_invalid {
-            let idx = i * 10;
-            bad_signatures_10_percent[idx] = keypairs[idx].sign(b"wrong message").into();
-            invalid_indices.insert(idx);
-        }
-        let bad_signature_refs_10_percent: Vec<&Signature> =
-            bad_signatures_10_percent.iter().collect();
-
-        group.bench_function(
-            format!("{num_validators} par_verify_batch (10% invalid)"),
-            |b| {
-                b.iter(|| {
-                    let results = black_box(
-                        SignatureProjective::par_verify_batch(
-                            &pubkey_refs,
-                            &bad_signature_refs_10_percent,
-                            message,
-                        )
-                        .unwrap(),
-                    );
-                    for (i, &is_valid) in results.iter().enumerate() {
-                        if invalid_indices.contains(&i) {
-                            assert!(!is_valid);
-                        } else {
-                            assert!(is_valid);
-                        }
-                    }
-                });
-            },
-        );
-
-        group.bench_function(
-            format!("{num_validators} par_verify_batch_binary_search (10% invalid)"),
-            |b| {
-                b.iter(|| {
-                    let results = black_box(
-                        SignatureProjective::par_verify_batch_binary_search(
-                            &pubkey_refs,
-                            &bad_signature_refs_10_percent,
-                            message,
-                            &options,
-                        )
-                        .unwrap(),
-                    );
-                    for (i, &is_valid) in results.iter().enumerate() {
-                        if invalid_indices.contains(&i) {
-                            assert!(!is_valid);
-                        } else {
-                            assert!(is_valid);
-                        }
-                    }
+                    assert!(verification_result);
                 });
             },
         );
     }
     group.finish()
 }
-
-// Stub function for when the `parallel` function is not enabled.
-#[cfg(not(feature = "parallel"))]
-fn bench_batch_verification(_c: &mut Criterion) {}
 
 criterion_group!(
     benches,

--- a/bls-signatures/benches/bls_signatures.rs
+++ b/bls-signatures/benches/bls_signatures.rs
@@ -1,11 +1,9 @@
-#[cfg(feature = "parallel")]
-use solana_bls_signatures::{pubkey::Pubkey, signature::Signature};
 use {
     criterion::{criterion_group, criterion_main, Criterion},
     solana_bls_signatures::{
         keypair::Keypair,
-        pubkey::{PubkeyProjective, VerifiablePubkey},
-        signature::SignatureProjective,
+        pubkey::{Pubkey, PubkeyProjective, VerifiablePubkey},
+        signature::{Signature, SignatureProjective},
     },
     std::hint::black_box,
 };
@@ -141,7 +139,7 @@ fn bench_batch_verification(c: &mut Criterion) {
 
         // Create a unique message for each validator
         let messages: Vec<Vec<u8>> = (0..*num_validators)
-            .map(|i| format!("message_{}", i).into_bytes())
+            .map(|i| format!("message_{i}").into_bytes())
             .collect();
         let message_refs: Vec<&[u8]> = messages.iter().map(|m| m.as_slice()).collect();
 

--- a/bls-signatures/src/pubkey.rs
+++ b/bls-signatures/src/pubkey.rs
@@ -40,7 +40,7 @@ pub const BLS_PUBLIC_KEY_AFFINE_SIZE: usize = 96;
 pub const BLS_PUBLIC_KEY_AFFINE_BASE64_SIZE: usize = 256;
 
 #[cfg(all(not(target_os = "solana"), feature = "std"))]
-static NEG_G1_GENERATOR_AFFINE: LazyLock<G1Affine> =
+pub(crate) static NEG_G1_GENERATOR_AFFINE: LazyLock<G1Affine> =
     LazyLock::new(|| (-G1Projective::generator()).into());
 
 /// A trait for types that can be converted into a `PubkeyProjective`.

--- a/bls-signatures/src/signature.rs
+++ b/bls-signatures/src/signature.rs
@@ -1,5 +1,7 @@
 #[cfg(all(not(target_os = "solana"), feature = "std"))]
 use crate::pubkey::NEG_G1_GENERATOR_AFFINE;
+#[cfg(not(feature = "std"))]
+use blstrs::G1Projective;
 #[cfg(feature = "bytemuck")]
 use bytemuck::{Pod, PodInOption, Zeroable, ZeroableInOption};
 #[cfg(not(target_os = "solana"))]
@@ -155,6 +157,7 @@ impl SignatureProjective {
         #[cfg(not(feature = "std"))]
         let neg_g1_generator = &neg_g1_generator_val;
 
+        #[allow(clippy::arithmetic_side_effects)]
         let mut terms = alloc::vec::Vec::with_capacity(public_keys.len() + 1);
         for i in 0..public_keys.len() {
             terms.push((&pubkeys_affine[i], &prepared_hashes[i]));
@@ -239,6 +242,7 @@ impl SignatureProjective {
         // 1. Aggregate signatures.
         // 2. Deserialize public keys into curve points.
         // 3. Hash messages into curve points and prepare them for pairing.
+        #[allow(clippy::type_complexity)]
         let ((pubkeys_affine_res, prepared_hashes_res), aggregate_signature_res): (
             (Result<Vec<_>, _>, Result<Vec<_>, _>),
             Result<SignatureProjective, BlsError>,


### PR DESCRIPTION
#### Problem
Currently, there is no public function to a batch of BLS signatures on different messages.

#### Summary of Changes
I added `batch_verify` and `par_batch_verify` functions to verify signatures on different messages.

After I added these functions, I realized that there are many different functions to verify different combination of signatures on messages, which could be quite confusing for developers. I ended up just removing the existing `par_verify_batch` and `par_verify_batch_binary_search` functions.

Now, the exposed API is quite simple. The `aggregate_verify` and `par_aggregate_verify` functions verify BLS signatures on the same message. The `batch_verify` and `par_batch_verify` functions verify BLS signatures on different messages.