### PR TITLE
hash: Add semver-checks lints

### DIFF
--- a/hash/Cargo.toml
+++ b/hash/Cargo.toml
@@ -10,6 +10,14 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.cargo-semver-checks.lints]
+# cargo-semver-checks performs checks on the exported symbol graph, so re-exports
+# are considered different elements and they will be flagged as breaking changes
+# even if the public API is equivalent.
+enum_missing = "allow"
+pub_module_level_const_missing = "allow"
+struct_missing = "allow"
+
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 all-features = true


### PR DESCRIPTION
### Problem

The `hash` crate now re-exports the types from `hash@v4` to maintain compatibility between the different major versions. But it is still not possible to publish a patch version from the maintenance/v3.x branch since semver-checks  does not support checking cross-crate elements and reports the re-exports as missing/breaking changes.

This is known limitation of semver-cheks:
* https://github.com/obi1kenobi/cargo-semver-checks/issues/638
* https://rust-lang.github.io/rust-project-goals/2024h2/cargo-semver-checks.html

### Solution

Disable the semver-checks lints for the `hash` crate so the re-exported elements are not flagged as missing.

Unsuccessful semver-checks (current): https://github.com/anza-xyz/solana-sdk/actions/runs/19088345538/job/54533431155

Successful semver-checks (this PR): https://github.com/febo/solana-sdk/actions/runs/19100305658/job/54570359447