### PR TITLE
msg: Use dependency without default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -254,7 +254,7 @@ solana-loader-v3-interface = { path = "loader-v3-interface", version = "6.0.0" }
 solana-loader-v4-interface = { path = "loader-v4-interface", version = "3.0.0" }
 solana-logger = { path = "logger", version = "3.0.0" }
 solana-message = { path = "message", version = "3.0.0" }
-solana-msg = { path = "msg", version = "3.0.0" }
+solana-msg = { path = "msg", version = "3.0.0", default-features = false }
 solana-native-token = { path = "native-token", version = "3.0.0" }
 solana-nonce = { path = "nonce", version = "3.0.0" }
 solana-nonce-account = { path = "nonce-account", version = "3.0.0" }

--- a/program-entrypoint/Cargo.toml
+++ b/program-entrypoint/Cargo.toml
@@ -17,6 +17,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 solana-account-info = { workspace = true }
 solana-define-syscall = { workspace = true }
-solana-msg = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true, default-features = false }
+
+[dev-dependencies]
+solana-msg = { workspace = true, features = ["std"] }

--- a/program-entrypoint/src/lib.rs
+++ b/program-entrypoint/src/lib.rs
@@ -12,14 +12,12 @@ use {
         slice::{from_raw_parts, from_raw_parts_mut},
     },
 };
-// need to re-export msg for custom_heap_default macro, `AccountInfo` and `Pubkey` for
-// entrypoint_no_alloc macro
+// need to re-export `AccountInfo` and `Pubkey` for entrypoint_no_alloc macro
 pub use {
     solana_account_info::AccountInfo as __AccountInfo,
     solana_account_info::MAX_PERMITTED_DATA_INCREASE,
     // Re-exporting for custom_panic
     solana_define_syscall::definitions::{sol_log_ as __log, sol_panic_ as __panic},
-    solana_msg::msg as __msg,
     solana_program_error::ProgramResult,
     solana_pubkey::Pubkey as __Pubkey,
 };

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -77,7 +77,7 @@ solana-instruction-error = { workspace = true, features = ["num-traits"] }
 solana-instructions-sysvar = { workspace = true }
 solana-keccak-hasher = { workspace = true, features = ["sha3"] }
 solana-last-restart-slot = { workspace = true, features = ["serde", "sysvar"] }
-solana-msg = { workspace = true }
+solana-msg = { workspace = true, features = ["std"] }
 solana-native-token = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true, features = ["serde"] }

--- a/secp256k1-program/Cargo.toml
+++ b/secp256k1-program/Cargo.toml
@@ -44,6 +44,6 @@ solana-example-mocks = { path = "../example-mocks" }
 solana-instruction = { workspace = true }
 solana-instructions-sysvar = { workspace = true }
 solana-keccak-hasher = { workspace = true, features = ["sha3"] }
-solana-msg = { workspace = true }
+solana-msg = { workspace = true, features = ["std"] }
 solana-program-error = { workspace = true }
 solana-secp256k1-program = { path = ".", features = ["bincode"] }

--- a/sysvar/Cargo.toml
+++ b/sysvar/Cargo.toml
@@ -70,7 +70,7 @@ solana-define-syscall = { workspace = true }
 anyhow = { workspace = true }
 serial_test = { workspace = true }
 solana-example-mocks = { path = "../example-mocks" }
-solana-msg = { workspace = true }
+solana-msg = { workspace = true, features = ["std"] }
 solana-sha256-hasher = { workspace = true }
 solana-sysvar = { path = ".", features = ["dev-context-only-utils"] }
 test-case = { workspace = true }


### PR DESCRIPTION
#### Problem

The solana-msg crate is brought in with default features, which makes it impossible to make downstream users of the crate no-std.

#### Summary of changes

Add `default-features = false` for solana-msg at the workspace-level, and add the std feature to solana-program, which is the only place that requires it.

As part of this, I noticed that solana-program-entrypoint re-exports msg, but the re-export is never used, so I removed it.