### PR TITLE
bug: fix parallel feature on master

### DIFF
--- a/bls-signatures/src/pubkey.rs
+++ b/bls-signatures/src/pubkey.rs
@@ -528,7 +528,7 @@ mod tests {
         let pubkey1 = PubkeyProjective::try_from(&keypair1.public).unwrap();
 
         // Test `aggregate`
-        let sequential_agg = PubkeyProjective::aggregate(&[&pubkey0, &pubkey1]).unwrap();
+        let sequential_agg = PubkeyProjective::aggregate([pubkey0, pubkey1].iter()).unwrap();
         let parallel_agg = PubkeyProjective::par_aggregate(&[&pubkey0, &pubkey1]).unwrap();
         assert_eq!(sequential_agg, parallel_agg);
 

--- a/bls-signatures/src/signature.rs
+++ b/bls-signatures/src/signature.rs
@@ -738,7 +738,8 @@ mod tests {
         let signature1 = keypair1.sign(b"");
 
         // Test `aggregate`
-        let sequential_agg = SignatureProjective::aggregate(&[&signature0, &signature1]).unwrap();
+        let sequential_agg =
+            SignatureProjective::aggregate([signature0, signature1].iter()).unwrap();
         let parallel_agg = SignatureProjective::par_aggregate(&[&signature0, &signature1]).unwrap();
         assert_eq!(sequential_agg, parallel_agg);
 


### PR DESCRIPTION
Looks like we are not testing parallel feature on CI and it is currently broken on master.  This PR allows `cargo test --features=parallel` to succeed on my local machine.