### PR TITLE
feat: add `no_std` support for commitment-config crate

### DIFF
--- a/commitment-config/Cargo.toml
+++ b/commitment-config/Cargo.toml
@@ -17,5 +17,5 @@ targets = ["x86_64-unknown-linux-gnu"]
 serde = ["dep:serde", "dep:serde_derive"]
 
 [dependencies]
-serde = { workspace = true, optional = true }
+serde = { workspace = true, optional = true, default-features = false}
 serde_derive = { workspace = true, optional = true }

--- a/commitment-config/Cargo.toml
+++ b/commitment-config/Cargo.toml
@@ -17,5 +17,5 @@ targets = ["x86_64-unknown-linux-gnu"]
 serde = ["dep:serde", "dep:serde_derive"]
 
 [dependencies]
-serde = { workspace = true, optional = true, default-features = false}
+serde = { workspace = true, optional = true, default-features = false }
 serde_derive = { workspace = true, optional = true }

--- a/commitment-config/Cargo.toml
+++ b/commitment-config/Cargo.toml
@@ -17,5 +17,5 @@ targets = ["x86_64-unknown-linux-gnu"]
 serde = ["dep:serde", "dep:serde_derive"]
 
 [dependencies]
-serde = { workspace = true, optional = true, default-features = false }
+serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }

--- a/commitment-config/src/lib.rs
+++ b/commitment-config/src/lib.rs
@@ -1,5 +1,5 @@
 //! Definitions of commitment levels.
-
+#![no_std]
 use core::{fmt, str::FromStr};
 
 #[cfg_attr(
@@ -110,8 +110,8 @@ impl FromStr for CommitmentLevel {
     }
 }
 
-impl std::fmt::Display for CommitmentLevel {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Display for CommitmentLevel {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let s = match self {
             CommitmentLevel::Processed => "processed",
             CommitmentLevel::Confirmed => "confirmed",

--- a/scripts/check-no-std.sh
+++ b/scripts/check-no-std.sh
@@ -10,6 +10,7 @@ cd "${src_root}"
 no_std_crates=(
   -p solana-address
   -p solana-clock
+  -p solana-commitment-config
   -p solana-define-syscall
   -p solana-fee-calculator
   -p solana-program-error


### PR DESCRIPTION
### Problem

`solana-commitment-config` crate is not `no_std` when it's no_std-friendly

### Summary of Changes

- make `solana-commitment-config` as `no_std` crate
- disable default (std) features for `serde` dependency 