### PR TITLE
address!: Add required feature to `address!` macro

### DIFF
--- a/address/src/lib.rs
+++ b/address/src/lib.rs
@@ -334,6 +334,7 @@ impl PartialEq for Address {
     }
 }
 
+#[cfg(feature = "decode")]
 /// Convenience macro to define a static `Address` value.
 ///
 /// Input: a single literal base58 string representation of an `Address`.


### PR DESCRIPTION
### Problem

The `address!` macro requires `Address::from_str_const`, which is behind the "decode" feature, but the macro itself is not.

### Solution

Make the `address!` macro to be behind the "decode" feature.