### PR TITLE
feat: add `no_std` support for compute-budget-interface crate

### DIFF
--- a/compute-budget-interface/Cargo.toml
+++ b/compute-budget-interface/Cargo.toml
@@ -15,10 +15,12 @@ all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
 [features]
+default = ["std"]
 borsh = ["dep:borsh"]
-dev-context-only-utils = ["borsh"]
+dev-context-only-utils = ["borsh", "std"]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "serde"]
 serde = ["dep:serde", "dep:serde_derive"]
+std = ["serde?/std", "borsh?/std"]
 
 [dependencies]
 borsh = { workspace = true, optional = true }

--- a/compute-budget-interface/Cargo.toml
+++ b/compute-budget-interface/Cargo.toml
@@ -15,8 +15,8 @@ all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
 [features]
-default = ["std"]
 borsh = ["dep:borsh"]
+default = ["std"]
 dev-context-only-utils = ["borsh", "std"]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "serde"]
 serde = ["dep:serde", "dep:serde_derive"]
@@ -26,12 +26,8 @@ std = ["serde?/std", "borsh?/std"]
 borsh = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-solana-frozen-abi = { workspace = true, features = [
-    "frozen-abi",
-], optional = true }
-solana-frozen-abi-macro = { workspace = true, features = [
-    "frozen-abi",
-], optional = true }
+solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-instruction = { workspace = true, features = ["std"] }
 solana-sdk-ids = { workspace = true }
 

--- a/compute-budget-interface/src/lib.rs
+++ b/compute-budget-interface/src/lib.rs
@@ -1,20 +1,23 @@
 //! Instructions for the compute budget native program.
-#![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(feature = "frozen-abi")]
+use solana_frozen_abi_macro::{AbiEnumVisitor, AbiExample};
+
 #[cfg(feature = "borsh")]
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_instruction::Instruction;
+
+#[cfg(feature = "std")]
+extern crate std;
 pub use solana_sdk_ids::compute_budget::{check_id, id, ID};
+#[cfg(feature = "dev-context-only-utils")]
+use std::vec::Vec;
 
 /// Compute Budget Instructions
-#[cfg_attr(
-    feature = "frozen-abi",
-    derive(
-        solana_frozen_abi_macro::AbiExample,
-        solana_frozen_abi_macro::AbiEnumVisitor
-    )
-)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
 #[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "serde",
@@ -88,6 +91,9 @@ mod tests {
         let ix = ComputeBudgetInstruction::set_compute_unit_limit(257);
         assert_eq!(ix.data, [2, 1, 1, 0, 0].to_vec());
         let ix = ComputeBudgetInstruction::set_compute_unit_price(u64::MAX);
-        assert_eq!(ix.data, [3, 255, 255, 255, 255, 255, 255, 255, 255].to_vec());
+        assert_eq!(
+            ix.data,
+            [3, 255, 255, 255, 255, 255, 255, 255, 255].to_vec()
+        );
     }
 }

--- a/compute-budget-interface/src/lib.rs
+++ b/compute-budget-interface/src/lib.rs
@@ -1,13 +1,11 @@
 //! Instructions for the compute budget native program.
+#![no_std]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
-#![cfg_attr(not(feature = "std"), no_std)]
-extern crate alloc;
 #[cfg(feature = "borsh")]
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_instruction::Instruction;
 pub use solana_sdk_ids::compute_budget::{check_id, id, ID};
-use alloc::vec;
 
 /// Compute Budget Instructions
 #[cfg_attr(
@@ -47,7 +45,7 @@ macro_rules! to_instruction {
         Instruction {
             program_id: id(),
             data: data.to_vec(),
-            accounts: vec![],
+            accounts: [].to_vec(),
         }
     }};
 }
@@ -88,8 +86,8 @@ mod tests {
     #[test]
     fn test_to_instruction() {
         let ix = ComputeBudgetInstruction::set_compute_unit_limit(257);
-        assert_eq!(ix.data, vec![2, 1, 1, 0, 0]);
+        assert_eq!(ix.data, [2, 1, 1, 0, 0].to_vec());
         let ix = ComputeBudgetInstruction::set_compute_unit_price(u64::MAX);
-        assert_eq!(ix.data, vec![3, 255, 255, 255, 255, 255, 255, 255, 255]);
+        assert_eq!(ix.data, [3, 255, 255, 255, 255, 255, 255, 255, 255].to_vec());
     }
 }

--- a/compute-budget-interface/src/lib.rs
+++ b/compute-budget-interface/src/lib.rs
@@ -1,11 +1,13 @@
 //! Instructions for the compute budget native program.
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
-
+#![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
 #[cfg(feature = "borsh")]
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_instruction::Instruction;
 pub use solana_sdk_ids::compute_budget::{check_id, id, ID};
+use alloc::vec;
 
 /// Compute Budget Instructions
 #[cfg_attr(

--- a/scripts/check-no-std.sh
+++ b/scripts/check-no-std.sh
@@ -11,6 +11,7 @@ no_std_crates=(
   -p solana-address
   -p solana-clock
   -p solana-commitment-config
+  -p solana-compute-budget-interface
   -p solana-define-syscall
   -p solana-epoch-info
   -p solana-fee-calculator


### PR DESCRIPTION
### Problem

`solana-compute-budget-interface` crate has no `no_std` support

### Summary of Changes
- add `std` feature and make it enabled by default
- use optional `serde` and its std feature in std mode of the `solana-compute-budget-interface` crate
- add `std` sub-feature in the `dev-context-only-utils` feature