### PR TITLE
address: Revert custom `PartialEq`, add `address_eq`

### DIFF
--- a/address/src/lib.rs
+++ b/address/src/lib.rs
@@ -322,7 +322,8 @@ impl core::fmt::Display for Address {
 /// This isn't the implementation for the `PartialEq` trait because we can't do
 /// structural equality with a trait implementation.
 ///
-/// More information at https://github.com/anza-xyz/solana-sdk/issues/345
+/// [Issue #345](https://github.com/anza-xyz/solana-sdk/issues/345) contains
+/// more information about the problem.
 #[inline(always)]
 pub fn address_eq(a1: &Address, a2: &Address) -> bool {
     let p1_ptr = a1.0.as_ptr().cast::<u64>();


### PR DESCRIPTION
#### Problem

As noted in #345, the custom implementation of `PartialEq` makes it impossible to match against const values, breaking downstream users.

#### Summary of changes

Revert the PartialEq implementation, and make it into a new function called `address_eq`. We'll rely on the compiler to do the right thing in the future instead.

Fixes #345