### PR TITLE
[WIP] Use sol_get_sysvar instead of sol_get_<NAME>_sysvar, now with deserialization

### DIFF
--- a/define-syscall/src/definitions.rs
+++ b/define-syscall/src/definitions.rs
@@ -49,12 +49,12 @@ define_syscall!(fn sol_get_return_data(data: *mut u8, length: u64, program_id: *
 // - `is_writable` (`u8`): `true` if the instruction requires the account to be writable
 define_syscall!(fn sol_get_processed_sibling_instruction(index: u64, meta: *mut u8, program_id: *mut u8, data: *mut u8, accounts: *mut u8) -> u64);
 
-// these are to be deprecated once they are superceded by sol_get_sysvar
-define_syscall!(fn sol_get_clock_sysvar(addr: *mut u8) -> u64);
-define_syscall!(fn sol_get_epoch_schedule_sysvar(addr: *mut u8) -> u64);
-define_syscall!(fn sol_get_rent_sysvar(addr: *mut u8) -> u64);
-define_syscall!(fn sol_get_last_restart_slot(addr: *mut u8) -> u64);
-define_syscall!(fn sol_get_epoch_rewards_sysvar(addr: *mut u8) -> u64);
+// these are deprecated - use sol_get_sysvar instead
+define_syscall!(#[deprecated(since = "3.0.0", note = "Use `sol_get_sysvar` with `Clock` sysvar address instead")] fn sol_get_clock_sysvar(addr: *mut u8) -> u64);
+define_syscall!(#[deprecated(since = "3.0.0", note = "Use `sol_get_sysvar` with `EpochSchedule` sysvar address instead")] fn sol_get_epoch_schedule_sysvar(addr: *mut u8) -> u64);
+define_syscall!(#[deprecated(since = "3.0.0", note = "Use `sol_get_sysvar` with `Rent` sysvar address instead")] fn sol_get_rent_sysvar(addr: *mut u8) -> u64);
+define_syscall!(#[deprecated(since = "3.0.0", note = "Use `sol_get_sysvar` with `LastRestartSlot` sysvar address instead")] fn sol_get_last_restart_slot(addr: *mut u8) -> u64);
+define_syscall!(#[deprecated(since = "3.0.0", note = "Use `sol_get_sysvar` with `EpochRewards` sysvar address instead")] fn sol_get_epoch_rewards_sysvar(addr: *mut u8) -> u64);
 
 // this cannot go through sol_get_sysvar but can be removed once no longer in use
 define_syscall!(fn sol_get_fees_sysvar(addr: *mut u8) -> u64);

--- a/define-syscall/src/lib.rs
+++ b/define-syscall/src/lib.rs
@@ -9,7 +9,8 @@ pub mod definitions;
 ))]
 #[macro_export]
 macro_rules! define_syscall {
-    (fn $name:ident($($arg:ident: $typ:ty),*) -> $ret:ty) => {
+    ($(#[$attr:meta])* fn $name:ident($($arg:ident: $typ:ty),*) -> $ret:ty) => {
+        $(#[$attr])*
         #[inline]
         pub unsafe fn $name($($arg: $typ),*) -> $ret {
             // this enum is used to force the hash to be computed in a const context
@@ -23,8 +24,8 @@ macro_rules! define_syscall {
         }
 
     };
-    (fn $name:ident($($arg:ident: $typ:ty),*)) => {
-        define_syscall!(fn $name($($arg: $typ),*) -> ());
+    ($(#[$attr:meta])* fn $name:ident($($arg:ident: $typ:ty),*)) => {
+        define_syscall!($(#[$attr])* fn $name($($arg: $typ),*) -> ());
     }
 }
 
@@ -34,13 +35,14 @@ macro_rules! define_syscall {
 )))]
 #[macro_export]
 macro_rules! define_syscall {
-    (fn $name:ident($($arg:ident: $typ:ty),*) -> $ret:ty) => {
+    ($(#[$attr:meta])* fn $name:ident($($arg:ident: $typ:ty),*) -> $ret:ty) => {
         extern "C" {
+            $(#[$attr])*
             pub fn $name($($arg: $typ),*) -> $ret;
         }
     };
-    (fn $name:ident($($arg:ident: $typ:ty),*)) => {
-        define_syscall!(fn $name($($arg: $typ),*) -> ());
+    ($(#[$attr:meta])* fn $name:ident($($arg:ident: $typ:ty),*)) => {
+        define_syscall!($(#[$attr])* fn $name($($arg: $typ),*) -> ());
     }
 }
 

--- a/sysvar/src/clock.rs
+++ b/sysvar/src/clock.rs
@@ -130,8 +130,94 @@ pub use {
 };
 
 impl Sysvar for Clock {
-    impl_sysvar_get!(sol_get_clock_sysvar);
+    impl_sysvar_get!(id());
 }
 
 #[cfg(feature = "bincode")]
 impl SysvarSerialize for Clock {}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, crate::tests::to_bytes, serial_test::serial};
+
+    #[test]
+    fn test_clock_size_matches_bincode() {
+        // Prove that Clock's in-memory layout matches its bincode serialization,
+        // so we do not need to use define_sysvar_wire.
+        let clock = Clock::default();
+        let in_memory_size = core::mem::size_of::<Clock>();
+
+        #[cfg(feature = "bincode")]
+        {
+            let bincode_size = bincode::serialized_size(&clock).unwrap() as usize;
+            assert_eq!(
+                in_memory_size, bincode_size,
+                "Clock in-memory size ({in_memory_size}) must match bincode size ({bincode_size})",
+            );
+        }
+
+        // Clock is 5 u64s = 40 bytes
+        assert_eq!(in_memory_size, 40);
+    }
+
+    #[test]
+    #[serial]
+    fn test_clock_get_uses_sysvar_syscall() {
+        let expected = Clock {
+            slot: 1,
+            epoch_start_timestamp: 2,
+            epoch: 3,
+            leader_schedule_epoch: 4,
+            unix_timestamp: 5,
+        };
+
+        let data = to_bytes(&expected);
+        crate::tests::mock_get_sysvar_syscall(&data);
+
+        let got = Clock::get().unwrap();
+        assert_eq!(got, expected);
+    }
+
+    struct ValidateIdSyscall {
+        data: Vec<u8>,
+    }
+
+    impl crate::program_stubs::SyscallStubs for ValidateIdSyscall {
+        fn sol_get_sysvar(
+            &self,
+            sysvar_id_addr: *const u8,
+            var_addr: *mut u8,
+            offset: u64,
+            length: u64,
+        ) -> u64 {
+            // Validate that the macro passed the correct sysvar id pointer
+            let passed_id = unsafe { *(sysvar_id_addr as *const solana_pubkey::Pubkey) };
+            assert_eq!(passed_id, id());
+
+            let slice = unsafe { std::slice::from_raw_parts_mut(var_addr, length as usize) };
+            slice.copy_from_slice(
+                &self.data[offset as usize..(offset.saturating_add(length)) as usize],
+            );
+            solana_program_entrypoint::SUCCESS
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_clock_get_passes_correct_sysvar_id() {
+        let expected = Clock {
+            slot: 11,
+            epoch_start_timestamp: 22,
+            epoch: 33,
+            leader_schedule_epoch: 44,
+            unix_timestamp: 55,
+        };
+        let data = to_bytes(&expected);
+        let prev = crate::program_stubs::set_syscall_stubs(Box::new(ValidateIdSyscall { data }));
+
+        let got = Clock::get().unwrap();
+        assert_eq!(got, expected);
+
+        let _ = crate::program_stubs::set_syscall_stubs(prev);
+    }
+}

--- a/sysvar/src/program_stubs.rs
+++ b/sysvar/src/program_stubs.rs
@@ -155,32 +155,6 @@ pub(crate) fn sol_get_sysvar(
         .sol_get_sysvar(sysvar_id_addr, var_addr, offset, length)
 }
 
-pub(crate) fn sol_get_clock_sysvar(var_addr: *mut u8) -> u64 {
-    SYSCALL_STUBS.read().unwrap().sol_get_clock_sysvar(var_addr)
-}
-
-pub(crate) fn sol_get_epoch_schedule_sysvar(var_addr: *mut u8) -> u64 {
-    SYSCALL_STUBS
-        .read()
-        .unwrap()
-        .sol_get_epoch_schedule_sysvar(var_addr)
-}
-
-pub(crate) fn sol_get_fees_sysvar(var_addr: *mut u8) -> u64 {
-    SYSCALL_STUBS.read().unwrap().sol_get_fees_sysvar(var_addr)
-}
-
-pub(crate) fn sol_get_rent_sysvar(var_addr: *mut u8) -> u64 {
-    SYSCALL_STUBS.read().unwrap().sol_get_rent_sysvar(var_addr)
-}
-
-pub(crate) fn sol_get_last_restart_slot(var_addr: *mut u8) -> u64 {
-    SYSCALL_STUBS
-        .read()
-        .unwrap()
-        .sol_get_last_restart_slot(var_addr)
-}
-
 pub fn sol_get_epoch_stake(vote_address: *const u8) -> u64 {
     SYSCALL_STUBS
         .read()
@@ -211,9 +185,6 @@ pub fn sol_get_stack_height() -> u64 {
     SYSCALL_STUBS.read().unwrap().sol_get_stack_height()
 }
 
-pub(crate) fn sol_get_epoch_rewards_sysvar(var_addr: *mut u8) -> u64 {
-    SYSCALL_STUBS
-        .read()
-        .unwrap()
-        .sol_get_epoch_rewards_sysvar(var_addr)
+pub(crate) fn sol_get_fees_sysvar(var_addr: *mut u8) -> u64 {
+    SYSCALL_STUBS.read().unwrap().sol_get_fees_sysvar(var_addr)
 }


### PR DESCRIPTION
[WIP]

This addresses Issue https://github.com/anza-xyz/solana-sdk/issues/235, fixing two issues with the [original](https://github.com/anza-xyz/solana-sdk/pull/257) (reverted) PR:

1. The contract of `from_raw_parts_mut` was being violated, in a way that miri considered safe, but which could have theoretically caused trouble in the future.
2. The implementation assumed that the number of bytes returned by the runtime was exactly
`mem::size_of::<Self>()`, which was not always true. `Rent`, for example, contains a `u64`, an `f64` and a `u8`. In memory the compiler pads this struct to 24 bytes, but the runtime stores its contents as a 17‑byte `bincode` serialization. The `get_sysvar` call thus returns only 17 bytes. Passing a 24‑byte buffer results in an `OFFSET_LENGTH_EXCEEDS_SYSVAR` error and undefined behavior when uninitialized bytes are interpreted as f64.

In order to address this second issue, this PR provides 1‑byte‑aligned representations of the sysvars that match the on‑chain encoding. Then, we can zero-copy the bytes directly into those representations and convert them to the canonical structs without using `bincode`.

This is lightweight but bespoke deserialization to avoid requiring any given dependency.