### PR TITLE
docs: Add [package.metadata.docs.rs] and doc_auto_cfg

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Run ShellCheck
         run: ./scripts/check-shell.sh
 
+      - name: Check doc features
+        run: ./scripts/check-doc-features.sh
+
   check-crates:
     name: Check crate ownership
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,11 @@ check-cfg = [
     'cfg(feature, values("frozen-abi", "no-entrypoint"))',
 ]
 
+[workspace.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
 [workspace.metadata.release]
 pre-release-commit-message = "Publish {{crate_name}} v{{version}}"
 tag-message = "Publish {{crate_name}} v{{version}}"

--- a/address/Cargo.toml
+++ b/address/Cargo.toml
@@ -10,6 +10,11 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
 [features]
 atomic = ["dep:solana-atomic-u64"]
 borsh = ["dep:borsh", "std"]

--- a/atomic-u64/src/lib.rs
+++ b/atomic-u64/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 pub use implementation::AtomicU64;
 
 #[cfg(target_pointer_width = "64")]

--- a/big-mod-exp/src/lib.rs
+++ b/big-mod-exp/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #[repr(C)]
 pub struct BigModExpParams {
     pub base: *const u8,

--- a/bincode/src/lib.rs
+++ b/bincode/src/lib.rs
@@ -1,6 +1,7 @@
 //! Contains a single utility function for deserializing from [bincode].
 //!
 //! [bincode]: https://docs.rs/bincode
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use {bincode::config::Options, solana_instruction_error::InstructionError};
 

--- a/bls-signatures/Cargo.toml
+++ b/bls-signatures/Cargo.toml
@@ -10,6 +10,11 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
 [lib]
 crate-type = ["rlib"]
 

--- a/bls-signatures/src/lib.rs
+++ b/bls-signatures/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 
 extern crate alloc;

--- a/bn254/Cargo.toml
+++ b/bn254/Cargo.toml
@@ -10,6 +10,11 @@ license = { workspace = true }
 edition = { workspace = true }
 include = ["src/**/*"]
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
 [dependencies]
 bytemuck = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }

--- a/bn254/src/lib.rs
+++ b/bn254/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 pub(crate) mod addition;
 pub mod compression;
 pub(crate) mod multiplication;

--- a/borsh/src/lib.rs
+++ b/borsh/src/lib.rs
@@ -1,2 +1,3 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 pub mod macros;
 pub mod v1;

--- a/client-traits/src/lib.rs
+++ b/client-traits/src/lib.rs
@@ -6,6 +6,7 @@
 //!
 //! Asynchronous implementations are expected to create transactions, sign them, and send
 //! them but without waiting to see if the server accepted it.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use {
     solana_account::Account,

--- a/commitment-config/src/lib.rs
+++ b/commitment-config/src/lib.rs
@@ -1,5 +1,6 @@
 //! Definitions of commitment levels.
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 use core::{fmt, str::FromStr};
 
 #[cfg_attr(

--- a/cpi/src/lib.rs
+++ b/cpi/src/lib.rs
@@ -12,6 +12,7 @@
 //! [`invoke_signed`]: invoke_signed
 //! [cpi]: https://solana.com/docs/core/cpi
 //! [`solana_program::program`]: https://docs.rs/solana-program/latest/solana_program/program/
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use {
     solana_account_info::AccountInfo, solana_instruction::Instruction,

--- a/define-syscall/src/lib.rs
+++ b/define-syscall/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub mod definitions;
 

--- a/derivation-path/src/lib.rs
+++ b/derivation-path/src/lib.rs
@@ -8,6 +8,7 @@
 //! > `m/44'/501'`
 //!
 //! with 501 being the Solana coin type.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use {
     core::{iter::IntoIterator, slice::Iter},

--- a/ed25519-program/src/lib.rs
+++ b/ed25519-program/src/lib.rs
@@ -1,6 +1,7 @@
 //! Instructions for the [ed25519 native program][np].
 //!
 //! [np]: https://docs.solanalabs.com/runtime/programs#ed25519-program
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use {
     bytemuck::bytes_of,

--- a/epoch-info/src/lib.rs
+++ b/epoch-info/src/lib.rs
@@ -3,6 +3,7 @@
 //! As returned by the [`getEpochInfo`] RPC method.
 //!
 //! [`getEpochInfo`]: https://solana.com/docs/rpc/http/getepochinfo
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg_attr(
     feature = "serde",

--- a/epoch-rewards-hasher/src/lib.rs
+++ b/epoch-rewards-hasher/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 use {siphasher::sip::SipHasher13, solana_hash::Hash, solana_pubkey::Pubkey, std::hash::Hasher};
 
 #[derive(Debug, Clone)]

--- a/epoch-schedule/src/lib.rs
+++ b/epoch-schedule/src/lib.rs
@@ -13,6 +13,7 @@
 //!
 //! [`DEFAULT_SLOTS_PER_EPOCH`]: https://docs.rs/solana-clock/latest/solana_clock/constant.DEFAULT_SLOTS_PER_EPOCH.html
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![no_std]
 #[cfg(feature = "frozen-abi")]
 extern crate std;

--- a/epoch-stake/src/lib.rs
+++ b/epoch-stake/src/lib.rs
@@ -3,6 +3,7 @@
 //! On-chain programs can use this API to retrieve the total stake for the
 //! current epoch or the stake for a specific vote account using the
 //! `sol_get_epoch_stake` syscall.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use solana_pubkey::Pubkey;
 

--- a/feature-gate-interface/src/lib.rs
+++ b/feature-gate-interface/src/lib.rs
@@ -10,6 +10,7 @@
 //!    `Feature::default()`
 //! 2. When the next epoch is entered the runtime will check for new activation requests and
 //!    active them.  When this occurs, the activation slot is recorded in the feature account
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub mod error;
 pub mod instruction;

--- a/file-download/src/lib.rs
+++ b/file-download/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::arithmetic_side_effects)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 use {
     console::Emoji,
     indicatif::{ProgressBar, ProgressStyle},

--- a/frozen-abi-macro/Cargo.toml
+++ b/frozen-abi-macro/Cargo.toml
@@ -9,6 +9,11 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
 [lib]
 proc-macro = true
 

--- a/frozen-abi-macro/src/lib.rs
+++ b/frozen-abi-macro/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 extern crate proc_macro;
 
 use proc_macro::TokenStream;

--- a/frozen-abi/Cargo.toml
+++ b/frozen-abi/Cargo.toml
@@ -9,6 +9,11 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
 [features]
 default = []
 # activate the frozen-abi feature when we actually want to do frozen-abi testing,

--- a/frozen-abi/src/lib.rs
+++ b/frozen-abi/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(incomplete_features)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(specialization))]
 
 // Allows macro expansion of `use ::solana_frozen_abi::*` to work within this crate

--- a/hard-forks/src/lib.rs
+++ b/hard-forks/src/lib.rs
@@ -1,6 +1,7 @@
 //! The list of slot boundaries at which a hard fork should
 //! occur.
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]

--- a/inflation/src/lib.rs
+++ b/inflation/src/lib.rs
@@ -1,4 +1,5 @@
 //! configuration for network inflation
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};

--- a/instruction-error/src/lib.rs
+++ b/instruction-error/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #[cfg(feature = "num-traits")]
 use num_traits::ToPrimitive;

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -1,4 +1,5 @@
 //! The `logger` module configures `env_logger`
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use {
     lazy_static::lazy_static,

--- a/msg/src/lib.rs
+++ b/msg/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #[cfg(feature = "std")]
 extern crate std;
 /// Print a message to the log.

--- a/native-token/src/lib.rs
+++ b/native-token/src/lib.rs
@@ -1,5 +1,6 @@
 //! Definitions for the native SOL token and its fractional lamports.
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![allow(clippy::arithmetic_side_effects)]
 
 /// There are 10^9 lamports in one SOL

--- a/nonce-account/src/lib.rs
+++ b/nonce-account/src/lib.rs
@@ -1,4 +1,5 @@
 //! Functions related to nonce accounts.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use {
     solana_account::{state_traits::StateMut, AccountSharedData, ReadableAccount},

--- a/package-metadata-macro/src/lib.rs
+++ b/package-metadata-macro/src/lib.rs
@@ -1,4 +1,5 @@
 //! Macro to access data from the `package.metadata` section of Cargo.toml
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 extern crate proc_macro;
 

--- a/package-metadata/src/lib.rs
+++ b/package-metadata/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 /// Macro for accessing data from the `package.metadata` section of the Cargo manifest
 ///
 /// # Arguments

--- a/precompile-error/src/lib.rs
+++ b/precompile-error/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 /// Precompile errors
 use core::fmt;
 

--- a/presigner/src/lib.rs
+++ b/presigner/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 pub use solana_signer::PresignerError;
 use {
     solana_pubkey::Pubkey,

--- a/program-entrypoint/src/lib.rs
+++ b/program-entrypoint/src/lib.rs
@@ -1,4 +1,5 @@
 //! The Rust-based BPF program entrypoint supported by the latest BPF loader.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 extern crate alloc;
 use {

--- a/program-memory/src/lib.rs
+++ b/program-memory/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 //! Basic low-level memory operations.
 //!

--- a/program-option/src/lib.rs
+++ b/program-option/src/lib.rs
@@ -3,6 +3,7 @@
 //!
 //! This implementation mostly matches `std::option` except iterators since the iteration
 //! trait requires returning `std::option::Option`
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use std::{
     convert, mem,

--- a/program-pack/src/lib.rs
+++ b/program-pack/src/lib.rs
@@ -5,6 +5,7 @@
 //! serialization format.
 //!
 //! [spl]: https://github.com/solana-labs/solana-program-library
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use solana_program_error::ProgramError;
 

--- a/quic-definitions/src/lib.rs
+++ b/quic-definitions/src/lib.rs
@@ -1,4 +1,5 @@
 //! Definitions related to Solana over QUIC.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 use {solana_keypair::Keypair, std::time::Duration};
 
 pub const QUIC_PORT_OFFSET: u16 = 6;

--- a/rent/src/lib.rs
+++ b/rent/src/lib.rs
@@ -4,6 +4,7 @@
 
 #![allow(clippy::arithmetic_side_effects)]
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #[cfg(feature = "frozen-abi")]
 extern crate std;

--- a/reward-info/src/lib.rs
+++ b/reward-info/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "frozen-abi")]

--- a/sanitize/src/lib.rs
+++ b/sanitize/src/lib.rs
@@ -1,6 +1,7 @@
 //! A trait for sanitizing values and members of over the wire messages.
 
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use core::{error::Error, fmt};
 

--- a/scripts/check-doc-features.sh
+++ b/scripts/check-doc-features.sh
@@ -7,7 +7,7 @@ cd "${src_root}"
 
 err=0
 # Get all Cargo.toml files that don't have [package.metadata.docs.rs] specified
-files=$(comm -23 <(git ls-files -- '**/Cargo.toml' | sort) <(git grep -l "\[package.metadata.docs.rs\]" | sort))
+files=$(comm -23 <(git ls-files -- '**/Cargo.toml' | sort) <(git grep -l "^\[package.metadata.docs.rs\]" | sort))
 if [[ -n $files ]]; then
   echo "Files found without [package.metadata.docs.rs]:"
   echo "$files"
@@ -15,7 +15,7 @@ if [[ -n $files ]]; then
 fi
 
 # Get all lib.rs files that don't have #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-files=$(comm -23 <(git ls-files -- '**/lib.rs' | sort) <(git grep -lE '#!\[cfg_attr\(docsrs, feature\(doc_auto_cfg\)\)\]' | sort))
+files=$(comm -23 <(git ls-files -- '**/lib.rs' | sort) <(git grep -lE '^#!\[cfg_attr\(docsrs, feature\(doc_auto_cfg\)\)\]' | sort))
 if [[ -n $files ]]; then
   echo "Files found without #![cfg_attr(docsrs, feature(doc_auto_cfg))]"
   echo "$files"

--- a/scripts/check-doc-features.sh
+++ b/scripts/check-doc-features.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+here="$(dirname "$0")"
+src_root="$(readlink -f "${here}/..")"
+cd "${src_root}"
+
+err=0
+# Get all Cargo.toml files that don't have [package.metadata.docs.rs] specified
+files=$(comm -23 <(git ls-files -- '**/Cargo.toml' | sort) <(git grep -l "\[package.metadata.docs.rs\]" | sort))
+if [[ -n $files ]]; then
+  echo "Files found without [package.metadata.docs.rs]:"
+  echo $files
+  err=1
+fi
+
+# Get all lib.rs files that don't have #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+files=$(comm -23 <(git ls-files -- '**/lib.rs' | sort) <(git grep -lE '#!\[cfg_attr\(docsrs, feature\(doc_auto_cfg\)\)\]' | sort))
+if [[ -n $files ]]; then
+  echo "Files found without #![cfg_attr(docsrs, feature(doc_auto_cfg))]"
+  echo $files
+  err=1
+fi
+exit $err

--- a/scripts/check-doc-features.sh
+++ b/scripts/check-doc-features.sh
@@ -10,7 +10,7 @@ err=0
 files=$(comm -23 <(git ls-files -- '**/Cargo.toml' | sort) <(git grep -l "\[package.metadata.docs.rs\]" | sort))
 if [[ -n $files ]]; then
   echo "Files found without [package.metadata.docs.rs]:"
-  echo $files
+  echo "$files"
   err=1
 fi
 
@@ -18,7 +18,7 @@ fi
 files=$(comm -23 <(git ls-files -- '**/lib.rs' | sort) <(git grep -lE '#!\[cfg_attr\(docsrs, feature\(doc_auto_cfg\)\)\]' | sort))
 if [[ -n $files ]]; then
   echo "Files found without #![cfg_attr(docsrs, feature(doc_auto_cfg))]"
-  echo $files
+  echo "$files"
   err=1
 fi
 exit $err

--- a/sdk-ids/src/lib.rs
+++ b/sdk-ids/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub mod address_lookup_table {
     solana_pubkey::declare_id!("AddressLookupTab1e1111111111111111111111111");

--- a/sdk-macro/src/lib.rs
+++ b/sdk-macro/src/lib.rs
@@ -1,6 +1,7 @@
 //! Convenience macro to declare a static public key and functions to interact with it
 //!
 //! Input: a single literal base58 string representation of a program's id
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 extern crate proc_macro;
 

--- a/sdk-wasm-js-tests/Cargo.toml
+++ b/sdk-wasm-js-tests/Cargo.toml
@@ -10,6 +10,11 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 

--- a/sdk-wasm-js-tests/src/lib.rs
+++ b/sdk-wasm-js-tests/src/lib.rs
@@ -1,4 +1,5 @@
 //! `SystemInstruction` Javascript interface
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg(target_arch = "wasm32")]
 #![allow(non_snake_case)]
 pub use solana_sdk_wasm_js::{

--- a/sdk-wasm-js/src/lib.rs
+++ b/sdk-wasm-js/src/lib.rs
@@ -1,4 +1,5 @@
 //! solana-program Javascript interface
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg(target_arch = "wasm32")]
 
 use {

--- a/secp256k1-recover/src/lib.rs
+++ b/secp256k1-recover/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 //! Public key recovery from [secp256k1] ECDSA signatures.
 //!
 //! [secp256k1]: https://en.bitcoin.it/wiki/Secp256k1

--- a/secp256r1-program/src/lib.rs
+++ b/secp256r1-program/src/lib.rs
@@ -9,6 +9,7 @@
 //! This property can be problematic for developers who assume each signature is unique. Without enforcing
 //! low-S values, the same message and key can produce two different valid signatures, potentially breaking
 //! replay protection schemes that rely on signature uniqueness.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 use bytemuck::{Pod, Zeroable};
 pub use solana_sdk_ids::secp256r1_program::{check_id, id, ID};
 

--- a/seed-derivable/src/lib.rs
+++ b/seed-derivable/src/lib.rs
@@ -1,4 +1,5 @@
 //! The interface by which keys are derived.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 use {solana_derivation_path::DerivationPath, std::error};
 
 /// The `SeedDerivable` trait defines the interface by which cryptographic keys/keypairs are

--- a/seed-phrase/src/lib.rs
+++ b/seed-phrase/src/lib.rs
@@ -1,4 +1,5 @@
 //! Functions for generating keypairs from seed phrases.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 use hmac::Hmac;
 
 pub fn generate_seed_from_seed_phrase_and_passphrase(

--- a/serde-varint/src/lib.rs
+++ b/serde-varint/src/lib.rs
@@ -1,5 +1,5 @@
 //! Integers that serialize to variable size.
-
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![allow(clippy::arithmetic_side_effects)]
 use {
     serde::{

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -1,4 +1,5 @@
 //! Serde helpers.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use serde::{Deserialize, Deserializer};
 

--- a/serialize-utils/src/lib.rs
+++ b/serialize-utils/src/lib.rs
@@ -1,5 +1,6 @@
 //! Helpers for reading and writing bytes.
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![allow(clippy::arithmetic_side_effects)]
 use {solana_pubkey::Pubkey, solana_sanitize::SanitizeError};
 

--- a/sha256-hasher/src/lib.rs
+++ b/sha256-hasher/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #[cfg(all(feature = "sha2", not(target_os = "solana")))]
 use sha2::{Digest, Sha256};
 use solana_hash::Hash;

--- a/short-vec/src/lib.rs
+++ b/short-vec/src/lib.rs
@@ -1,5 +1,6 @@
 //! Compact serde-encoding of vectors with small length.
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![allow(clippy::arithmetic_side_effects)]
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::AbiExample;

--- a/shred-version/src/lib.rs
+++ b/shred-version/src/lib.rs
@@ -1,6 +1,7 @@
 //! Calculation of [shred] versions.
 //!
 //! [shred]: https://solana.com/docs/terminology#shred
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use {solana_hard_forks::HardForks, solana_hash::Hash, solana_sha256_hasher::hashv};
 

--- a/signer-store/Cargo.toml
+++ b/signer-store/Cargo.toml
@@ -9,6 +9,11 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
 [dependencies]
 bitvec = { workspace = true }
 num-derive = { workspace = true }

--- a/signer-store/src/lib.rs
+++ b/signer-store/src/lib.rs
@@ -35,6 +35,7 @@
 //!     original number of bits (i.e., the length of the input vectors; not the
 //!     length of the final vector).
 //! 3.  **Data Payload**: A sequence of bytes containing the packed base-3 digits.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use {
     bitvec::prelude::*,

--- a/slot-hashes/src/lib.rs
+++ b/slot-hashes/src/lib.rs
@@ -5,6 +5,7 @@
 //! The sysvar ID is declared in [`solana_program::sysvar::slot_hashes`].
 //!
 //! [`solana_program::sysvar::slot_hashes`]: https://docs.rs/solana-program/latest/solana_program/sysvar/slot_hashes/index.html
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(feature = "sysvar")]
 pub mod sysvar;

--- a/stable-layout/Cargo.toml
+++ b/stable-layout/Cargo.toml
@@ -9,6 +9,11 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
 [dependencies]
 solana-instruction = { workspace = true, default-features = false, features = [
     "std",

--- a/stable-layout/src/lib.rs
+++ b/stable-layout/src/lib.rs
@@ -1,6 +1,7 @@
 //! Types with stable memory layouts
 //!
 //! Internal use only; here be dragons!
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub mod stable_instruction;
 pub mod stable_rc;

--- a/system-transaction/src/lib.rs
+++ b/system-transaction/src/lib.rs
@@ -1,4 +1,5 @@
 //! The `system_transaction` module provides functionality for creating system transactions.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use {
     solana_hash::Hash, solana_keypair::Keypair, solana_message::Message, solana_pubkey::Pubkey,

--- a/system-wasm-js/src/lib.rs
+++ b/system-wasm-js/src/lib.rs
@@ -1,5 +1,6 @@
 //! `SystemInstruction` Javascript interface
 #![cfg(target_arch = "wasm32")]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![allow(non_snake_case)]
 use {
     solana_sdk_wasm_js::{address::Address, instruction::Instruction},

--- a/sysvar-id/src/lib.rs
+++ b/sysvar-id/src/lib.rs
@@ -17,6 +17,7 @@
 //! For more details see the Solana [documentation on sysvars][sysvardoc].
 //!
 //! [sysvardoc]: https://docs.solanalabs.com/runtime/sysvars
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 /// Re-export types required for macros
 pub use {

--- a/time-utils/src/lib.rs
+++ b/time-utils/src/lib.rs
@@ -1,4 +1,5 @@
 //! `std::time` utility functions.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 use std::{
     sync::atomic::{AtomicU64, Ordering},
     time::{Duration, SystemTime, UNIX_EPOCH},

--- a/validator-exit/src/lib.rs
+++ b/validator-exit/src/lib.rs
@@ -1,4 +1,5 @@
 //! Used by validators to run events on exit.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use std::fmt;
 


### PR DESCRIPTION
#### Problem

A few packages aren't configured properly for the docs.rs build to handle features.

#### Summary of changes

Add `[package.metadata.docs.rs]` to Cargo.toml files that don't have it, and `#![cfg_attr(docsrs, feature(doc_auto_cfg))]` to lib.rs files that don't have it either.

Also, add a CI step to make sure that all Cargo.toml and lib.rs files have the proper annotations.