### PR TITLE
address: Add `declare_id` / `declare_deprecated_id` from pubkey

### DIFF
--- a/address/src/lib.rs
+++ b/address/src/lib.rs
@@ -356,6 +356,85 @@ macro_rules! address {
     };
 }
 
+/// Convenience macro to declare a static address and functions to interact with it.
+///
+/// Input: a single literal base58 string representation of a program's ID.
+///
+/// # Example
+///
+/// ```
+/// # // wrapper is used so that the macro invocation occurs in the item position
+/// # // rather than in the statement position which isn't allowed.
+/// use std::str::FromStr;
+/// use solana_address::{declare_id, Address};
+///
+/// # mod item_wrapper {
+/// #   use solana_address::declare_id;
+/// declare_id!("My11111111111111111111111111111111111111111");
+/// # }
+/// # use item_wrapper::id;
+///
+/// let my_id = Address::from_str("My11111111111111111111111111111111111111111").unwrap();
+/// assert_eq!(id(), my_id);
+/// ```
+#[cfg(feature = "decode")]
+#[macro_export]
+macro_rules! declare_id {
+    ($address:expr) => {
+        /// The const program ID.
+        pub const ID: $crate::Address = $crate::Address::from_str_const($address);
+
+        /// Returns `true` if given address is the ID.
+        // TODO make this const once `derive_const` makes it out of nightly
+        // and we can `derive_const(PartialEq)` on `Address`.
+        pub fn check_id(id: &$crate::Address) -> bool {
+            id == &ID
+        }
+
+        /// Returns the ID.
+        pub const fn id() -> $crate::Address {
+            ID
+        }
+
+        #[cfg(test)]
+        #[test]
+        fn test_id() {
+            assert!(check_id(&id()));
+        }
+    };
+}
+
+/// Same as [`declare_id`] except that it reports that this ID has been deprecated.
+#[cfg(feature = "decode")]
+#[macro_export]
+macro_rules! declare_deprecated_id {
+    ($address:expr) => {
+        /// The const ID.
+        pub const ID: $crate::Address = $crate::Address::from_str_const($address);
+
+        /// Returns `true` if given address is the ID.
+        // TODO make this const once `derive_const` makes it out of nightly
+        // and we can `derive_const(PartialEq)` on `Address`.
+        #[deprecated()]
+        pub fn check_id(id: &$crate::Address) -> bool {
+            id == &ID
+        }
+
+        /// Returns the ID.
+        #[deprecated()]
+        pub const fn id() -> $crate::Address {
+            ID
+        }
+
+        #[cfg(test)]
+        #[test]
+        #[allow(deprecated)]
+        fn test_id() {
+            assert!(check_id(&id()));
+        }
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use {super::*, core::str::from_utf8, std::string::String};

--- a/pubkey/src/lib.rs
+++ b/pubkey/src/lib.rs
@@ -12,7 +12,7 @@ pub use solana_address::bytes_are_curve_point;
 #[cfg(target_os = "solana")]
 pub use solana_address::syscalls;
 pub use solana_address::{
-    address as pubkey,
+    address as pubkey, declare_deprecated_id, declare_id,
     error::{AddressError as PubkeyError, ParseAddressError as ParsePubkeyError},
     Address as Pubkey, ADDRESS_BYTES as PUBKEY_BYTES, MAX_SEEDS, MAX_SEED_LEN,
 };
@@ -25,81 +25,4 @@ pub use solana_address::{
 #[cfg(all(feature = "rand", not(target_os = "solana")))]
 pub fn new_rand() -> Pubkey {
     Pubkey::from(rand::random::<[u8; PUBKEY_BYTES]>())
-}
-
-/// Convenience macro to declare a static public key and functions to interact with it.
-///
-/// Input: a single literal base58 string representation of a program's ID.
-///
-/// # Example
-///
-/// ```
-/// # // wrapper is used so that the macro invocation occurs in the item position
-/// # // rather than in the statement position which isn't allowed.
-/// use std::str::FromStr;
-/// use solana_pubkey::{declare_id, Pubkey};
-///
-/// # mod item_wrapper {
-/// #   use solana_pubkey::declare_id;
-/// declare_id!("My11111111111111111111111111111111111111111");
-/// # }
-/// # use item_wrapper::id;
-///
-/// let my_id = Pubkey::from_str("My11111111111111111111111111111111111111111").unwrap();
-/// assert_eq!(id(), my_id);
-/// ```
-#[macro_export]
-macro_rules! declare_id {
-    ($pubkey:expr) => {
-        /// The const program ID.
-        pub const ID: $crate::Pubkey = $crate::Pubkey::from_str_const($pubkey);
-
-        /// Returns `true` if given pubkey is the program ID.
-        // TODO make this const once `derive_const` makes it out of nightly
-        // and we can `derive_const(PartialEq)` on `Pubkey`.
-        pub fn check_id(id: &$crate::Pubkey) -> bool {
-            id == &ID
-        }
-
-        /// Returns the program ID.
-        pub const fn id() -> $crate::Pubkey {
-            ID
-        }
-
-        #[cfg(test)]
-        #[test]
-        fn test_id() {
-            assert!(check_id(&id()));
-        }
-    };
-}
-
-/// Same as [`declare_id`] except that it reports that this ID has been deprecated.
-#[macro_export]
-macro_rules! declare_deprecated_id {
-    ($pubkey:expr) => {
-        /// The const program ID.
-        pub const ID: $crate::Pubkey = $crate::Pubkey::from_str_const($pubkey);
-
-        /// Returns `true` if given pubkey is the program ID.
-        // TODO make this const once `derive_const` makes it out of nightly
-        // and we can `derive_const(PartialEq)` on `Pubkey`.
-        #[deprecated()]
-        pub fn check_id(id: &$crate::Pubkey) -> bool {
-            id == &ID
-        }
-
-        /// Returns the program ID.
-        #[deprecated()]
-        pub const fn id() -> $crate::Pubkey {
-            ID
-        }
-
-        #[cfg(test)]
-        #[test]
-        #[allow(deprecated)]
-        fn test_id() {
-            assert!(check_id(&id()));
-        }
-    };
 }


### PR DESCRIPTION
#### Problem

We should start using solana-address instead of solana-pubkey in most places, but solana-address doesn't have `declare_id` or `declare_deprecated_id`.

I noticed this while trying to get solana-pubkey properly no-std compatible.

#### Summary of changes

Move them from solana-pubkey, and re-export from solana-pubkey.