### PR TITLE
Publish solana-sha256-hasher v3.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3716,7 +3716,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sha256-hasher"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "sha2",
  "solana-define-syscall",

--- a/sha256-hasher/Cargo.toml
+++ b/sha256-hasher/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-sha256-hasher"
 description = "Solana SHA256 hashing"
 documentation = "https://docs.rs/solana-sha256-hasher"
-version = "3.0.0"
+version = "3.0.1"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }


### PR DESCRIPTION
#### Problem

We published sha256-hasher v3.0.1 from the maintenance/v3.x branch to avoid picking up solana-hash v4, which would make it harder for agave to start using the change immediately. However, this means that master is actually *behind* the maintenance branch, which would cause an issue if we try to publish from master.

#### Summary of changes

Just cherry-pick the last commit from maintenance/v3.x which contains the version bump.