### PR TITLE
address!: Log visibility

### DIFF
--- a/address/src/lib.rs
+++ b/address/src/lib.rs
@@ -272,6 +272,12 @@ impl Address {
     pub fn is_on_curve(&self) -> bool {
         bytes_are_curve_point(self)
     }
+
+    #[cfg(all(not(target_os = "solana"), feature = "std"))]
+    /// Log a `Address` from a program
+    pub fn log(&self) {
+        std::println!("{}", std::string::ToString::to_string(&self));
+    }
 }
 
 impl AsRef<[u8]> for Address {

--- a/address/src/syscalls.rs
+++ b/address/src/syscalls.rs
@@ -15,16 +15,10 @@ pub use solana_define_syscall::definitions::{
 const SUCCESS: u64 = 0;
 
 impl Address {
-    #[cfg(any(target_os = "solana", feature = "std"))]
+    #[cfg(target_os = "solana")]
     /// Log a `Address` from a program
     pub fn log(&self) {
-        #[cfg(target_os = "solana")]
-        unsafe {
-            sol_log_pubkey(self.as_ref() as *const _ as *const u8)
-        };
-
-        #[cfg(not(target_os = "solana"))]
-        std::println!("{}", std::string::ToString::to_string(&self));
+        unsafe { sol_log_pubkey(self.as_ref() as *const _ as *const u8) };
     }
 
     /// Find a valid [program derived address][pda] and its corresponding bump seed.

--- a/scripts/check-nits.sh
+++ b/scripts/check-nits.sh
@@ -18,7 +18,7 @@ declare prints=(
 declare print_free_tree=(
   ':**.rs'
   ':^address/src/hasher.rs'
-  ':^address/src/syscalls.rs'
+  ':^address/src/lib.rs'
   ':^logger/src/lib.rs'
   ':^msg/src/lib.rs'
   ':^program-option/src/lib.rs'


### PR DESCRIPTION
### Problem

Currently the `Address::log` implementation is behind the "curve25519" and "syscalls" features. While this works for programs, it is overly restrictive when in "std" context.

### Solution

Move the "std" specific implementation so that it is gated on the "std" feature only.