### PR TITLE
sysvar: Fix UB in sysvar loading

### DIFF
--- a/sysvar/src/clock.rs
+++ b/sysvar/src/clock.rs
@@ -130,11 +130,15 @@ pub use {
 };
 
 impl Sysvar for Clock {
-    impl_sysvar_get!(id());
-}
+    #[cfg(not(feature = "bincode"))]
+    impl_sysvar_get!(sol_get_clock_sysvar);
+    #[cfg(feature = "bincode")]
+    impl_sysvar_get!(id(), SERIALIZED_SIZE);}
 
 #[cfg(feature = "bincode")]
 impl SysvarSerialize for Clock {}
+
+const SERIALIZED_SIZE: usize = 40;
 
 #[cfg(test)]
 mod tests {
@@ -199,5 +203,12 @@ mod tests {
         assert_eq!(got, expected);
 
         let _ = crate::program_stubs::set_syscall_stubs(prev);
+    }
+
+    #[cfg(feature = "bincode")]
+    #[test]
+    fn test_clock_sysvar_size() {
+        let clock = Clock::default();
+        assert_eq!(bincode::serialized_size(&clock).unwrap(), SERIALIZED_SIZE as u64);
     }
 }

--- a/sysvar/src/epoch_rewards.rs
+++ b/sysvar/src/epoch_rewards.rs
@@ -163,11 +163,16 @@ pub use {
 };
 
 impl Sysvar for EpochRewards {
-    impl_sysvar_get!(id());
+    #[cfg(not(feature = "bincode"))]
+    impl_sysvar_get!(sol_get_epoch_rewards_sysvar);
+    #[cfg(feature = "bincode")]
+    impl_sysvar_get!(id(), SERIALIZED_SIZE);
 }
 
 #[cfg(feature = "bincode")]
 impl SysvarSerialize for EpochRewards {}
+
+const SERIALIZED_SIZE: usize = 81;
 
 #[cfg(test)]
 mod tests {
@@ -191,5 +196,12 @@ mod tests {
 
         let got = EpochRewards::get().unwrap();
         assert_eq!(got, expected);
+    }
+
+    #[cfg(feature = "bincode")]
+    #[test]
+    fn test_epoch_rewards_sysvar_size() {
+        let rewards = EpochRewards::default();
+        assert_eq!(bincode::serialized_size(&rewards).unwrap(), SERIALIZED_SIZE as u64);
     }
 }

--- a/sysvar/src/epoch_schedule.rs
+++ b/sysvar/src/epoch_schedule.rs
@@ -128,11 +128,16 @@ pub use {
 };
 
 impl Sysvar for EpochSchedule {
-    impl_sysvar_get!(id());
+    #[cfg(not(feature = "bincode"))]
+    impl_sysvar_get!(sol_get_epoch_schedule_sysvar);
+    #[cfg(feature = "bincode")]
+    impl_sysvar_get!(id(), SERIALIZED_SIZE);
 }
 
 #[cfg(feature = "bincode")]
 impl SysvarSerialize for EpochSchedule {}
+
+const SERIALIZED_SIZE: usize = 33;
 
 #[cfg(test)]
 mod tests {
@@ -147,5 +152,15 @@ mod tests {
 
         let got = EpochSchedule::get().unwrap();
         assert_eq!(got, expected);
+    }
+
+    #[cfg(feature = "bincode")]
+    #[test]
+    fn test_epoch_schedule_sysvar_size() {
+        let schedule = EpochSchedule::default();
+        assert_eq!(
+            bincode::serialized_size(&schedule).unwrap(),
+            SERIALIZED_SIZE as u64
+        );
     }
 }

--- a/sysvar/src/last_restart_slot.rs
+++ b/sysvar/src/last_restart_slot.rs
@@ -45,11 +45,15 @@ pub use {
 };
 
 impl Sysvar for LastRestartSlot {
-    impl_sysvar_get!(id());
-}
+    #[cfg(not(feature = "bincode"))]
+    impl_sysvar_get!(sol_get_last_restart_slot);
+    #[cfg(feature = "bincode")]
+    impl_sysvar_get!(id(), SERIALIZED_SIZE);}
 
 #[cfg(feature = "bincode")]
 impl SysvarSerialize for LastRestartSlot {}
+
+const SERIALIZED_SIZE: usize = 8;
 
 #[cfg(test)]
 mod tests {
@@ -66,5 +70,16 @@ mod tests {
 
         let got = LastRestartSlot::get().unwrap();
         assert_eq!(got, expected);
+    }
+
+
+    #[cfg(feature = "bincode")]
+    #[test]
+    fn test_last_restart_slot_sysvar_size() {
+        let slot = LastRestartSlot::default();
+        assert_eq!(
+            bincode::serialized_size(&slot).unwrap(),
+            SERIALIZED_SIZE as u64
+        );
     }
 }

--- a/sysvar/src/rent.rs
+++ b/sysvar/src/rent.rs
@@ -129,11 +129,16 @@ pub use {
     solana_sdk_ids::sysvar::rent::{check_id, id, ID},
 };
 impl Sysvar for Rent {
-    impl_sysvar_get!(id());
+    #[cfg(not(feature = "bincode"))]
+    impl_sysvar_get!(sol_get_rent_sysvar);
+    #[cfg(feature = "bincode")]
+    impl_sysvar_get!(id(), SERIALIZED_SIZE);
 }
 
 #[cfg(feature = "bincode")]
 impl SysvarSerialize for Rent {}
+
+const SERIALIZED_SIZE: usize = 17;
 
 #[cfg(test)]
 mod tests_sysvar_get {
@@ -152,5 +157,19 @@ mod tests_sysvar_get {
 
         let got = Rent::get().unwrap();
         assert_eq!(got, expected);
+    }
+
+    #[cfg(feature = "bincode")]
+    #[test]
+    fn test_rent_sysvar_size() {
+        let rent = Rent {
+            lamports_per_byte_year: 123,
+            exemption_threshold: 2.5,
+            burn_percent: 7,
+        };
+        assert_eq!(
+            bincode::serialized_size(&rent).unwrap(),
+            SERIALIZED_SIZE as u64
+        );
     }
 }


### PR DESCRIPTION
https://github.com/anza-xyz/solana-sdk/pull/257#discussion_r2553138460

Slices must be initialized, but the implementation of `Sysvar::get` creates a `&mut [u8]` from an uninitialized buffer. This causes UB and miscompiles.
Resolve this by introducing a new private function which takes a mutable _pointer_ (may be uninitialized) and use that instead.