### PR TITLE
[bls-signatures] Add support for custom payloads for bls PoP

### DIFF
--- a/bls-signatures/benches/bls_signatures.rs
+++ b/bls-signatures/benches/bls_signatures.rs
@@ -112,15 +112,15 @@ fn bench_key_generation(c: &mut Criterion) {
 // Benchmark for creating and verifying a proof of possession
 fn bench_proof_of_possession(c: &mut Criterion) {
     let keypair = Keypair::new();
-    let pop = keypair.proof_of_possession();
+    let pop = keypair.proof_of_possession(None);
 
     c.bench_function("proof_of_possession_creation", |b| {
-        b.iter(|| black_box(keypair.proof_of_possession()));
+        b.iter(|| black_box(keypair.proof_of_possession(None)));
     });
 
     c.bench_function("proof_of_possession_verification", |b| {
         b.iter(|| {
-            black_box(keypair.public.verify_proof_of_possession(&pop)).unwrap();
+            black_box(keypair.public.verify_proof_of_possession(&pop, None)).unwrap();
         })
     });
 }

--- a/bls-signatures/src/hash.rs
+++ b/bls-signatures/src/hash.rs
@@ -15,7 +15,14 @@ pub fn hash_message_to_point(message: &[u8]) -> G2Projective {
 }
 
 /// Hash a pubkey to a G2 point
-pub(crate) fn hash_pubkey_to_g2(public_key: &PubkeyProjective) -> G2Projective {
-    let pubkey_bytes = public_key.0.to_compressed();
-    G2Projective::hash_to_curve(&pubkey_bytes, POP_DST, &[])
+pub(crate) fn hash_pubkey_to_g2(
+    public_key: &PubkeyProjective,
+    payload: Option<&[u8]>,
+) -> G2Projective {
+    if let Some(bytes) = payload {
+        G2Projective::hash_to_curve(bytes, POP_DST, &[])
+    } else {
+        let public_key_bytes = public_key.0.to_compressed();
+        G2Projective::hash_to_curve(&public_key_bytes, POP_DST, &[])
+    }
 }

--- a/bls-signatures/src/keypair.rs
+++ b/bls-signatures/src/keypair.rs
@@ -53,8 +53,8 @@ impl Keypair {
     }
 
     /// Generate a proof of possession for the given keypair
-    pub fn proof_of_possession(&self) -> ProofOfPossessionProjective {
-        self.secret.proof_of_possession()
+    pub fn proof_of_possession(&self, payload: Option<&[u8]>) -> ProofOfPossessionProjective {
+        self.secret.proof_of_possession(payload)
     }
 
     /// Sign a message using the provided secret key

--- a/bls-signatures/src/secret_key.rs
+++ b/bls-signatures/src/secret_key.rs
@@ -67,10 +67,10 @@ impl SecretKey {
 
     /// Generate a proof of possession for the corresponding pubkey
     #[allow(clippy::arithmetic_side_effects)]
-    pub fn proof_of_possession(&self) -> ProofOfPossessionProjective {
+    pub fn proof_of_possession(&self, payload: Option<&[u8]>) -> ProofOfPossessionProjective {
         let pubkey = PubkeyProjective::from_secret(self);
-        let hashed_pubkey_bytes = hash_pubkey_to_g2(&pubkey);
-        ProofOfPossessionProjective(hashed_pubkey_bytes * self.0)
+        let hashed_point = hash_pubkey_to_g2(&pubkey, payload);
+        ProofOfPossessionProjective(hashed_point * self.0)
     }
 
     /// Sign a message using the provided secret key


### PR DESCRIPTION
#### Problem

Currently, the PoP generation API in the crate doesn't support custom payload. To support https://github.com/solana-foundation/solana-improvement-documents/pull/387 where custom [message](https://github.com/solana-foundation/solana-improvement-documents/pull/387/files#diff-45cf6d94dd49af7b43169bd0433976c0a0596b8d18659267a7cabe37de639ad7R124) is used for domain separation, we need the interface for the caller to generate and verify PoP on custom payload.

#### Summary of Changes

I added a field `payload: Option<&[u8]>` to the PoP generation and verification functions. If this field is `None`, then the functions just use the BLS public key as bytes for the payload. If this field is `Some(...)`, then it uses the provided bytes to generate the message for PoP.