### PR TITLE
[sdk-wasm-js] Add length check on type conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3713,6 +3713,7 @@ dependencies = [
  "solana-instruction",
  "solana-keypair",
  "solana-message",
+ "solana-packet",
  "solana-signature",
  "solana-signer",
  "solana-transaction",

--- a/sdk-wasm-js/Cargo.toml
+++ b/sdk-wasm-js/Cargo.toml
@@ -24,6 +24,7 @@ solana-hash = { workspace = true }
 solana-instruction = { workspace = true, features = ["std"] }
 solana-keypair = { workspace = true }
 solana-message = { workspace = true }
+solana-packet = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 solana-transaction = { workspace = true, features = ["bincode", "verify"] }

--- a/sdk-wasm-js/src/instruction.rs
+++ b/sdk-wasm-js/src/instruction.rs
@@ -3,9 +3,12 @@
 //! (ref: https://github.com/rustwasm/wasm-bindgen/issues/111)
 #![allow(non_snake_case)]
 
-use {crate::address::Address, js_sys::Uint8Array, wasm_bindgen::prelude::*};
+use {
+    crate::address::Address, js_sys::Uint8Array, solana_packet::PACKET_DATA_SIZE,
+    wasm_bindgen::prelude::*,
+};
 
-const MAX_INSTRUCTION_DATA_LEN: usize = 1232;
+const MAX_INSTRUCTION_DATA_LEN: usize = PACKET_DATA_SIZE;
 
 /// wasm-bindgen version of the Instruction struct.
 /// This duplication is required until https://github.com/rustwasm/wasm-bindgen/issues/3671

--- a/sdk-wasm-js/src/instruction.rs
+++ b/sdk-wasm-js/src/instruction.rs
@@ -3,7 +3,9 @@
 //! (ref: https://github.com/rustwasm/wasm-bindgen/issues/111)
 #![allow(non_snake_case)]
 
-use {crate::address::Address, wasm_bindgen::prelude::*};
+use {crate::address::Address, js_sys::Uint8Array, wasm_bindgen::prelude::*};
+
+const MAX_INSTRUCTION_DATA_LEN: usize = 1232;
 
 /// wasm-bindgen version of the Instruction struct.
 /// This duplication is required until https://github.com/rustwasm/wasm-bindgen/issues/3671
@@ -25,8 +27,18 @@ impl Instruction {
             .into()
     }
 
-    pub fn setData(&mut self, data: &[u8]) {
+    pub fn setData(&mut self, data: Uint8Array) -> Result<(), JsValue> {
+        if data.length() as usize > MAX_INSTRUCTION_DATA_LEN {
+            return Err(std::format!(
+                "Instruction data too large: {} > {}",
+                data.length(),
+                MAX_INSTRUCTION_DATA_LEN
+            )
+            .into());
+        }
+
         self.inner.data = data.to_vec();
+        Ok(())
     }
 
     pub fn addAccount(&mut self, account_meta: AccountMeta) {

--- a/sdk-wasm-js/src/keypair.rs
+++ b/sdk-wasm-js/src/keypair.rs
@@ -1,4 +1,6 @@
-use {crate::address::Address, solana_signer::Signer, wasm_bindgen::prelude::*};
+use {crate::address::Address, js_sys::Uint8Array, solana_signer::Signer, wasm_bindgen::prelude::*};
+
+const KEYPAIR_LEN: usize = 64;
 
 #[wasm_bindgen]
 #[derive(Debug)]
@@ -23,8 +25,19 @@ impl Keypair {
     }
 
     /// Recover a `Keypair` from a `Uint8Array`
-    pub fn fromBytes(bytes: &[u8]) -> Result<Self, JsValue> {
-        solana_keypair::Keypair::try_from(bytes)
+    pub fn fromBytes(uint8_array: Uint8Array) -> Result<Self, JsValue> {
+        if uint8_array.length() as usize != KEYPAIR_LEN {
+            return Err(std::format!(
+                "Invalid length for Keypair bytes: expected {}, got {}",
+                KEYPAIR_LEN,
+                uint8_array.length()
+            )
+            .into());
+        }
+        let mut buf = [0u8; KEYPAIR_LEN];
+        uint8_array.copy_to(&mut buf);
+
+        solana_keypair::Keypair::try_from(buf.as_ref())
             .map(Into::into)
             .map_err(|e| e.to_string().into())
     }

--- a/sdk-wasm-js/src/keypair.rs
+++ b/sdk-wasm-js/src/keypair.rs
@@ -1,6 +1,7 @@
-use {crate::address::Address, js_sys::Uint8Array, solana_signer::Signer, wasm_bindgen::prelude::*};
-
-const KEYPAIR_LEN: usize = 64;
+use {
+    crate::address::Address, js_sys::Uint8Array, solana_keypair::KEYPAIR_LENGTH,
+    solana_signer::Signer, wasm_bindgen::prelude::*,
+};
 
 #[wasm_bindgen]
 #[derive(Debug)]
@@ -26,15 +27,15 @@ impl Keypair {
 
     /// Recover a `Keypair` from a `Uint8Array`
     pub fn fromBytes(uint8_array: Uint8Array) -> Result<Self, JsValue> {
-        if uint8_array.length() as usize != KEYPAIR_LEN {
+        if uint8_array.length() as usize != KEYPAIR_LENGTH {
             return Err(std::format!(
                 "Invalid length for Keypair bytes: expected {}, got {}",
-                KEYPAIR_LEN,
+                KEYPAIR_LENGTH,
                 uint8_array.length()
             )
             .into());
         }
-        let mut buf = [0u8; KEYPAIR_LEN];
+        let mut buf = [0u8; KEYPAIR_LENGTH];
         uint8_array.copy_to(&mut buf);
 
         solana_keypair::Keypair::try_from(buf.as_ref())

--- a/sdk-wasm-js/src/transaction.rs
+++ b/sdk-wasm-js/src/transaction.rs
@@ -5,10 +5,11 @@ use {
         address::Address, hash::Hash, instruction::Instruction, keypair::Keypair, message::Message,
     },
     js_sys::Uint8Array,
+    solana_packet::PACKET_DATA_SIZE,
     wasm_bindgen::prelude::{wasm_bindgen, JsValue},
 };
 
-const MAX_TRANSACTION_SIZE: usize = 1232;
+const MAX_TRANSACTION_SIZE: usize = PACKET_DATA_SIZE;
 
 /// wasm-bindgen version of the Transaction struct.
 /// This duplication is required until https://github.com/rustwasm/wasm-bindgen/issues/3671

--- a/sdk-wasm-js/src/transaction.rs
+++ b/sdk-wasm-js/src/transaction.rs
@@ -4,8 +4,11 @@ use {
     crate::{
         address::Address, hash::Hash, instruction::Instruction, keypair::Keypair, message::Message,
     },
+    js_sys::Uint8Array,
     wasm_bindgen::prelude::{wasm_bindgen, JsValue},
 };
+
+const MAX_TRANSACTION_SIZE: usize = 1232;
 
 /// wasm-bindgen version of the Transaction struct.
 /// This duplication is required until https://github.com/rustwasm/wasm-bindgen/issues/3671
@@ -66,8 +69,19 @@ impl Transaction {
         bincode::serialize(&self.inner).unwrap().into()
     }
 
-    pub fn fromBytes(bytes: &[u8]) -> Result<Self, JsValue> {
-        bincode::deserialize::<solana_transaction::Transaction>(bytes)
+    pub fn fromBytes(uint8_array: Uint8Array) -> Result<Self, JsValue> {
+        if uint8_array.length() as usize > MAX_TRANSACTION_SIZE {
+            return Err(std::format!(
+                "Transaction size too large: {} > {}",
+                uint8_array.length(),
+                MAX_TRANSACTION_SIZE
+            )
+            .into());
+        }
+
+        let bytes_vec = uint8_array.to_vec();
+
+        bincode::deserialize::<solana_transaction::Transaction>(&bytes_vec)
             .map(Into::into)
             .map_err(|x| std::string::ToString::to_string(&x).into())
     }

--- a/sdk-wasm-js/tests/address.mjs
+++ b/sdk-wasm-js/tests/address.mjs
@@ -4,6 +4,8 @@ solana_program_init();
 
 // TODO: wasm_bindgen doesn't currently support exporting constants
 const MAX_SEED_LEN = 32;
+const ADDRESS_BYTES = 32;
+const MAX_SEEDS = 16;
 
 describe("Address", function () {
   it("invalid", () => {
@@ -181,5 +183,42 @@ describe("Address", function () {
         )
       )
     ).to.be.true;
+  });
+
+    it("input length validation", () => {
+    expect(() => {
+      new Address(new Uint8Array(ADDRESS_BYTES + 1));
+    }).to.throw(/Invalid Uint8Array length/);
+
+    expect(() => {
+        new Address(new Uint8Array(ADDRESS_BYTES - 1));
+    }).to.throw(/Invalid Uint8Array length/);
+
+    expect(() => {
+      new Address(new Array(ADDRESS_BYTES + 1).fill(0));
+    }).to.throw(/Invalid Array length/);
+
+    expect(() => {
+        new Address(new Array(ADDRESS_BYTES - 1).fill(0));
+    }).to.throw(/Invalid Array length/);
+
+    const programId = new Address("11111111111111111111111111111111");
+
+    const tooManySeeds = new Array(MAX_SEEDS + 1).fill(new Uint8Array(1));
+    expect(() => {
+      Address.createProgramAddress(tooManySeeds, programId);
+    }).to.throw(/Too many seeds/);
+
+    expect(() => {
+      Address.findProgramAddress(tooManySeeds, programId);
+    }).to.throw(/Too many seeds/);
+
+    expect(() => {
+      Address.createProgramAddress([Buffer.alloc(MAX_SEED_LEN + 1)], programId);
+    }).to.throw(/Seed 0 too long/);
+
+    expect(() => {
+      Address.findProgramAddress([Buffer.alloc(MAX_SEED_LEN + 1)], programId);
+    }).to.throw(/Seed 0 too long/);
   });
 });

--- a/sdk-wasm-js/tests/hash.mjs
+++ b/sdk-wasm-js/tests/hash.mjs
@@ -78,4 +78,22 @@ describe("Hash", function () {
       ])
     );
   });
+
+  it("input length validation", () => {
+    expect(() => {
+      new Hash(new Uint8Array(HASH_BYTES + 1));
+    }).to.throw(/Invalid Uint8Array length/);
+
+    expect(() => {
+      new Hash(new Uint8Array(HASH_BYTES - 1));
+    }).to.throw(/Invalid Uint8Array length/);
+
+    expect(() => {
+      new Hash(new Array(HASH_BYTES + 1).fill(0));
+    }).to.throw(/Invalid Array length/);
+
+    expect(() => {
+      new Hash(new Array(HASH_BYTES - 1).fill(0));
+    }).to.throw(/Invalid Array length/);
+  });
 });

--- a/sdk-wasm-js/tests/keypair.mjs
+++ b/sdk-wasm-js/tests/keypair.mjs
@@ -2,6 +2,8 @@ import { expect } from "chai";
 import { solana_program_init, Keypair } from "crate";
 solana_program_init();
 
+const KEYPAIR_LEN = 64;
+
 describe("Keypair", function () {
   it("works", () => {
     const keypair = new Keypair();
@@ -11,4 +13,14 @@ describe("Keypair", function () {
     const recoveredKeypair = Keypair.fromBytes(bytes);
     expect(keypair.pubkey().equals(recoveredKeypair.pubkey()));
   });
+
+  it("input length validation", () => {
+    expect(() => {
+      Keypair.fromBytes(new Uint8Array(KEYPAIR_LEN + 1));
+    }).to.throw(/Invalid length for Keypair bytes/);
+
+    expect(() => {
+        Keypair.fromBytes(new Uint8Array(KEYPAIR_LEN - 1));
+      }).to.throw(/Invalid length for Keypair bytes/);
+  })
 });

--- a/sdk-wasm-js/tests/transaction.mjs
+++ b/sdk-wasm-js/tests/transaction.mjs
@@ -10,6 +10,8 @@ import {
 } from "crate";
 solana_program_init();
 
+const MAX_TRANSACTION_SIZE = 1232;
+
 describe("Transaction", function () {
   it("Instruction", () => {
     const payer = Keypair.fromBytes(
@@ -56,5 +58,12 @@ describe("Transaction", function () {
     expect(Buffer.from(transaction.toBytes()).toString("base64")).to.equal(
       "AoZrVzP93eyp3vbl6CU9XQjQfm4Xp/7nSiBlsX/kJmfTQZsGTOrFnt6EUqHVte97fGZ71UAXDfLbR5B31OtRdgdab57BOU8mq0ztMutZAVBPtGJHVly8RPz4TYa+OFU7EIk3Wrv4WUMCb/NR+LxELLH+tQt5SrkvB7rCE2DniM8JAgABBPwcAnjq1ItvYAiozCJIx811pVIzIF3TJO/1i9pj08+xwUDHXd5TrOB0zTYmv7KVR0GELkd+UT/+FWVaNEPMgMcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxJrndgN4IFTxep3s6kO0ROug7bEsbx0xxuDkqEvwUusBAwIBAgwCAAAAewAAAAAAAAA="
     );
+  });
+
+  it("input length validation", () => {
+    const oversizedTxBytes = new Uint8Array(MAX_TRANSACTION_SIZE + 1);
+    expect(() => {
+      Transaction.fromBytes(oversizedTxBytes);
+    }).to.throw(/Transaction size too large/);
   });
 });


### PR DESCRIPTION
#### Problem

The `solana-sdk-wasm-js` crate contain several functions that copy an outside-controlled JS data into WebAssembly memory before validating the input's size. This "copy-before-validate" can lead to excessive memory growth when oversized data are provided as input.

#### Summary of Changes

I went through the crate to added length checks for all the functions that "copy-before-validate".
- `hash.rs`: This was pretty straightforward. I just added length check if the value that is provided to the constructor does not match the expected hash bytes (32 bytes).

- `keypair.rs`: I updated the API of `fromBytes` function to directly take in a `Uint8Array` instead of a bytes slice. 

  When a function exported via #[wasm_bindgen] accepts a byte slice (&[u8]) argument, wasm-bindgen generates JavaScript glue code. This glue code automatically allocates space in Wasm linear memory and copies the entire input Uint8Array before the Rust function body executes. This prevents the Rust code from validating the size before the allocation occurs. 

  Other parts should be straightforward.

- `transaction.rs`: This was straightforward as well. The only nontrvial part is bounding the maximum transaction size length. I set this constant to be the maximum packet size from the `solana-packet` crate.

- `instruction.rs`: I changed the `setData` function to take in a `Uint8Array` instead of a byte slice.

- `address.rs`: This file required the most changes in terms of code lines, but should be straightforward I think.