### PR TITLE
Create compose function for `AccountSharedData`

### DIFF
--- a/account/src/lib.rs
+++ b/account/src/lib.rs
@@ -729,6 +729,22 @@ impl AccountSharedData {
             rent_epoch,
         }
     }
+
+    pub fn compose(
+        lamports: u64,
+        data: Vec<u8>,
+        owner: Pubkey,
+        executable: bool,
+        rent_epoch: Epoch,
+    ) -> Self {
+        AccountSharedData {
+            lamports,
+            data: Arc::new(data),
+            owner,
+            executable,
+            rent_epoch,
+        }
+    }
 }
 
 pub type InheritableAccountFields = (u64, Epoch);


### PR DESCRIPTION
**Problem**

We want to remove `fn create` from `WritableAccount`, because the new account format for SVM has only references and does not allow one to create it from owned values, like the function in the trait.

I tracked all monorepo usages, and found that `create` is only used for `AccountSharedData`. There is a single usage for `struct Account`, but all its fields are public, so we can create it directly. See https://github.com/LucasSte/agave/commit/224a93e46f77e80bdae71d54678aefbb946a2a1f

**Solution**

Create `fn compose` in `impl AccountSharedData` to replace `fn create`.