### PR TITLE
vote-interface: make `compute_vote_latency` private

### DIFF
--- a/vote-interface/src/state/vote_state_v3.rs
+++ b/vote-interface/src/state/vote_state_v3.rs
@@ -299,7 +299,7 @@ impl VoteStateV3 {
     }
 
     // Computes the vote latency for vote on voted_for_slot where the vote itself landed in current_slot
-    pub fn compute_vote_latency(voted_for_slot: Slot, current_slot: Slot) -> u8 {
+    fn compute_vote_latency(voted_for_slot: Slot, current_slot: Slot) -> u8 {
         std::cmp::min(current_slot.saturating_sub(voted_for_slot), u8::MAX as u64) as u8
     }
 


### PR DESCRIPTION
We made this a free function in https://github.com/anza-xyz/agave/pull/7822. We shouldn't offer it as a public associated function on `VoteStateV3` anymore. After other methods are ported to the Vote program, like `process_vote_slot`, we can drop it entirely.