### PR TITLE
[ci] Update `test-coverage.sh` to run on all features

### DIFF
--- a/scripts/test-coverage.sh
+++ b/scripts/test-coverage.sh
@@ -62,7 +62,7 @@ fi
 # macro code green always. Also, forcibly discard the vast amount of log by
 # redirecting the stderr.
 RUST_LOG="solana=trace,$RUST_LOG" \
-  ./cargo nightly test --features frozen-abi --target-dir "./target/cov" "${PACKAGES[@]}" 2>/dev/null
+  ./cargo nightly test --all-features --target-dir "./target/cov" "${PACKAGES[@]}" 2>/dev/null
 
 # Generate test reports
 echo "--- grcov"


### PR DESCRIPTION
#### Problem

https://github.com/anza-xyz/solana-sdk/pull/371 seems to have broken a test for the `parallel` feature of the bls crate, but the CI still passed. This was fixed in https://github.com/anza-xyz/solana-sdk/pull/375, but I was wondering if we could update the CI to test all features.

#### Summary of Changes

I updated `test-coverage.sh` to test on all features instead of just frozen-abi.