### PR TITLE
program-log: Add cfg for 128-bits types

### DIFF
--- a/program-log/src/lib.rs
+++ b/program-log/src/lib.rs
@@ -473,14 +473,9 @@ mod tests {
             };
         }
 
-        unsigned_test_case!(
-            (u8, 3),
-            (u16, 5),
-            (u32, 10),
-            (u64, 20),
-            (u128, 39),
-            (usize, 20)
-        );
+        unsigned_test_case!((u8, 3), (u16, 5), (u32, 10), (u64, 20), (usize, 20));
+        #[cfg(not(target_arch = "bpf"))]
+        unsigned_test_case!((u128, 39),);
     }
 
     #[test]
@@ -516,14 +511,9 @@ mod tests {
             };
         }
 
-        signed_test_case!(
-            (i8, 3),
-            (i16, 5),
-            (i32, 10),
-            (i64, 20),
-            (i128, 39),
-            (isize, 20)
-        );
+        signed_test_case!((i8, 3), (i16, 5), (i32, 10), (i64, 20), (isize, 20));
+        #[cfg(not(target_arch = "bpf"))]
+        signed_test_case!((i128, 39),);
     }
 
     #[test]

--- a/program-log/src/logger.rs
+++ b/program-log/src/logger.rs
@@ -378,8 +378,9 @@ impl_log_for_unsigned_integer!(u8);
 impl_log_for_unsigned_integer!(u16);
 impl_log_for_unsigned_integer!(u32);
 impl_log_for_unsigned_integer!(u64);
-impl_log_for_unsigned_integer!(u128);
 impl_log_for_unsigned_integer!(usize);
+#[cfg(not(target_arch = "bpf"))]
+impl_log_for_unsigned_integer!(u128);
 
 /// Implement the log trait for the signed integer types.
 macro_rules! impl_log_for_signed {
@@ -435,8 +436,9 @@ impl_log_for_signed!(i8);
 impl_log_for_signed!(i16);
 impl_log_for_signed!(i32);
 impl_log_for_signed!(i64);
-impl_log_for_signed!(i128);
 impl_log_for_signed!(isize);
+#[cfg(not(target_arch = "bpf"))]
+impl_log_for_signed!(i128);
 
 /// Implement the log trait for the `&str` type.
 unsafe impl Log for &str {


### PR DESCRIPTION
### Problem

While program-log "claims" to be upstream BPF compatible, it uses `u128`/`i128` types which are not supported.

### Solution

Any code that references `u128/`i128` is now behind a `#[cfg(not(target_arch = "bpf"))]`.