### PR TITLE
define-syscall: Add abort syscall

### DIFF
--- a/define-syscall/src/definitions.rs
+++ b/define-syscall/src/definitions.rs
@@ -31,7 +31,8 @@ define_syscall!(fn sol_remaining_compute_units() -> u64);
 define_syscall!(fn sol_alt_bn128_compression(op: u64, input: *const u8, input_size: u64, result: *mut u8) -> u64);
 define_syscall!(fn sol_get_sysvar(sysvar_id_addr: *const u8, result: *mut u8, offset: u64, length: u64) -> u64);
 define_syscall!(fn sol_get_epoch_stake(vote_address: *const u8) -> u64);
-define_syscall!(fn sol_panic_(filename: *const u8, filename_len: u64, line: u64, column: u64));
+define_syscall!(fn sol_panic_(filename: *const u8, filename_len: u64, line: u64, column: u64) -> !);
+define_syscall!(fn abort() -> !);
 
 // these are deprecated - use sol_get_sysvar instead
 define_syscall!(#[deprecated(since = "3.0.0", note = "Use `sol_get_sysvar` with `Clock` sysvar address instead")] fn sol_get_clock_sysvar(addr: *mut u8) -> u64);


### PR DESCRIPTION
### Problem

When defining a `#[panic_handler]` in `no_std` programs, the attribute must be applied to a function with signature `fn(&PanicInfo) -> !`. In most cases the function will either use the `sol_panic_` or `abort` syscalls, but their definition either don't match the required signature or it is missing.

### Solution

This PR makes two changes to facilitate the definition of `no_std` panic handlers:
* updates the signature of `sol_panic_handler_` to indicate it never returns (return of `!`)
* add the definition for the `abort` syscall