### PR TITLE
[bn254] declare msrv (1.87.0)

### DIFF
--- a/bn254/Cargo.toml
+++ b/bn254/Cargo.toml
@@ -9,6 +9,7 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 include = ["src/**/*"]
+rust-version = "1.87.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
#### Problem
ca06d9904 introduced `usize::is_multiple_of()` in solana-bn254, which is unstable before rust 1.87.0

#### Changes
declare msrv in solana-bn254

probably release this and yank 3.1.0