### PR TITLE
Remove too granular Copy implementation

### DIFF
--- a/address/src/lib.rs
+++ b/address/src/lib.rs
@@ -91,8 +91,7 @@ pub const PDA_MARKER: &[u8; 21] = b"ProgramDerivedAddress";
 #[cfg_attr(feature = "bytemuck", derive(Pod, Zeroable))]
 #[cfg_attr(feature = "dev-context-only-utils", derive(Arbitrary))]
 #[cfg_attr(not(feature = "decode"), derive(Debug))]
-#[cfg_attr(feature = "copy", derive(Copy))]
-#[derive(Clone, Default, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Default, Eq, Ord, PartialEq, PartialOrd, Copy)]
 pub struct Address(pub(crate) [u8; 32]);
 
 #[cfg(feature = "sanitize")]


### PR DESCRIPTION
Since an Address is a wrapper type around a Copy type ([u8;32]) it uselessly break older user-code during crates upgrade which didn't required `copy` in older version of the crate. Moreover the feature-flag `copy` is not documented in the documentation