### PR TITLE
Bump rust version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.89.0"


### PR DESCRIPTION
### Problem

The last version of `cargo-semver-checks` now requires Rust `v1.89` but the workspace is using   `v1.88`.

### Solution

Update the workspace to `v1.89`. This fixes the issue with `semver-checks`: https://github.com/febo/solana-sdk/actions/runs/19038798216/job/54370066309