### PR TITLE
hash: Allow to build without std

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -551,3 +551,21 @@ jobs:
 
       - name: Run benches
         run: ./scripts/test-bench.sh
+
+  check-no-std:
+    name: Check no_std build
+    runs-on: ubuntu-latest
+    needs: [check]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          nightly-toolchain: true
+          cargo-cache-key: cargo-nightly-bench
+          cargo-cache-fallback-key: cargo-nightly
+
+      - name: Run check
+        run: ./scripts/check-no-std.sh

--- a/address-lookup-table-interface/Cargo.toml
+++ b/address-lookup-table-interface/Cargo.toml
@@ -53,7 +53,7 @@ solana-pubkey = { workspace = true, features = ["curve25519"] }
 solana-address-lookup-table-interface = { path = ".", features = [
     "dev-context-only-utils",
 ] }
-solana-hash = { workspace = true }
+solana-hash = { workspace = true, features = ["std"] }
 
 [lints]
 workspace = true

--- a/hash/Cargo.toml
+++ b/hash/Cargo.toml
@@ -21,7 +21,7 @@ bytemuck = ["dep:bytemuck", "dep:bytemuck_derive"]
 default = ["std"]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "std"]
 serde = ["dep:serde", "dep:serde_derive"]
-std = []
+std = ["dep:solana-atomic-u64"]
 
 [dependencies]
 borsh = { workspace = true, optional = true }
@@ -30,7 +30,7 @@ bytemuck_derive = { workspace = true, optional = true }
 five8 = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-solana-atomic-u64 = { workspace = true }
+solana-atomic-u64 = { workspace = true, optional = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }

--- a/hash/src/lib.rs
+++ b/hash/src/lib.rs
@@ -121,6 +121,7 @@ impl Hash {
     }
 
     /// unique Hash for tests and benchmarks.
+    #[cfg(feature = "std")]
     pub fn new_unique() -> Self {
         use solana_atomic_u64::AtomicU64;
         static I: AtomicU64 = AtomicU64::new(1);

--- a/scripts/check-no-std.sh
+++ b/scripts/check-no-std.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+here="$(dirname "$0")"
+src_root="$(readlink -f "${here}/..")"
+
+cd "${src_root}"
+
+no_std_crates=(
+  -p solana-hash
+  -p solana-sanitize
+)
+# Use the upstream BPF target, which doesn't support std, to make sure that our
+# no_std support really works.
+target="bpfel-unknown-none"
+
+# pacify shellcheck: cannot follow dynamic path
+# shellcheck disable=SC1090,SC1091
+source "$here"/rust-version.sh nightly
+# pacify shellcheck: cannot follow sourced variables
+# shellcheck disable=SC2154
+rustup component add rust-src "--toolchain=$rust_nightly"
+./cargo nightly check -Zbuild-std=core \
+  "--target=$target" \
+  --no-default-features \
+  "${no_std_crates[@]}"

--- a/transaction/Cargo.toml
+++ b/transaction/Cargo.toml
@@ -22,7 +22,12 @@ bincode = [
     "solana-message/bincode",
 ]
 blake3 = ["bincode", "solana-message/blake3"]
-dev-context-only-utils = ["blake3", "serde", "verify"]
+dev-context-only-utils = [
+    "blake3",
+    "solana-hash/std",
+    "serde",
+    "verify",
+]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
@@ -61,7 +66,7 @@ anyhow = { workspace = true }
 bincode = { workspace = true }
 borsh = { workspace = true }
 solana-example-mocks = { path = "../example-mocks" }
-solana-hash = { workspace = true }
+solana-hash = { workspace = true, features = ["std"] }
 solana-instruction = { workspace = true, features = ["borsh"] }
 solana-keypair = { workspace = true }
 solana-nonce = { workspace = true }


### PR DESCRIPTION
Hide the `solana-atomic-u64` dependency and `Hash::new_unique` method behind the `std` feature.