### PR TITLE
fix(transaction): apply features to `solana-transaction-error` dep

### DIFF
--- a/transaction/Cargo.toml
+++ b/transaction/Cargo.toml
@@ -23,7 +23,11 @@ bincode = [
 ]
 blake3 = ["bincode", "solana-message/blake3"]
 dev-context-only-utils = ["blake3", "serde", "verify", "solana-hash/atomic"]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "solana-transaction-error/frozen-abi"]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-transaction-error/frozen-abi",
+]
 serde = [
     "dep:serde",
     "dep:serde_derive",


### PR DESCRIPTION
When the `serde` feature is applied to the `solana-transaction` it should also be applied to `solana-transaction-error`. 

Also do the same for the `frozen-abi` feature.