### PR TITLE
shred-version: Move test over from Agave

### DIFF
--- a/shred-version/Cargo.toml
+++ b/shred-version/Cargo.toml
@@ -17,5 +17,8 @@ solana-hard-forks = { workspace = true }
 solana-hash = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 
+[dev-dependencies]
+solana-sha256-hasher = { workspace = true, features = ["sha2"] }
+
 [lints]
 workspace = true

--- a/shred-version/src/lib.rs
+++ b/shred-version/src/lib.rs
@@ -40,6 +40,29 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_version_from_hash() {
+        let hash = [
+            0xa5u8, 0xa5, 0x5a, 0x5a, 0xa5, 0xa5, 0x5a, 0x5a, 0xa5, 0xa5, 0x5a, 0x5a, 0xa5, 0xa5,
+            0x5a, 0x5a, 0xa5, 0xa5, 0x5a, 0x5a, 0xa5, 0xa5, 0x5a, 0x5a, 0xa5, 0xa5, 0x5a, 0x5a,
+            0xa5, 0xa5, 0x5a, 0x5a,
+        ];
+        let version = version_from_hash(&Hash::new_from_array(hash));
+        assert_eq!(version, 1);
+        let hash = [
+            0xa5u8, 0xa5, 0x5a, 0x5a, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        let version = version_from_hash(&Hash::new_from_array(hash));
+        assert_eq!(version, 0xffff);
+        let hash = [
+            0xa5u8, 0xa5, 0x5a, 0x5a, 0xa5, 0xa5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        let version = version_from_hash(&Hash::new_from_array(hash));
+        assert_eq!(version, 0x5a5b);
+    }
+
+    #[test]
     fn test_compute_shred_version() {
         assert_eq!(compute_shred_version(&Hash::default(), None), 1);
         let mut hard_forks = HardForks::default();


### PR DESCRIPTION
This test currently lives in `solana-ledger` crate; however, the test is for logic in the `solana-shred-version` crate in this repo so the test should live here. The test will be deleted from Agave after this PR merges.

Agave permalink:
https://github.com/anza-xyz/agave/blob/6545467a8981b758101eb7cc36aef2064e431ecc/ledger/src/shred.rs#L1067-L1088