### PR TITLE
vote-interface: add read api

### DIFF
--- a/vote-interface/src/state/mod.rs
+++ b/vote-interface/src/state/mod.rs
@@ -21,6 +21,8 @@ pub mod vote_state_1_14_11;
 pub use vote_state_1_14_11::*;
 pub mod vote_state_versions;
 pub use vote_state_versions::*;
+pub mod vote_state_read;
+pub use vote_state_read::VoteStateRead;
 pub mod vote_state_v3;
 pub use vote_state_v3::VoteStateV3;
 pub mod vote_state_v4;

--- a/vote-interface/src/state/vote_state_read.rs
+++ b/vote-interface/src/state/vote_state_read.rs
@@ -1,0 +1,44 @@
+//! Vote state reader API.
+
+use {
+    super::{AuthorizedVoters, BlockTimestamp, LandedVote},
+    solana_clock::{Epoch, Slot},
+    solana_pubkey::Pubkey,
+    std::collections::VecDeque,
+};
+
+/// Read-only trait for accessing vote state data.
+pub trait VoteStateRead {
+    /// Returns the authorized voters.
+    fn authorized_voters(&self) -> &AuthorizedVoters;
+
+    /// Returns the authorized withdrawer.
+    fn authorized_withdrawer(&self) -> &Pubkey;
+
+    /// Returns the total credits.
+    fn credits(&self) -> u64 {
+        if self.epoch_credits().is_empty() {
+            0
+        } else {
+            self.epoch_credits().last().unwrap().1
+        }
+    }
+
+    /// Returns the epoch credits.
+    fn epoch_credits(&self) -> &Vec<(Epoch, u64, u64)>;
+
+    /// Returns the inflation rewards commission in basis points.
+    fn inflation_rewards_commission_bps(&self) -> u16;
+
+    /// Returns the last timestamp.
+    fn last_timestamp(&self) -> &BlockTimestamp;
+
+    /// Returns the node pubkey.
+    fn node_pubkey(&self) -> &Pubkey;
+
+    /// Returns the root slot.
+    fn root_slot(&self) -> Option<Slot>;
+
+    /// Returns the votes deque.
+    fn votes(&self) -> &VecDeque<LandedVote>;
+}

--- a/vote-interface/src/state/vote_state_read.rs
+++ b/vote-interface/src/state/vote_state_read.rs
@@ -1,17 +1,13 @@
 //! Vote state reader API.
 
 use {
-    super::{AuthorizedVoters, BlockTimestamp, LandedVote},
+    super::BlockTimestamp,
     solana_clock::{Epoch, Slot},
     solana_pubkey::Pubkey,
-    std::collections::VecDeque,
 };
 
 /// Read-only trait for accessing vote state data.
 pub trait VoteStateRead {
-    /// Returns the authorized voters.
-    fn authorized_voters(&self) -> &AuthorizedVoters;
-
     /// Returns the authorized withdrawer.
     fn authorized_withdrawer(&self) -> &Pubkey;
 
@@ -38,7 +34,4 @@ pub trait VoteStateRead {
 
     /// Returns the root slot.
     fn root_slot(&self) -> Option<Slot>;
-
-    /// Returns the votes deque.
-    fn votes(&self) -> &VecDeque<LandedVote>;
 }

--- a/vote-interface/src/state/vote_state_v3.rs
+++ b/vote-interface/src/state/vote_state_v3.rs
@@ -8,8 +8,9 @@ use serde_derive::{Deserialize, Serialize};
 use solana_frozen_abi_macro::{frozen_abi, AbiExample};
 use {
     super::{
-        BlockTimestamp, CircBuf, LandedVote, Lockout, VoteInit, MAX_EPOCH_CREDITS_HISTORY,
-        MAX_LOCKOUT_HISTORY, VOTE_CREDITS_GRACE_SLOTS, VOTE_CREDITS_MAXIMUM_PER_SLOT,
+        BlockTimestamp, CircBuf, LandedVote, Lockout, VoteInit, VoteStateRead,
+        MAX_EPOCH_CREDITS_HISTORY, MAX_LOCKOUT_HISTORY, VOTE_CREDITS_GRACE_SLOTS,
+        VOTE_CREDITS_MAXIMUM_PER_SLOT,
     },
     crate::{
         authorized_voters::AuthorizedVoters, error::VoteError, state::DEFAULT_PRIOR_VOTERS_OFFSET,
@@ -511,5 +512,40 @@ impl VoteStateV3 {
         const DEFAULT_PRIOR_VOTERS_END: usize = VERSION_OFFSET + DEFAULT_PRIOR_VOTERS_OFFSET;
         data.len() == VoteStateV3::size_of()
             && data[VERSION_OFFSET..DEFAULT_PRIOR_VOTERS_END] != [0; DEFAULT_PRIOR_VOTERS_OFFSET]
+    }
+}
+
+impl VoteStateRead for VoteStateV3 {
+    fn authorized_voters(&self) -> &AuthorizedVoters {
+        &self.authorized_voters
+    }
+
+    fn authorized_withdrawer(&self) -> &Pubkey {
+        &self.authorized_withdrawer
+    }
+
+    fn epoch_credits(&self) -> &Vec<(Epoch, u64, u64)> {
+        &self.epoch_credits
+    }
+
+    #[allow(clippy::arithmetic_side_effects)]
+    fn inflation_rewards_commission_bps(&self) -> u16 {
+        self.commission as u16 * 100
+    }
+
+    fn last_timestamp(&self) -> &BlockTimestamp {
+        &self.last_timestamp
+    }
+
+    fn node_pubkey(&self) -> &Pubkey {
+        &self.node_pubkey
+    }
+
+    fn root_slot(&self) -> Option<Slot> {
+        self.root_slot
+    }
+
+    fn votes(&self) -> &VecDeque<LandedVote> {
+        &self.votes
     }
 }

--- a/vote-interface/src/state/vote_state_v3.rs
+++ b/vote-interface/src/state/vote_state_v3.rs
@@ -516,10 +516,6 @@ impl VoteStateV3 {
 }
 
 impl VoteStateRead for VoteStateV3 {
-    fn authorized_voters(&self) -> &AuthorizedVoters {
-        &self.authorized_voters
-    }
-
     fn authorized_withdrawer(&self) -> &Pubkey {
         &self.authorized_withdrawer
     }
@@ -543,9 +539,5 @@ impl VoteStateRead for VoteStateV3 {
 
     fn root_slot(&self) -> Option<Slot> {
         self.root_slot
-    }
-
-    fn votes(&self) -> &VecDeque<LandedVote> {
-        &self.votes
     }
 }

--- a/vote-interface/src/state/vote_state_v4.rs
+++ b/vote-interface/src/state/vote_state_v4.rs
@@ -11,7 +11,7 @@ use solana_frozen_abi_macro::{frozen_abi, AbiExample};
 #[cfg(any(target_os = "solana", feature = "bincode"))]
 use solana_instruction::error::InstructionError;
 use {
-    super::{BlockTimestamp, LandedVote, BLS_PUBLIC_KEY_COMPRESSED_SIZE},
+    super::{BlockTimestamp, LandedVote, VoteStateRead, BLS_PUBLIC_KEY_COMPRESSED_SIZE},
     crate::authorized_voters::AuthorizedVoters,
     solana_clock::{Epoch, Slot},
     solana_pubkey::Pubkey,
@@ -213,5 +213,39 @@ impl VoteStateV4 {
             authorized_voters,
             ..Self::default()
         }
+    }
+}
+
+impl VoteStateRead for VoteStateV4 {
+    fn authorized_voters(&self) -> &AuthorizedVoters {
+        &self.authorized_voters
+    }
+
+    fn authorized_withdrawer(&self) -> &Pubkey {
+        &self.authorized_withdrawer
+    }
+
+    fn epoch_credits(&self) -> &Vec<(Epoch, u64, u64)> {
+        &self.epoch_credits
+    }
+
+    fn inflation_rewards_commission_bps(&self) -> u16 {
+        self.inflation_rewards_commission_bps
+    }
+
+    fn last_timestamp(&self) -> &BlockTimestamp {
+        &self.last_timestamp
+    }
+
+    fn node_pubkey(&self) -> &Pubkey {
+        &self.node_pubkey
+    }
+
+    fn root_slot(&self) -> Option<Slot> {
+        self.root_slot
+    }
+
+    fn votes(&self) -> &VecDeque<LandedVote> {
+        &self.votes
     }
 }

--- a/vote-interface/src/state/vote_state_v4.rs
+++ b/vote-interface/src/state/vote_state_v4.rs
@@ -217,10 +217,6 @@ impl VoteStateV4 {
 }
 
 impl VoteStateRead for VoteStateV4 {
-    fn authorized_voters(&self) -> &AuthorizedVoters {
-        &self.authorized_voters
-    }
-
     fn authorized_withdrawer(&self) -> &Pubkey {
         &self.authorized_withdrawer
     }
@@ -243,9 +239,5 @@ impl VoteStateRead for VoteStateV4 {
 
     fn root_slot(&self) -> Option<Slot> {
         self.root_slot
-    }
-
-    fn votes(&self) -> &VecDeque<LandedVote> {
-        &self.votes
     }
 }

--- a/vote-interface/src/state/vote_state_versions.rs
+++ b/vote-interface/src/state/vote_state_versions.rs
@@ -2,17 +2,17 @@
 use arbitrary::{Arbitrary, Unstructured};
 use {
     crate::state::{
-        vote_state_0_23_5::VoteState0_23_5, vote_state_1_14_11::VoteState1_14_11, AuthorizedVoters,
-        BlockTimestamp, LandedVote, VoteStateRead, VoteStateV3, VoteStateV4,
+        vote_state_0_23_5::VoteState0_23_5, vote_state_1_14_11::VoteState1_14_11, BlockTimestamp,
+        VoteStateRead, VoteStateV3, VoteStateV4,
     },
     solana_clock::{Epoch, Slot},
     solana_pubkey::Pubkey,
-    std::collections::VecDeque,
 };
 #[cfg(any(test, all(not(target_os = "solana"), feature = "bincode")))]
 use {
-    crate::state::{CircBuf, Lockout},
+    crate::state::{AuthorizedVoters, CircBuf, LandedVote, Lockout},
     solana_instruction::error::InstructionError,
+    std::collections::VecDeque,
 };
 
 #[cfg_attr(
@@ -193,18 +193,6 @@ impl VoteStateVersions {
 }
 
 impl VoteStateRead for VoteStateVersions {
-    fn authorized_voters(&self) -> &AuthorizedVoters {
-        match self {
-            VoteStateVersions::V0_23_5(_state) => {
-                // V0_23_5 does not have AuthorizedVoters struct.
-                unimplemented!("V0_23_5 does not support authorized_voters.")
-            }
-            VoteStateVersions::V1_14_11(state) => &state.authorized_voters,
-            VoteStateVersions::V3(state) => state.authorized_voters(),
-            VoteStateVersions::V4(state) => state.authorized_voters(),
-        }
-    }
-
     fn authorized_withdrawer(&self) -> &Pubkey {
         match self {
             VoteStateVersions::V0_23_5(state) => &state.authorized_withdrawer,
@@ -256,21 +244,6 @@ impl VoteStateRead for VoteStateVersions {
             VoteStateVersions::V1_14_11(state) => state.root_slot,
             VoteStateVersions::V3(state) => state.root_slot(),
             VoteStateVersions::V4(state) => state.root_slot(),
-        }
-    }
-
-    fn votes(&self) -> &VecDeque<LandedVote> {
-        match self {
-            VoteStateVersions::V0_23_5(_state) => {
-                // V0_23_5 uses VecDeque<Lockout>, not VecDeque<LandedVote>.
-                unimplemented!("V0_23_5 does not support votes.")
-            }
-            VoteStateVersions::V1_14_11(_state) => {
-                // V1_14_11 uses VecDeque<Lockout>, not VecDeque<LandedVote>.
-                unimplemented!("V1_14_11 does not support votes.")
-            }
-            VoteStateVersions::V3(state) => state.votes(),
-            VoteStateVersions::V4(state) => state.votes(),
         }
     }
 }


### PR DESCRIPTION
Adds a read-only API that covers `VoteStateVersions`, `VoteStateV4` and `VoteStateV3`.