### PR TITLE
Remove `to_account_shared_data` from ReadableAccount

### DIFF
--- a/account/src/lib.rs
+++ b/account/src/lib.rs
@@ -227,17 +227,6 @@ pub trait ReadableAccount: Sized {
     fn owner(&self) -> &Pubkey;
     fn executable(&self) -> bool;
     fn rent_epoch(&self) -> Epoch;
-    #[deprecated(since = "3.2.0")]
-    fn to_account_shared_data(&self) -> AccountSharedData {
-        #[allow(deprecated)]
-        AccountSharedData::create(
-            self.lamports(),
-            self.data().to_vec(),
-            *self.owner(),
-            self.executable(),
-            self.rent_epoch(),
-        )
-    }
 }
 
 impl ReadableAccount for Account {
@@ -346,10 +335,6 @@ impl ReadableAccount for AccountSharedData {
     fn rent_epoch(&self) -> Epoch {
         self.rent_epoch
     }
-    fn to_account_shared_data(&self) -> AccountSharedData {
-        // avoid data copy here
-        self.clone()
-    }
 }
 
 impl ReadableAccount for Ref<'_, AccountSharedData> {
@@ -367,16 +352,6 @@ impl ReadableAccount for Ref<'_, AccountSharedData> {
     }
     fn rent_epoch(&self) -> Epoch {
         self.rent_epoch
-    }
-    fn to_account_shared_data(&self) -> AccountSharedData {
-        AccountSharedData {
-            lamports: self.lamports(),
-            // avoid data copy here
-            data: Arc::clone(&self.data),
-            owner: *self.owner(),
-            executable: self.executable(),
-            rent_epoch: self.rent_epoch(),
-        }
     }
 }
 
@@ -874,18 +849,6 @@ pub mod tests {
         let key = Pubkey::new_unique();
         let (_account1, mut account2) = make_two_accounts(&key);
         account2.serialize_data(&"hello world").unwrap();
-    }
-
-    #[test]
-    #[allow(deprecated)]
-    fn test_to_account_shared_data() {
-        let key = Pubkey::new_unique();
-        let (account1, account2) = make_two_accounts(&key);
-        assert!(accounts_equal(&account1, &account2));
-        let account3 = account1.to_account_shared_data();
-        let account4 = account2.to_account_shared_data();
-        assert!(accounts_equal(&account1, &account3));
-        assert!(accounts_equal(&account1, &account4));
     }
 
     #[test]


### PR DESCRIPTION
**Problem**

We are introducing a new account layout for the SVM. We'll also have "view" structs that do not own the fields for when programs borrow an account. Those structs implement `ReadableAccount`, but cannot be converted into `AccountSharedData` without losing references to the underlying data.

**Solution**

Remove the `to_account_shared_data` from `ReadableAccount`.