### PR TITLE
ci: Fix proc-macro test on publish

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -176,7 +176,7 @@ jobs:
         shell: bash
         run: |
           set +e # toml crashes the whole shell if it fails to find the key
-          result=$(toml get "${{ inputs.package-path }}/Cargo.toml" lib.proc-macro)
+          result=$(toml get "${{ inputs.package_path }}/Cargo.toml" lib.proc-macro)
           if [[ "$result" == *"true"* ]]; then
             echo "is_proc_macro=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
### Problem

#417 inverted the proc-macro test so semver-checks would run on library crates, but it broke the test for proc-macro crates.

### Solution

Modify the test to look for a `"proc-macro"` attribute under the `"[lib]"` section. It also fixes a typo that made the test to (incorrectly) run on any crate:
* `inputs.package-path` -> `inputs.package_path`

The problem with the current behaviour can be seen here: https://github.com/anza-xyz/solana-sdk/actions/runs/19166485673/job/54788310868

A successful run on a proc-macro crate: https://github.com/febo/solana-sdk/actions/runs/19168994216/job/54796492385

A successful run on a lib crate: https://github.com/febo/solana-sdk/actions/runs/19169075552/job/54796765269