### PR TITLE
vote: use `InvalidAccountData` for v0_23_5 vsv deserializing

### DIFF
--- a/vote-interface/src/state/vote_state_versions.rs
+++ b/vote-interface/src/state/vote_state_versions.rs
@@ -152,7 +152,7 @@ impl VoteStateVersions {
         let variant = solana_serialize_utils::cursor::read_u32(&mut cursor)?;
         match variant {
             // V0_23_5 not supported.
-            0 => Err(InstructionError::UninitializedAccount),
+            0 => Err(InstructionError::InvalidAccountData),
             // V1_14_11
             1 => {
                 let mut vote_state = Box::new(MaybeUninit::uninit());


### PR DESCRIPTION
In FD, we have `get_state()` implemented and used instead of implementing Agave's custom deserializers for vote states. To simplify the deserialization logic, `InvalidAccountData` should be thrown to match the error semantics of `get_state()` in fuzz-generated cases where v0_23_5 vote accounts have invalid data.