### PR TITLE
extend program entry to 128

### DIFF
--- a/program-entrypoint/src/lib.rs
+++ b/program-entrypoint/src/lib.rs
@@ -169,7 +169,7 @@ macro_rules! entrypoint_no_alloc {
             #[allow(clippy::declare_interior_mutable_const)]
             const UNINIT_ACCOUNT_INFO: MaybeUninit<AccountInfo> =
                 MaybeUninit::<AccountInfo>::uninit();
-            const MAX_ACCOUNT_INFOS: usize = 64;
+            const MAX_ACCOUNT_INFOS: usize = 128;
             let mut accounts = [UNINIT_ACCOUNT_INFO; MAX_ACCOUNT_INFOS];
             let (program_id, num_accounts, instruction_data) =
                 unsafe { $crate::deserialize_into(input, &mut accounts) };


### PR DESCRIPTION
This pull request increases the maximum number of `AccountInfo` objects that can be processed in the `entrypoint_no_alloc` macro within `program-entrypoint/src/lib.rs`. This change allows handling more accounts per transaction, which can be important for complex programs or instructions.

Resource limit adjustment:

* Increased the `MAX_ACCOUNT_INFOS` constant from 64 to 128 in the `entrypoint_no_alloc` macro to support processing up to 128 accounts per transaction.