### PR TITLE
[bn-254] Change input to a sized array for LE addition, multiplication, and compression

### DIFF
--- a/bn254/benches/bn254.rs
+++ b/bn254/benches/bn254.rs
@@ -66,7 +66,7 @@ fn bench_addition_le(c: &mut Criterion) {
     let p_bytes = convert_endianness::<32, 64>(&ADD_P_BYTES_BE);
     let q_bytes = convert_endianness::<32, 64>(&ADD_Q_BYTES_BE);
 
-    let input_bytes = [&p_bytes[..], &q_bytes[..]].concat();
+    let input_bytes = [&p_bytes[..], &q_bytes[..]].concat().try_into().unwrap();
 
     c.bench_function("bn128 addition le", |b| {
         b.iter(|| alt_bn128_g1_addition_le(&input_bytes))
@@ -88,7 +88,10 @@ fn bench_multiplication_le(c: &mut Criterion) {
     let point_bytes = convert_endianness::<32, 64>(&MUL_POINT_BYTES_BE);
     let scalar_bytes = convert_endianness::<32, 32>(&MUL_SCALAR_BYTES_BE);
 
-    let input_bytes = [&point_bytes[..], &scalar_bytes[..]].concat();
+    let input_bytes = [&point_bytes[..], &scalar_bytes[..]]
+        .concat()
+        .try_into()
+        .unwrap();
 
     c.bench_function("bn128 multiplication le", |b| {
         b.iter(|| alt_bn128_g1_multiplication_le(&input_bytes))

--- a/bn254/src/addition.rs
+++ b/bn254/src/addition.rs
@@ -146,16 +146,15 @@ pub fn alt_bn128_addition(input: &[u8]) -> Result<Vec<u8>, AltBn128Error> {
 }
 
 #[inline(always)]
-pub fn alt_bn128_g1_addition_le(input: &[u8]) -> Result<Vec<u8>, AltBn128Error> {
+pub fn alt_bn128_g1_addition_le(
+    input: &[u8; ALT_BN128_ADDITION_INPUT_SIZE],
+) -> Result<Vec<u8>, AltBn128Error> {
     #[cfg(not(target_os = "solana"))]
     {
         alt_bn128_versioned_g1_addition(VersionedG1Addition::V0, input, Endianness::LE)
     }
     #[cfg(target_os = "solana")]
     {
-        if input.len() > ALT_BN128_ADDITION_INPUT_SIZE {
-            return Err(AltBn128Error::InvalidInputData);
-        }
         let mut result_buffer = [0; ALT_BN128_ADDITION_OUTPUT_SIZE];
         let result = unsafe {
             syscalls::sol_alt_bn128_group_op(

--- a/bn254/src/compression.rs
+++ b/bn254/src/compression.rs
@@ -362,7 +362,7 @@ mod target_arch {
     }
 
     pub fn alt_bn128_g1_compress_le(
-        input: &[u8],
+        input: &[u8; ALT_BN128_G1_POINT_SIZE],
     ) -> Result<[u8; ALT_BN128_G1_COMPRESSED_POINT_SIZE], AltBn128CompressionError> {
         let mut result_buffer = [0; ALT_BN128_G1_COMPRESSED_POINT_SIZE];
         let result = unsafe {
@@ -400,7 +400,7 @@ mod target_arch {
     }
 
     pub fn alt_bn128_g1_decompress_le(
-        input: &[u8],
+        input: &[u8; ALT_BN128_G1_COMPRESSED_POINT_SIZE],
     ) -> Result<[u8; ALT_BN128_G1_POINT_SIZE], AltBn128CompressionError> {
         let mut result_buffer = [0; ALT_BN128_G1_POINT_SIZE];
         let result = unsafe {
@@ -438,7 +438,7 @@ mod target_arch {
     }
 
     pub fn alt_bn128_g2_compress_le(
-        input: &[u8],
+        input: &[u8; ALT_BN128_G2_POINT_SIZE],
     ) -> Result<[u8; ALT_BN128_G2_COMPRESSED_POINT_SIZE], AltBn128CompressionError> {
         let mut result_buffer = [0; ALT_BN128_G2_COMPRESSED_POINT_SIZE];
         let result = unsafe {

--- a/bn254/src/multiplication.rs
+++ b/bn254/src/multiplication.rs
@@ -160,16 +160,15 @@ pub fn alt_bn128_multiplication(input: &[u8]) -> Result<Vec<u8>, AltBn128Error> 
 }
 
 #[inline(always)]
-pub fn alt_bn128_g1_multiplication_le(input: &[u8]) -> Result<Vec<u8>, AltBn128Error> {
+pub fn alt_bn128_g1_multiplication_le(
+    input: &[u8; ALT_BN128_MULTIPLICATION_INPUT_SIZE],
+) -> Result<Vec<u8>, AltBn128Error> {
     #[cfg(not(target_os = "solana"))]
     {
         alt_bn128_versioned_g1_multiplication(VersionedG1Multiplication::V1, input, Endianness::LE)
     }
     #[cfg(target_os = "solana")]
     {
-        if input.len() != ALT_BN128_MULTIPLICATION_INPUT_SIZE {
-            return Err(AltBn128Error::InvalidInputData);
-        }
         let mut result_buffer = [0u8; ALT_BN128_MULTIPLICATION_OUTPUT_SIZE];
         let result = unsafe {
             syscalls::sol_alt_bn128_group_op(


### PR DESCRIPTION
Currently, functions take slice as input. However, LE addition, multiplication, and compression require an input of a concrete length. This PR changes the input to a sized array, which is less error-prone.
This change can also be applied to BE compression, but it is a breaking change.