### PR TITLE
pubkey: Allow to build without std

### DIFF
--- a/address/Cargo.toml
+++ b/address/Cargo.toml
@@ -28,7 +28,7 @@ rand = ["dep:rand", "atomic", "std"]
 sanitize = ["dep:solana-sanitize"]
 serde = ["dep:serde", "dep:serde_derive"]
 sha2 = ["dep:solana-sha256-hasher", "error"]
-std = ["decode"]
+std = ["atomic", "decode"]
 syscalls = ["dep:solana-define-syscall", "error"]
 
 [dependencies]

--- a/pubkey/Cargo.toml
+++ b/pubkey/Cargo.toml
@@ -29,7 +29,7 @@ std = ["solana-address/std"]
 
 [dependencies]
 rand = { workspace = true, optional = true }
-solana-address = { workspace = true, features = ["atomic", "decode", "error", "sanitize", "sha2", "syscalls"] }
+solana-address = { workspace = true, features = ["error", "sanitize", "sha2", "syscalls"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Make the `atomic` feature of `solana-address` dependency optional.

Fixes: #301