### PR TITLE
Fix hasher performance degredation caused by rust upgrade

### DIFF
--- a/sha256-hasher/src/lib.rs
+++ b/sha256-hasher/src/lib.rs
@@ -20,14 +20,19 @@ pub struct Hasher {
 
 #[cfg(all(feature = "sha2", not(any(target_os = "solana", target_arch = "bpf"))))]
 impl Hasher {
+    #[inline(always)]
     pub fn hash(&mut self, val: &[u8]) {
         self.hasher.update(val);
     }
+
+    #[inline(always)]
     pub fn hashv(&mut self, vals: &[&[u8]]) {
         for val in vals {
             self.hash(val);
         }
     }
+
+    #[inline(always)]
     pub fn result(self) -> Hash {
         let bytes: [u8; HASH_BYTES] = self.hasher.finalize().into();
         bytes.into()


### PR DESCRIPTION
#### Problem Statement:
When upgrading Rust from 1.86 to 1.87, it was found the performance of the PoH hashing degraded. Since then, all rust upgrades have been blocked.

#### Solution
After analysis it was found that inlining differences during the LLVM compilation were causing the performance difference. By force inlining the performance improved in current nightly to better than 1.87

Results were verified with proof of hash bench:
1.86 without force inline
```
test bench_poh_hash                   ... bench:   1,397,297.50 ns/iter (+/- 4,870.21)
```

1.86 with force inline
```
test bench_poh_hash                   ... bench:   1,391,815.20 ns/iter (+/- 2,922.94)
```

nightly without force inline
```
test bench_poh_hash                   ... bench:   1,474,467.60 ns/iter (+/- 6,121.96)
```

nightly with force inline
```
test bench_poh_hash                   ... bench:   1,348,648.70 ns/iter (+/- 2,663.92)
```

And on chain:

Below shows performance with nightly
Before the restart, nightly without the fix is running. 
After the restart, nightly with the fix is running.
It is also better than 1.86 (which is not shown on the graph)
<img width="1638" height="342" alt="Image" src="https://github.com/user-attachments/assets/1e66ae74-8e01-4017-b4e3-a664ac8d47ed" />

https://github.com/anza-xyz/agave/issues/8869