### PR TITLE
CI: Remove disabled checks for semver and downstream

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,26 +91,6 @@ jobs:
       - name: Check formatting
         run: ./scripts/check-fmt.sh
 
-  check-downstream-agave:
-    if: false # re-enable after agave uses loader-v3-interface v3
-    name: Cargo check Agave master
-    runs-on: ubuntu-latest
-    needs: [sanity]
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Environment
-        uses: ./.github/actions/setup
-        with:
-          agave: true
-          stable-toolchain: true
-          cargo-cache-key: cargo-downstream-agave-check
-          cargo-cache-fallback-key: cargo-downstream-agave
-
-      - name: Run checks
-        run: ./scripts/check-downstream-agave.sh
-
   clippy:
     name: Clippy
     needs: [sanity]
@@ -181,30 +161,6 @@ jobs:
 
       - name: Run cargo-audit
         run: ./scripts/check-audit.sh
-
-  semver:
-    if: false # enable after 2.2.0 is cut
-    name: Check semver
-    runs-on: ubuntu-latest
-    needs: [sanity]
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Environment
-        uses: ./.github/actions/setup
-        with:
-          stable-toolchain: true
-          cargo-cache-key: cargo-stable-semver
-          cargo-cache-fallback-key: cargo-stable
-
-      - name: Install cargo-semver-checks
-        uses: taiki-e/cache-cargo-install-action@v2
-        with:
-          tool: cargo-semver-checks
-
-      - name: Run semver checks
-        run: ./scripts/check-semver.sh
 
   check:
     name: Cargo hack check

--- a/scripts/check-semver.sh
+++ b/scripts/check-semver.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -eo pipefail
-here="$(dirname "$0")"
-src_root="$(readlink -f "${here}/..")"
-cd "${src_root}"
-
-cargo semver-checks


### PR DESCRIPTION
#### Problem

The main CI job has two jobs disabled: semver-checks and downstream agave checks.

The semver-checks job on every PR is more trouble than it's worth, so we only run it before publishing, when semver breakage truly matters.

The downstream Agave check has a similar problem, where it quickly goes red.

#### Summary of changes

Just remove them. I kept the downstream testing script, since it can still be useful in certain situations, just not in CI. The semver-check script is pretty useless though, so I removed that.