### PR TITLE
manifest: bump serialize-utils at workspace level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -287,7 +287,7 @@ solana-seed-derivable = { path = "seed-derivable", version = "3.0.0" }
 solana-seed-phrase = { path = "seed-phrase", version = "3.0.0" }
 solana-serde = { path = "serde", version = "3.0.0" }
 solana-serde-varint = { path = "serde-varint", version = "3.0.0" }
-solana-serialize-utils = { path = "serialize-utils", version = "3.0.0" }
+solana-serialize-utils = { path = "serialize-utils", version = "3.1.0" }
 solana-sha256-hasher = { path = "sha256-hasher", version = "3.0.0" }
 solana-short-vec = { path = "short-vec", version = "3.0.0" }
 solana-shred-version = { path = "shred-version", version = "3.0.0" }


### PR DESCRIPTION
Bumps the version (minor) of `solana-serialize-utils` so we can publish a new `solana-vote-interface` and set the minimum version to 3.1.0.

This step was not automatically done during publish. See #309.