### PR TITLE
ci: publish script: make dependent version a configurable param

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -32,7 +32,10 @@ on:
         type: boolean
         default: true
       dependent_version:
-        description: How workspace dependencies should be handled
+        description: |
+          How workspace dependencies should be handled.
+          - "fix": (Default) Only bumps the workspace for semver-breakage - prefer this option
+          - "upgrade": Bumps workspace version regardless - only use if another SDK crate requires new code
         required: true
         default: fix
         type: choice

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -31,6 +31,14 @@ on:
         required: true
         type: boolean
         default: true
+      dependent_version:
+        description: How workspace dependencies should be handled
+        required: true
+        default: fix
+        type: choice
+        options:
+          - fix
+          - upgrade
 
 jobs:
   sanity:
@@ -218,7 +226,7 @@ jobs:
             OPTIONS=""
           fi
 
-          ./scripts/publish-rust.sh "${{ inputs.package_path }}" $LEVEL $OPTIONS
+          ./scripts/publish-rust.sh "${{ inputs.package_path }}" $LEVEL "${{ inputs.dependent_version }}" $OPTIONS
 
       - name: Generate a changelog
         if: github.event.inputs.create_release == 'true'

--- a/scripts/publish-rust.sh
+++ b/scripts/publish-rust.sh
@@ -17,7 +17,8 @@ if [[ -z $2 ]]; then
   exit 1
 fi
 LEVEL=$2
-DRY_RUN=$3
+DEPENDENT_VERSION=$3
+DRY_RUN=$4
 
 # Go to the directory
 cd "${PACKAGE_PATH}"
@@ -31,7 +32,7 @@ tag_name="${package_name//solana-/}"
 if [[ -n ${DRY_RUN} ]]; then
   cargo release "${LEVEL}"
 else
-  cargo release "${LEVEL}" --tag-name "${tag_name}@v{{version}}" --no-confirm --execute --dependent-version fix
+  cargo release "${LEVEL}" --tag-name "${tag_name}@v{{version}}" --no-confirm --execute --dependent-version "${DEPENDENT_VERSION}"
 fi
 
 # Stop here if this is a dry run.


### PR DESCRIPTION
#### Problem
When publishing the vote-interface, I ran into a hiccup caused by the `cargo-release` argument `--dependent-version`.

Currently, the script hard-codes the argument as `--dependent-version fix`, where `fix` will only update the workspace manifest version of your dependency if it breaks semver.

However, in a situation where you may depend on something additive, such as #280, you might want to publish your lower dependency with a minor or patch but still update the workspace manifest. This functionality is available through the `upgrade` argument instead.

#### Summary of Changes
Add `dependent_version` as a configurable parameter, which defaults to `fix`, in the manually-triggered publish job.