### PR TITLE
Use `doc_cfg` instead of `doc_auto_cfg`

### DIFF
--- a/account-info/src/lib.rs
+++ b/account-info/src/lib.rs
@@ -1,5 +1,5 @@
 //! Account information.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 use {
     solana_address::Address,
     solana_program_error::ProgramError,

--- a/account-view/src/lib.rs
+++ b/account-view/src/lib.rs
@@ -1,7 +1,7 @@
 //! Data structures to represent account information.
 
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::arithmetic_side_effects)]
 
 use {

--- a/account/src/lib.rs
+++ b/account/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 //! The Solana [`Account`] type.
 
 #[cfg(feature = "dev-context-only-utils")]

--- a/address-lookup-table-interface/src/lib.rs
+++ b/address-lookup-table-interface/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 //! The [address lookup table program][np].
 //!
 //! [np]: https://docs.solanalabs.com/runtime/programs#address-lookup-table-program

--- a/address/src/lib.rs
+++ b/address/src/lib.rs
@@ -4,7 +4,7 @@
 //! (e.g. 14grJpemFaf88c8tiVb77W7TYg2W3ir6pfkKz3YjhhZ5).
 
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![allow(clippy::arithmetic_side_effects)]
 

--- a/atomic-u64/src/lib.rs
+++ b/atomic-u64/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 pub use implementation::AtomicU64;
 
 #[cfg(target_pointer_width = "64")]

--- a/big-mod-exp/src/lib.rs
+++ b/big-mod-exp/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #[repr(C)]
 pub struct BigModExpParams {
     pub base: *const u8,

--- a/bincode/src/lib.rs
+++ b/bincode/src/lib.rs
@@ -1,7 +1,7 @@
 //! Contains a single utility function for deserializing from [bincode].
 //!
 //! [bincode]: https://docs.rs/bincode
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use {bincode::config::Options, solana_instruction_error::InstructionError};
 

--- a/blake3-hasher/src/lib.rs
+++ b/blake3-hasher/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! [blake3]: https://github.com/BLAKE3-team/BLAKE3
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub use solana_hash::{Hash, ParseHashError, HASH_BYTES, MAX_BASE58_LEN};
 

--- a/bls-signatures/src/lib.rs
+++ b/bls-signatures/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 
 extern crate alloc;

--- a/bn254/src/lib.rs
+++ b/bn254/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 pub(crate) mod addition;
 pub mod compression;
 pub(crate) mod multiplication;

--- a/borsh/src/lib.rs
+++ b/borsh/src/lib.rs
@@ -1,3 +1,3 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 pub mod macros;
 pub mod v1;

--- a/client-traits/src/lib.rs
+++ b/client-traits/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! Asynchronous implementations are expected to create transactions, sign them, and send
 //! them but without waiting to see if the server accepted it.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use {
     solana_account::Account,

--- a/clock/src/lib.rs
+++ b/clock/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! [oracle]: https://docs.solanalabs.com/implemented-proposals/validator-timestamp-oracle
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "sysvar")]
 pub mod sysvar;

--- a/cluster-type/src/lib.rs
+++ b/cluster-type/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::{AbiEnumVisitor, AbiExample};
 use {solana_hash::Hash, std::str::FromStr};

--- a/commitment-config/src/lib.rs
+++ b/commitment-config/src/lib.rs
@@ -1,6 +1,6 @@
 //! Definitions of commitment levels.
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 use core::{fmt, str::FromStr};
 
 #[cfg_attr(

--- a/compute-budget-interface/src/lib.rs
+++ b/compute-budget-interface/src/lib.rs
@@ -1,5 +1,5 @@
 //! Instructions for the compute budget native program.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 
 #[cfg(feature = "borsh")]

--- a/cpi/src/lib.rs
+++ b/cpi/src/lib.rs
@@ -12,7 +12,7 @@
 //! [`invoke_signed`]: invoke_signed
 //! [cpi]: https://solana.com/docs/core/cpi
 //! [`solana_program::program`]: https://docs.rs/solana-program/latest/solana_program/program/
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use {
     solana_account_info::AccountInfo, solana_instruction::Instruction,

--- a/define-syscall/src/lib.rs
+++ b/define-syscall/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod definitions;
 

--- a/derivation-path/src/lib.rs
+++ b/derivation-path/src/lib.rs
@@ -8,7 +8,7 @@
 //! > `m/44'/501'`
 //!
 //! with 501 being the Solana coin type.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use {
     core::{iter::IntoIterator, slice::Iter},

--- a/ed25519-program/src/lib.rs
+++ b/ed25519-program/src/lib.rs
@@ -1,7 +1,7 @@
 //! Instructions for the [ed25519 native program][np].
 //!
 //! [np]: https://docs.solanalabs.com/runtime/programs#ed25519-program
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use {
     bytemuck::bytes_of,

--- a/epoch-info/src/lib.rs
+++ b/epoch-info/src/lib.rs
@@ -5,7 +5,7 @@
 //! As returned by the [`getEpochInfo`] RPC method.
 //!
 //! [`getEpochInfo`]: https://solana.com/docs/rpc/http/getepochinfo
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg_attr(
     feature = "serde",

--- a/epoch-rewards-hasher/src/lib.rs
+++ b/epoch-rewards-hasher/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 use {siphasher::sip::SipHasher13, solana_address::Address, solana_hash::Hash, std::hash::Hasher};
 
 #[derive(Debug, Clone)]

--- a/epoch-rewards/src/lib.rs
+++ b/epoch-rewards/src/lib.rs
@@ -7,7 +7,7 @@
 //! [`sysvar`]: crate::sysvar
 
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 
 #[cfg(feature = "sysvar")]

--- a/epoch-schedule/src/lib.rs
+++ b/epoch-schedule/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! [`DEFAULT_SLOTS_PER_EPOCH`]: https://docs.rs/solana-clock/latest/solana_clock/constant.DEFAULT_SLOTS_PER_EPOCH.html
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![no_std]
 #[cfg(feature = "frozen-abi")]
 extern crate std;

--- a/epoch-stake/src/lib.rs
+++ b/epoch-stake/src/lib.rs
@@ -3,7 +3,7 @@
 //! On-chain programs can use this API to retrieve the total stake for the
 //! current epoch or the stake for a specific vote account using the
 //! `sol_get_epoch_stake` syscall.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use solana_pubkey::Pubkey;
 

--- a/example-mocks/src/lib.rs
+++ b/example-mocks/src/lib.rs
@@ -12,7 +12,7 @@
 
 #![doc(hidden)]
 #![allow(clippy::new_without_default)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod solana_rpc_client {
     pub mod rpc_client {

--- a/feature-gate-interface/src/lib.rs
+++ b/feature-gate-interface/src/lib.rs
@@ -10,7 +10,7 @@
 //!    `Feature::default()`
 //! 2. When the next epoch is entered the runtime will check for new activation requests and
 //!    active them.  When this occurs, the activation slot is recorded in the feature account
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod error;
 pub mod instruction;

--- a/fee-calculator/src/lib.rs
+++ b/fee-calculator/src/lib.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![allow(clippy::arithmetic_side_effects)]
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 use log::*;
 #[cfg(feature = "frozen-abi")]
 extern crate std;

--- a/fee-structure/src/lib.rs
+++ b/fee-structure/src/lib.rs
@@ -1,5 +1,5 @@
 //! Fee structures.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 
 use std::num::NonZeroU32;

--- a/file-download/src/lib.rs
+++ b/file-download/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::arithmetic_side_effects)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 use {
     console::Emoji,
     indicatif::{ProgressBar, ProgressStyle},

--- a/frozen-abi-macro/src/lib.rs
+++ b/frozen-abi-macro/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 extern crate proc_macro;
 
 use proc_macro::TokenStream;

--- a/frozen-abi/src/lib.rs
+++ b/frozen-abi/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(incomplete_features)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(specialization))]
 
 // Allows macro expansion of `use ::solana_frozen_abi::*` to work within this crate

--- a/genesis-config/src/lib.rs
+++ b/genesis-config/src/lib.rs
@@ -1,7 +1,7 @@
 //! The chain's genesis config.
 
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::{frozen_abi, AbiExample};
 #[cfg(feature = "serde")]

--- a/hard-forks/src/lib.rs
+++ b/hard-forks/src/lib.rs
@@ -1,7 +1,7 @@
 //! The list of slot boundaries at which a hard fork should
 //! occur.
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]

--- a/hash/src/lib.rs
+++ b/hash/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #[cfg(feature = "borsh")]
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};

--- a/inflation/src/lib.rs
+++ b/inflation/src/lib.rs
@@ -1,5 +1,5 @@
 //! configuration for network inflation
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};

--- a/instruction-error/src/lib.rs
+++ b/instruction-error/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #[cfg(feature = "num-traits")]
 use num_traits::ToPrimitive;

--- a/instruction/src/lib.rs
+++ b/instruction/src/lib.rs
@@ -10,7 +10,7 @@
 //! while executing a given instruction is also included in `Instruction`, as
 //! [`AccountMeta`] values. The runtime uses this information to efficiently
 //! schedule execution of transactions.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::arithmetic_side_effects)]
 #![no_std]
 

--- a/instructions-sysvar/src/lib.rs
+++ b/instructions-sysvar/src/lib.rs
@@ -27,7 +27,7 @@
 //!
 //! [`secp256k1_instruction`]: https://docs.rs/solana-sdk/latest/solana_sdk/secp256k1_instruction/index.html
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::arithmetic_side_effects)]
 
 #[cfg(feature = "dev-context-only-utils")]

--- a/keccak-hasher/src/lib.rs
+++ b/keccak-hasher/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! [keccak]: https://keccak.team/keccak.html
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(all(feature = "sha3", not(any(target_os = "solana", target_arch = "bpf"))))]
 use sha3::{Digest, Keccak256};

--- a/keypair/src/lib.rs
+++ b/keypair/src/lib.rs
@@ -1,5 +1,5 @@
 //! Concrete implementation of a Solana `Signer` from raw bytes
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 use {
     ed25519_dalek::Signer as DalekSigner,
     rand::rngs::OsRng,

--- a/last-restart-slot/src/lib.rs
+++ b/last-restart-slot/src/lib.rs
@@ -1,5 +1,5 @@
 //! Information about the last restart slot (hard fork).
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "sysvar")]
 pub mod sysvar;

--- a/loader-v2-interface/src/lib.rs
+++ b/loader-v2-interface/src/lib.rs
@@ -1,5 +1,5 @@
 //! Instructions for the non-upgradable BPF loader.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "bincode")]
 use {

--- a/loader-v3-interface/src/lib.rs
+++ b/loader-v3-interface/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 //! An upgradeable BPF loader native program.
 //!
 //! The upgradeable BPF loader is responsible for deploying, upgrading, and

--- a/loader-v4-interface/src/lib.rs
+++ b/loader-v4-interface/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This is the loader of the program runtime v2.
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod instruction;
 pub mod state;

--- a/message/src/lib.rs
+++ b/message/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 //! Sequences of [`Instruction`]s executed within a single transaction.
 //!

--- a/msg/src/lib.rs
+++ b/msg/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #[cfg(feature = "alloc")]
 extern crate alloc;
 #[cfg(feature = "std")]

--- a/native-token/src/lib.rs
+++ b/native-token/src/lib.rs
@@ -1,6 +1,6 @@
 //! Definitions for the native SOL token and its fractional lamports.
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::arithmetic_side_effects)]
 
 /// There are 10^9 lamports in one SOL

--- a/nonce-account/src/lib.rs
+++ b/nonce-account/src/lib.rs
@@ -1,5 +1,5 @@
 //! Functions related to nonce accounts.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use {
     solana_account::{state_traits::StateMut, AccountSharedData, ReadableAccount},

--- a/nonce/src/lib.rs
+++ b/nonce/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 //! Durable transaction nonces.
 
 pub mod state;

--- a/offchain-message/src/lib.rs
+++ b/offchain-message/src/lib.rs
@@ -1,5 +1,5 @@
 //! Off-chain message container for storing non-transaction messages.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 use {
     num_enum::{IntoPrimitive, TryFromPrimitive},
     solana_hash::Hash,

--- a/package-metadata-macro/src/lib.rs
+++ b/package-metadata-macro/src/lib.rs
@@ -1,5 +1,5 @@
 //! Macro to access data from the `package.metadata` section of Cargo.toml
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 extern crate proc_macro;
 

--- a/package-metadata/src/lib.rs
+++ b/package-metadata/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /// Macro for accessing data from the `package.metadata` section of the Cargo manifest
 ///
 /// # Arguments

--- a/packet/src/lib.rs
+++ b/packet/src/lib.rs
@@ -1,6 +1,6 @@
 //! The definition of a Solana network packet.
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::AbiExample;

--- a/poh-config/src/lib.rs
+++ b/poh-config/src/lib.rs
@@ -1,5 +1,5 @@
 //! Definitions of Solana's proof of history.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 
 use std::time::Duration;

--- a/precompile-error/src/lib.rs
+++ b/precompile-error/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 /// Precompile errors
 use core::fmt;
 

--- a/presigner/src/lib.rs
+++ b/presigner/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 pub use solana_signer::PresignerError;
 use {
     solana_pubkey::Pubkey,

--- a/program-entrypoint/src/lib.rs
+++ b/program-entrypoint/src/lib.rs
@@ -1,5 +1,5 @@
 //! The Rust-based BPF program entrypoint supported by the latest BPF loader.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 extern crate alloc;
 use {

--- a/program-error/src/lib.rs
+++ b/program-error/src/lib.rs
@@ -1,7 +1,7 @@
 //! The [`ProgramError`] type and related definitions.
 
 #![allow(clippy::arithmetic_side_effects)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![no_std]
 #[cfg(feature = "borsh")]
 use borsh::io::Error as BorshIoError;

--- a/program-log-macro/src/lib.rs
+++ b/program-log-macro/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::arithmetic_side_effects)]
 
 extern crate alloc;

--- a/program-log/src/lib.rs
+++ b/program-log/src/lib.rs
@@ -44,7 +44,7 @@
 //! ```
 
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::arithmetic_side_effects)]
 
 pub mod logger;

--- a/program-memory/src/lib.rs
+++ b/program-memory/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! Basic low-level memory operations.
 //!

--- a/program-option/src/lib.rs
+++ b/program-option/src/lib.rs
@@ -3,7 +3,7 @@
 //!
 //! This implementation mostly matches `std::option` except iterators since the iteration
 //! trait requires returning `std::option::Option`
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use std::{
     convert, mem,

--- a/program-pack/src/lib.rs
+++ b/program-pack/src/lib.rs
@@ -5,7 +5,7 @@
 //! serialization format.
 //!
 //! [spl]: https://github.com/solana-labs/solana-program-library
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use solana_program_error::ProgramError;
 

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -465,7 +465,7 @@
 
 #![allow(incomplete_features)]
 #![cfg_attr(feature = "frozen-abi", feature(specialization))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 // Allows macro expansion of `use ::solana_program::*` to work within this crate
 extern crate self as solana_program;

--- a/pubkey/src/lib.rs
+++ b/pubkey/src/lib.rs
@@ -1,6 +1,6 @@
 //! Solana account addresses.
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![allow(clippy::arithmetic_side_effects)]
 

--- a/quic-definitions/src/lib.rs
+++ b/quic-definitions/src/lib.rs
@@ -1,5 +1,5 @@
 //! Definitions related to Solana over QUIC.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 use {solana_keypair::Keypair, std::time::Duration};
 
 pub const QUIC_PORT_OFFSET: u16 = 6;

--- a/rent/src/lib.rs
+++ b/rent/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![allow(clippy::arithmetic_side_effects)]
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #[cfg(feature = "frozen-abi")]
 extern crate std;

--- a/reward-info/src/lib.rs
+++ b/reward-info/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "frozen-abi")]

--- a/sanitize/src/lib.rs
+++ b/sanitize/src/lib.rs
@@ -1,7 +1,7 @@
 //! A trait for sanitizing values and members of over the wire messages.
 
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use core::{error::Error, fmt};
 

--- a/scripts/check-doc-features.sh
+++ b/scripts/check-doc-features.sh
@@ -14,10 +14,10 @@ if [[ -n $files ]]; then
   err=1
 fi
 
-# Get all lib.rs files that don't have #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-files=$(comm -23 <(git ls-files -- '**/lib.rs' | sort) <(git grep -lE '^#!\[cfg_attr\(docsrs, feature\(doc_auto_cfg\)\)\]' | sort))
+# Get all lib.rs files that don't have #![cfg_attr(docsrs, feature(doc_cfg))]
+files=$(comm -23 <(git ls-files -- '**/lib.rs' | sort) <(git grep -lE '^#!\[cfg_attr\(docsrs, feature\(doc_cfg\)\)\]' | sort))
 if [[ -n $files ]]; then
-  echo "Files found without #![cfg_attr(docsrs, feature(doc_auto_cfg))]"
+  echo "Files found without #![cfg_attr(docsrs, feature(doc_cfg))]"
   echo "$files"
   err=1
 fi

--- a/sdk-ids/src/lib.rs
+++ b/sdk-ids/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod address_lookup_table {
     solana_address::declare_id!("AddressLookupTab1e1111111111111111111111111");

--- a/sdk-macro/src/lib.rs
+++ b/sdk-macro/src/lib.rs
@@ -1,7 +1,7 @@
 //! Convenience macro to declare a static public key and functions to interact with it
 //!
 //! Input: a single literal base58 string representation of a program's id
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 extern crate proc_macro;
 

--- a/sdk-wasm-js-tests/src/lib.rs
+++ b/sdk-wasm-js-tests/src/lib.rs
@@ -1,5 +1,5 @@
 //! `SystemInstruction` Javascript interface
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg(target_arch = "wasm32")]
 #![allow(non_snake_case)]
 pub use solana_sdk_wasm_js::{

--- a/sdk-wasm-js/src/lib.rs
+++ b/sdk-wasm-js/src/lib.rs
@@ -1,5 +1,5 @@
 //! solana-program Javascript interface
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg(target_arch = "wasm32")]
 
 use {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -29,7 +29,7 @@
 //! [json]: https://solana.com/docs/rpc
 //! [`clap`]: https://docs.rs/clap
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 // Allows macro expansion of `use ::solana_sdk::*` to work within this crate
 extern crate self as solana_sdk;

--- a/secp256k1-program/src/lib.rs
+++ b/secp256k1-program/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 //! Instructions for the [secp256k1 native program][np].
 //!
 //! [np]: https://docs.solanalabs.com/runtime/programs#secp256k1-program

--- a/secp256k1-recover/src/lib.rs
+++ b/secp256k1-recover/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 //! Public key recovery from [secp256k1] ECDSA signatures.
 //!
 //! [secp256k1]: https://en.bitcoin.it/wiki/Secp256k1

--- a/secp256r1-program/src/lib.rs
+++ b/secp256r1-program/src/lib.rs
@@ -9,7 +9,7 @@
 //! This property can be problematic for developers who assume each signature is unique. Without enforcing
 //! low-S values, the same message and key can produce two different valid signatures, potentially breaking
 //! replay protection schemes that rely on signature uniqueness.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 use bytemuck::{Pod, Zeroable};
 pub use solana_sdk_ids::secp256r1_program::{check_id, id, ID};
 

--- a/seed-derivable/src/lib.rs
+++ b/seed-derivable/src/lib.rs
@@ -1,5 +1,5 @@
 //! The interface by which keys are derived.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 use {solana_derivation_path::DerivationPath, std::error};
 
 /// The `SeedDerivable` trait defines the interface by which cryptographic keys/keypairs are

--- a/seed-phrase/src/lib.rs
+++ b/seed-phrase/src/lib.rs
@@ -1,5 +1,5 @@
 //! Functions for generating keypairs from seed phrases.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 use hmac::Hmac;
 
 pub fn generate_seed_from_seed_phrase_and_passphrase(

--- a/serde-varint/src/lib.rs
+++ b/serde-varint/src/lib.rs
@@ -1,5 +1,5 @@
 //! Integers that serialize to variable size.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::arithmetic_side_effects)]
 use {
     serde::{

--- a/serde/src/lib.rs
+++ b/serde/src/lib.rs
@@ -1,5 +1,5 @@
 //! Serde helpers.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use serde::{Deserialize, Deserializer};
 

--- a/serialize-utils/src/lib.rs
+++ b/serialize-utils/src/lib.rs
@@ -1,6 +1,6 @@
 //! Helpers for reading and writing bytes.
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::arithmetic_side_effects)]
 use {solana_pubkey::Pubkey, solana_sanitize::SanitizeError};
 

--- a/sha256-hasher/src/lib.rs
+++ b/sha256-hasher/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(any(target_os = "solana", target_arch = "bpf"))]
 pub use solana_define_syscall::definitions::sol_sha256;

--- a/short-vec/src/lib.rs
+++ b/short-vec/src/lib.rs
@@ -1,6 +1,6 @@
 //! Compact serde-encoding of vectors with small length.
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::arithmetic_side_effects)]
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::AbiExample;

--- a/shred-version/src/lib.rs
+++ b/shred-version/src/lib.rs
@@ -1,7 +1,7 @@
 //! Calculation of [shred] versions.
 //!
 //! [shred]: https://solana.com/docs/terminology#shred
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use {solana_hard_forks::HardForks, solana_hash::Hash, solana_sha256_hasher::hashv};
 

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -1,6 +1,6 @@
 //! 64-byte signature type.
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #[cfg(any(test, feature = "verify"))]
 use core::convert::TryInto;

--- a/signer-store/src/lib.rs
+++ b/signer-store/src/lib.rs
@@ -35,7 +35,7 @@
 //!     original number of bits (i.e., the length of the input vectors; not the
 //!     length of the final vector).
 //! 3.  **Data Payload**: A sequence of bytes containing the packed base-3 digits.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use {
     bitvec::prelude::*,

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -1,5 +1,5 @@
 //! Abstractions and implementations for transaction signers.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 use {
     core::fmt,
     solana_pubkey::Pubkey,

--- a/slot-hashes/src/lib.rs
+++ b/slot-hashes/src/lib.rs
@@ -5,7 +5,7 @@
 //! The sysvar ID is declared in [`solana_program::sysvar::slot_hashes`].
 //!
 //! [`solana_program::sysvar::slot_hashes`]: https://docs.rs/solana-program/latest/solana_program/sysvar/slot_hashes/index.html
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "sysvar")]
 pub mod sysvar;

--- a/slot-history/src/lib.rs
+++ b/slot-history/src/lib.rs
@@ -7,7 +7,7 @@
 //! [`sysvar::slot_history`]: https://docs.rs/solana-program/latest/solana_program/sysvar/slot_history
 
 #![allow(clippy::arithmetic_side_effects)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "sysvar")]
 pub mod sysvar;

--- a/stable-layout/src/lib.rs
+++ b/stable-layout/src/lib.rs
@@ -1,7 +1,7 @@
 //! Types with stable memory layouts
 //!
 //! Internal use only; here be dragons!
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod stable_instruction;
 pub mod stable_rc;

--- a/system-interface/src/lib.rs
+++ b/system-interface/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/system-transaction/src/lib.rs
+++ b/system-transaction/src/lib.rs
@@ -1,5 +1,5 @@
 //! The `system_transaction` module provides functionality for creating system transactions.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use {
     solana_hash::Hash, solana_keypair::Keypair, solana_message::Message, solana_pubkey::Pubkey,

--- a/system-wasm-js/src/lib.rs
+++ b/system-wasm-js/src/lib.rs
@@ -1,6 +1,6 @@
 //! `SystemInstruction` Javascript interface
 #![cfg(target_arch = "wasm32")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(non_snake_case)]
 use {
     solana_sdk_wasm_js::{address::Address, instruction::Instruction},

--- a/sysvar-id/src/lib.rs
+++ b/sysvar-id/src/lib.rs
@@ -17,7 +17,7 @@
 //! For more details see the Solana [documentation on sysvars][sysvardoc].
 //!
 //! [sysvardoc]: https://docs.solanalabs.com/runtime/sysvars
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![no_std]
 
 /// Re-export types required for macros

--- a/sysvar/src/lib.rs
+++ b/sysvar/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 //! Access to special accounts with dynamically-updated data.
 //!

--- a/time-utils/src/lib.rs
+++ b/time-utils/src/lib.rs
@@ -1,5 +1,5 @@
 //! `std::time` utility functions.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 use std::{
     sync::atomic::{AtomicU64, Ordering},
     time::{Duration, SystemTime, UNIX_EPOCH},

--- a/transaction-error/src/lib.rs
+++ b/transaction-error/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "frozen-abi")]

--- a/transaction/src/lib.rs
+++ b/transaction/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 //! Atomically-committed sequences of instructions.
 //!
 //! While [`Instruction`]s are the basic unit of computation in Solana, they are

--- a/validator-exit/src/lib.rs
+++ b/validator-exit/src/lib.rs
@@ -1,5 +1,5 @@
 //! Used by validators to run events on exit.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use std::fmt;
 

--- a/vote-interface/src/lib.rs
+++ b/vote-interface/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 //! The [vote native program][np].
 //!


### PR DESCRIPTION
#### Problem

The docs builds are currently failing due to the changes in <https://github.com/rust-lang/rust/pull/138907>.

#### Summary of changes

As recommended there, use `doc_cfg` instead of `doc_auto_cfg`.