### PR TITLE
v3: CI: Pin cargo-release and cargo-semver-checks

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Install cargo-semver-checks
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-semver-checks,cargo-release
+          tool: cargo-semver-checks@0.44.0,cargo-release@0.25.20
 
       - name: Set Git Author (required for cargo-release)
         run: |


### PR DESCRIPTION
#### Problem

cargo-semver-checks now requires Rust 1.89, but the v3 branch is still on 1.88.

#### Summary of changes

Pin cargo-semver-checks to the last known working version. Do the same with cargo-release, since that just upgraded to Rust 1.89.