### PR TITLE
system-interface: Make it no-std compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ memmap2 = "0.5.10"
 memoffset = "0.9"
 num-bigint = "0.4.6"
 num-derive = "0.4"
-num-traits = "0.2.18"
+num-traits = { version = "0.2.18", default-features = false }
 num_enum = "0.7.3"
 openssl = "0.10.72"
 pairing = "0.23.0"

--- a/frozen-abi-macro/src/lib.rs
+++ b/frozen-abi-macro/src/lib.rs
@@ -279,8 +279,6 @@ fn quote_for_test(
     type_name: &Ident,
     expected_digest: &str,
 ) -> TokenStream2 {
-    // escape from nits.sh...
-    let p = Ident::new(&("ep".to_owned() + "rintln"), Span::call_site());
     quote! {
         #[cfg(test)]
         mod #test_mod_ident {
@@ -302,7 +300,7 @@ fn quote_for_test(
                 let actual_digest = ::std::format!("{}", hash);
                 if ::std::env::var("SOLANA_ABI_BULK_UPDATE").is_ok() {
                     if #expected_digest != actual_digest {
-                        #p!("sed -i -e 's/{}/{}/g' $(git grep --files-with-matches frozen_abi)", #expected_digest, hash);
+                        ::std::eprintln!("sed -i -e 's/{}/{}/g' $(git grep --files-with-matches frozen_abi)", #expected_digest, hash);
                     }
                     ::solana_frozen_abi::__private::log::warn!("Not testing the abi digest under SOLANA_ABI_BULK_UPDATE!");
                 } else {

--- a/scripts/check-nits.sh
+++ b/scripts/check-nits.sh
@@ -19,6 +19,7 @@ declare print_free_tree=(
   ':**.rs'
   ':^address/src/hasher.rs'
   ':^address/src/lib.rs'
+  ':^frozen-abi-macro/src/lib.rs'
   ':^logger/src/lib.rs'
   ':^msg/src/lib.rs'
   ':^program-log/src/logger.rs'

--- a/scripts/check-no-std.sh
+++ b/scripts/check-no-std.sh
@@ -24,6 +24,7 @@ no_std_crates=(
   -p solana-sdk-ids
   -p solana-signature
   -p solana-sysvar-id
+  -p solana-system-interface
 )
 # Use the upstream BPF target, which doesn't support std, to make sure that our
 # no_std support really works.

--- a/system-interface/Cargo.toml
+++ b/system-interface/Cargo.toml
@@ -19,16 +19,19 @@ rustdoc-args = ["--cfg=docsrs"]
 crate-type = ["rlib"]
 
 [features]
-bincode = ["dep:solana-instruction", "serde"]
+alloc = []
+bincode = ["dep:solana-instruction", "alloc", "serde"]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
     "dep:solana-logger",
     "serde",
+    "std",
     "solana-address/frozen-abi",
     "solana-address/std",
 ]
 serde = ["dep:serde", "dep:serde_derive", "solana-address/serde"]
+std = []
 
 [dependencies]
 num-traits = { workspace = true }

--- a/system-interface/src/instruction.rs
+++ b/system-interface/src/instruction.rs
@@ -46,12 +46,14 @@
 //! [`Instruction`]:
 //! https://docs.rs/solana-instruction/latest/solana_instruction/struct.Instruction.html
 
-use solana_address::Address;
 #[cfg(feature = "bincode")]
 use {
     crate::program::ID,
+    alloc::{string::ToString, vec, vec::Vec},
     solana_instruction::{AccountMeta, Instruction},
 };
+#[cfg(feature = "alloc")]
+use {alloc::string::String, solana_address::Address};
 
 // Inline some constants to avoid dependencies.
 //
@@ -85,6 +87,7 @@ const NONCE_STATE_SIZE: usize = 80;
     feature = "serde",
     derive(serde_derive::Deserialize, serde_derive::Serialize)
 )]
+#[cfg(feature = "alloc")]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SystemInstruction {
     /// Create a new account

--- a/system-interface/src/lib.rs
+++ b/system-interface/src/lib.rs
@@ -1,7 +1,13 @@
 //! The System program interface.
 
+#![no_std]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
 
 pub mod error;
 pub mod instruction;


### PR DESCRIPTION
#### Problem

We're about to publish a breaking change to system-interface, so why not have a little fun and make it no-std beforehand!

#### Summary of changes

Add alloc feature for vec / string and std feature for frozen-abi. There's not a ton you can do with the crate currently since the instructions require bincode / alloc, but we should be able to trim this more in the future with pinocchio-compatible types.

While testing this, I noticed that the frozen-abi tests didn't work for no-std crates, which will likely become a problem in the future, so I fixed the macro to properly emit eprintln rather than through the hacky way it's done now.