### PR TITLE
feat: add `no_std` support for epoch-info crate

### DIFF
--- a/epoch-info/src/lib.rs
+++ b/epoch-info/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 //! Information about the current epoch.
 //!
 //! As returned by the [`getEpochInfo`] RPC method.

--- a/scripts/check-no-std.sh
+++ b/scripts/check-no-std.sh
@@ -12,6 +12,7 @@ no_std_crates=(
   -p solana-clock
   -p solana-commitment-config
   -p solana-define-syscall
+  -p solana-epoch-info
   -p solana-fee-calculator
   -p solana-program-error
   -p solana-program-memory


### PR DESCRIPTION
### Problem

`solana-epoch-info` has no no_std support

### Summary of Changes

- add `no_std` crate level attribute to `solana-epoch-info` crate
- add this crate to the `check-no-std.sh` script