### PR TITLE
v2: CI: Pin cargo-release in publish job

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Install cargo-release
         uses: taiki-e/cache-cargo-install-action@v2
         with:
-          tool: cargo-release
+          tool: cargo-release@0.25.18
 
       - name: Ensure CARGO_REGISTRY_TOKEN variable is set
         env:


### PR DESCRIPTION
#### Problem

The publish job is failing because cargo-release requires a newer version of Rust.

#### Summary of changes

Pin cargo-release. This only worked based on luck during the previous CI run, where we were able to restore the cargo-release binary from a cache, which didn't require building it.