### PR TITLE
Update proc-macro2 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2031,9 +2031,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
### Problem

As pointed out in Jon's [comment](https://github.com/anza-xyz/solana-sdk/pull/413#pullrequestreview-3402099061), the doc generation is broken with the latest nightly version because of the `proc-macro2` crate. The problem can be seen here:

https://github.com/anza-xyz/solana-sdk/actions/runs/18995795556/job/54255414006

### Solution

Bump the version of `proc-macro2` on the lock file so docs.rs build succeeds.