### PR TITLE
ci: Pin cargo-release version

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -224,7 +224,7 @@ jobs:
           cargo-cache-fallback-key: cargo-stable
 
       - name: Install cargo-release
-        uses: taiki-e/cache-cargo-install-action@v2
+        uses: taiki-e/install-action@v2
         with:
           tool: cargo-release
 


### PR DESCRIPTION
### Problem

Currently the publish workflow is failing since the latest `cargo-release` version requires Rust `1.90.0` to build it.

### Solution

Switch the action to `taiki-e/install-action@v2` so the binary is used.