### PR TITLE
ci: Invert crate-type test on semver check

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -171,26 +171,26 @@ jobs:
         with:
           tool: toml-cli,cargo-semver-checks,cargo-release
 
-      - name: Check if crate has a lib target
-        id: has_lib
+      - name: Check if crate is a procedural macro
+        id: is_proc_macro
         shell: bash
         run: |
           set +e # toml crashes the whole shell if it fails to find the key
           result=$(toml get "${{ inputs.package-path }}/Cargo.toml" lib.crate-type)
-          if [[ "$result" == *"lib"* ]]; then
-            echo "has_lib=true" >> "$GITHUB_OUTPUT"
+          if [[ "$result" == *"proc-macro"* ]]; then
+            echo "is_proc_macro=true" >> "$GITHUB_OUTPUT"
           else
-            echo "has_lib=false" >> "$GITHUB_OUTPUT"
+            echo "is_proc_macro=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Set Git Author (required for cargo-release)
-        if: ${{ steps.has_lib.outputs.has_lib == 'true' }}
+        if: ${{ steps.is_proc_macro.outputs.is_proc_macro == 'false' }}
         run: |
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
       - name: Set Version
-        if: ${{ steps.has_lib.outputs.has_lib == 'true' }}
+        if: ${{ steps.is_proc_macro.outputs.is_proc_macro == 'false' }}
         run: |
           if [ "${{ inputs.level }}" == "version" ]; then
             LEVEL=${{ inputs.version }}
@@ -200,7 +200,7 @@ jobs:
           cargo release $LEVEL --manifest-path "${{ inputs.package_path }}/Cargo.toml" --no-tag --no-publish --no-push --no-confirm --execute
 
       - name: Check semver
-        if: ${{ steps.has_lib.outputs.has_lib == 'true' }}
+        if: ${{ steps.is_proc_macro.outputs.is_proc_macro == 'false' }}
         run: cargo semver-checks --manifest-path "${{ inputs.package_path }}/Cargo.toml"
 
   publish-crate:


### PR DESCRIPTION
### Problem

Currently, the semver check on the publish workflow skips crates that do not have a `crate-type` set to `"lib"`. Since the majority of crates do not have a `crate-type` set, this means that semver check is not performed.

### Solution

Invert the check to detect if a crate is a `proc-macro` instead, which will then be skipped. 

A successful run can be seen here: https://github.com/febo/solana-sdk/actions/runs/18980699432/job/54212177213

And a run where it is skipped since the crate is a proc-macro: https://github.com/febo/solana-sdk/actions/runs/18986872354/job/54232342051