### PR TITLE
loader-v4-interface: update status enum as per SIMD-0167

### DIFF
--- a/loader-v4-interface/src/state.rs
+++ b/loader-v4-interface/src/state.rs
@@ -1,9 +1,13 @@
 use solana_pubkey::Pubkey;
 
-#[repr(u64)]
+#[repr(u32)]
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum LoaderV4Status {
+    /// Account was zero-filled externally
+    Uninitialized,
+    /// Used as write buffer
+    Buffered,
     /// Program is in maintenance
     Retracted,
     /// Program is ready to be executed


### PR DESCRIPTION
As per [SIMD-0167](https://github.com/solana-foundation/solana-improvement-documents/pull/167), updates the status enum to match the proposal's specification.