### PR TITLE
CI: Only run semver checks on crates with a lib target

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -151,14 +151,28 @@ jobs:
       - name: Install cargo-semver-checks
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-semver-checks,cargo-release
+          tool: toml-cli,cargo-semver-checks,cargo-release
+
+      - name: Check if crate has a lib target
+        id: has_lib
+        shell: bash
+        run: |
+          set +e # toml crashes the whole shell if it fails to find the key
+          result=$(toml get "${{ inputs.package-path }}/Cargo.toml" lib.crate-type)
+          if [[ "$result" == *"lib"* ]]; then
+            echo "has_lib=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_lib=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set Git Author (required for cargo-release)
+        if: ${{ steps.has_lib.outputs.has_lib == 'true' }}
         run: |
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
       - name: Set Version
+        if: ${{ steps.has_lib.outputs.has_lib == 'true' }}
         run: |
           if [ "${{ inputs.level }}" == "version" ]; then
             LEVEL=${{ inputs.version }}
@@ -168,6 +182,7 @@ jobs:
           cargo release $LEVEL --manifest-path "${{ inputs.package_path }}/Cargo.toml" --no-tag --no-publish --no-push --no-confirm --execute
 
       - name: Check semver
+        if: ${{ steps.has_lib.outputs.has_lib == 'true' }}
         run: cargo semver-checks --manifest-path "${{ inputs.package_path }}/Cargo.toml"
 
   publish-crate:


### PR DESCRIPTION
#### Problem

The semver-checks step during publish doesn't distinguish the current crate targets, and semver-checks only works on crates with lib targets. This means it fails on proc-macro crates, preventing us from publishing.

#### Summary of changes

Similar to what's done in the program repos at [this workflow](https://github.com/solana-program/actions/blob/3823505ada06f9c8362cd935b73a7f22a1490374/.github/workflows/publish-rust.yml#L103), check for a lib target and then run semver-checks.