### PR TITLE
epoch-stake: Make the crate `no_std`

### DIFF
--- a/epoch-stake/src/lib.rs
+++ b/epoch-stake/src/lib.rs
@@ -4,6 +4,7 @@
 //! current epoch or the stake for a specific vote account using the
 //! `sol_get_epoch_stake` syscall.
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![no_std]
 
 use solana_pubkey::Pubkey;
 
@@ -22,7 +23,7 @@ fn get_epoch_stake(var_addr: *const u8) -> u64 {
 
 /// Get the current epoch's total stake.
 pub fn get_epoch_total_stake() -> u64 {
-    get_epoch_stake(std::ptr::null::<Pubkey>() as *const u8)
+    get_epoch_stake(core::ptr::null::<Pubkey>() as *const u8)
 }
 
 /// Get the current epoch stake for a given vote address.

--- a/scripts/check-no-std.sh
+++ b/scripts/check-no-std.sh
@@ -17,6 +17,7 @@ no_std_crates=(
   -p solana-epoch-info
   -p solana-epoch-rewards
   -p solana-epoch-schedule
+  -p solana-epoch-stake
   -p solana-fee-calculator
   -p solana-hash
   -p solana-keccak-hasher


### PR DESCRIPTION
Use `core::ptr` instead of `std::ptr` and mark the crate as `no_std`.