### PR TITLE
frozen-abi: check actual ABI compatibility ( agave issue #8091 )

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3050,6 +3050,7 @@ dependencies = [
  "im",
  "log",
  "memmap2",
+ "rand",
  "serde",
  "serde_bytes",
  "serde_derive",

--- a/frozen-abi/Cargo.toml
+++ b/frozen-abi/Cargo.toml
@@ -37,6 +37,7 @@ thiserror = { workspace = true }
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 im = { workspace = true, features = ["rayon", "serde"] }
 memmap2 = { workspace = true }
+rand = { workspace = true }
 
 [target.'cfg(not(target_os = "solana"))'.dev-dependencies]
 bitflags = { workspace = true, features = ["serde"] }

--- a/frozen-abi/src/lib.rs
+++ b/frozen-abi/src/lib.rs
@@ -10,7 +10,10 @@ pub mod abi_digester;
 #[cfg(feature = "frozen-abi")]
 pub mod abi_example;
 #[cfg(feature = "frozen-abi")]
-mod hash;
+pub mod hash;
+#[cfg(feature = "frozen-abi")]
+#[cfg(not(target_os = "solana"))]
+pub mod stable_abi;
 
 #[cfg(feature = "frozen-abi")]
 #[macro_use]

--- a/frozen-abi/src/stable_abi.rs
+++ b/frozen-abi/src/stable_abi.rs
@@ -1,0 +1,10 @@
+use rand::{distributions::Standard, Rng, RngCore};
+
+pub trait StableAbi: Sized {
+    fn random(rng: &mut impl RngCore) -> Self
+    where
+        Standard: rand::distributions::Distribution<Self>,
+    {
+        rng.gen::<Self>()
+    }
+}

--- a/scripts/test-frozen-abi.sh
+++ b/scripts/test-frozen-abi.sh
@@ -5,4 +5,5 @@ here="$(dirname "$0")"
 src_root="$(readlink -f "${here}/..")"
 cd "${src_root}"
 
-./cargo nightly hack --features frozen-abi --ignore-unknown-features test --lib -- test_abi_ --nocapture
+./cargo nightly hack --features frozen-abi --ignore-unknown-features test --lib -- test_abi_digest --nocapture
+./cargo nightly hack --features frozen-abi --ignore-unknown-features test --lib -- test_api_digest --nocapture


### PR DESCRIPTION
#### Problem

> Frozen ABI does not actually check ABI and checks API compatibility instead

[agave#8091](https://github.com/anza-xyz/agave/issues/8091)

#### Summary of Changes
Frozen ABI now supports both API compatibility checks and ABI stability checks.
- Introduced the new `StableAbi` trait.
- Updated macros to generate ABI tests conditionally.
- Added a `test_abi_` test that compares the provided abi_digest with a deterministically computed digest based on hashing multiple randomized instances of the tested type.

Its backward compatible drop-in, with optional abi compatibility check.
[example of use](https://github.com/anza-xyz/solana-sdk/pull/459/files#diff-6468a960878ea059c99ec897f59740910b7206e270eab369c147a2688830eacc)