### PR TITLE
Fixate serde version in 2.x (currently causing all new anchor programs to be broken)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,10 +192,10 @@ quote = "1.0.35"
 rand = "0.8.5"
 rand0-7 = { package = "rand", version = "0.7" }
 reqwest = { version = "0.11.27", default-features = false }
-serde = "1.0.217" # must match the serde_derive version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
+serde = "=1.0.217" # must match the serde_derive version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
 serde-big-array = "0.5.1"
 serde_bytes = "0.11.15"
-serde_derive = "1.0.217" # must match the serde version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
+serde_derive = "=1.0.217" # must match the serde version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
 serde_json = "1.0.139"
 serde_with = { version = "3.12.0", default-features = false }
 serial_test = "2.0.0"


### PR DESCRIPTION
`solana-instruction v2.3.2`  was released a few hours ago, which when using the `serde` feature tries to access stuff via `serde::__private::...`. Unfortunately, `__private` is no longer accessible in newer serde versions as of https://github.com/serde-rs/serde/pull/2980 (and instead requires the patch version to be specified too, e.g. `__private123` for patch 123). This isn't visible in this crate as the `Cargo.lock` file prevents it from updating, but in crates that depend on it and don't have a lockfile yet (e.g. a [new anchor project spawned with `anchor init`](https://github.com/solana-foundation/anchor/issues/4045)), it will default to the latest solana-instruction and serde version, which will spit out a million errors like the below:

```
error[E0433]: failed to resolve: could not find `__private` in `_serde`
    --> src/error.rs:1096:37
     |
1096 | ...                   _serde::__private::Ok(InstructionError::BorshIoError(
     |                               ^^^^^^^^^ could not find `__private` in `_serde`

error[E0433]: failed to resolve: could not find `__private` in `_serde`
    --> src/error.rs:1104:37
     |
1104 | ...                   _serde::__private::Ok(InstructionError::AccountNotRentExempt)
     |                               ^^^^^^^^^ could not find `__private` in `_serde`

error[E0433]: failed to resolve: could not find `__private` in `_serde`
    --> src/error.rs:1108:37
     |
1108 | ...                   _serde::__private::Ok(InstructionError::InvalidAccountOwner)
     |                               ^^^^^^^^^ could not find `__private` in `_serde`

error[E0433]: failed to resolve: could not find `__private` in `_serde`
    --> src/error.rs:1112:37
     |
1112 | ...                   _serde::__private::Ok(InstructionError::ArithmeticOverflow)
     |                               ^^^^^^^^^ could not find `__private` in `_serde`

error[E0433]: failed to resolve: could not find `__private` in `_serde`
    --> src/error.rs:1116:37
     |
1116 | ...                   _serde::__private::Ok(InstructionError::UnsupportedSysvar)
     |                               ^^^^^^^^^ could not find `__private` in `_serde`

error[E0433]: failed to resolve: could not find `__private` in `_serde`
    --> src/error.rs:1120:37
     |
1120 | ...                   _serde::__private::Ok(InstructionError::IllegalOwner)
     |                               ^^^^^^^^^ could not find `__private` in `_serde`

error[E0433]: failed to resolve: could not find `__private` in `_serde`
    --> src/error.rs:1124:37
     |
1124 | ...                   _serde::__private::Ok(
     |                               ^^^^^^^^^ could not find `__private` in `_serde`

error[E0433]: failed to resolve: could not find `__private` in `_serde`
    --> src/error.rs:1130:37
     |
1130 | ...                   _serde::__private::Ok(InstructionError::MaxAccountsExceeded)
     |                               ^^^^^^^^^ could not find `__private` in `_serde`

error[E0433]: failed to resolve: could not find `__private` in `_serde`
    --> src/error.rs:1134:37
     |
1134 | ...                   _serde::__private::Ok(
     |                               ^^^^^^^^^ could not find `__private` in `_serde`

error[E0433]: failed to resolve: could not find `__private` in `_serde`
```

The "right" fix would be to migrate away from using `__private` altogether, however for now this would be a good patch for solana-instruction to get it working for downstream users again. I think it would also make sense to yank 2.3.2.