### PR TITLE
Allow the creation of `AccountSharedData` with an existing `Arc<Vec<u8>>`

### DIFF
--- a/account/src/lib.rs
+++ b/account/src/lib.rs
@@ -712,6 +712,22 @@ impl AccountSharedData {
     pub fn serialize_data<T: serde::Serialize>(&mut self, state: &T) -> Result<(), bincode::Error> {
         shared_serialize_data(self, state)
     }
+
+    pub fn create_from_existing_shared_data(
+        lamports: u64,
+        data: Arc<Vec<u8>>,
+        owner: Pubkey,
+        executable: bool,
+        rent_epoch: Epoch,
+    ) -> AccountSharedData {
+        AccountSharedData {
+            lamports,
+            data,
+            owner,
+            executable,
+            rent_epoch,
+        }
+    }
 }
 
 pub type InheritableAccountFields = (u64, Epoch);


### PR DESCRIPTION
**Problem**

For [SIMD-0177](https://github.com/solana-foundation/solana-improvement-documents/pull/177), we are going to introduce a new account layout for program-runtime, which will hold ownership of the `Arc<Vec<u8>>`.

After the transaction finishes, we want to reconstruct the `AccountSharedData` to be used again in the rest of the validators, while maintaining the same Arc reference.

**Solution**

Implement a function to allow the creation of `AccountSharedData` with an existing instance of the Arc.