### PR TITLE
frozen-abi, script:  (bugfix) some frozen-abi tests are not performed

### DIFF
--- a/scripts/test-frozen-abi.sh
+++ b/scripts/test-frozen-abi.sh
@@ -5,5 +5,5 @@ here="$(dirname "$0")"
 src_root="$(readlink -f "${here}/..")"
 cd "${src_root}"
 
-./cargo nightly hack --features frozen-abi --ignore-unknown-features test --lib -- test_abi_digest --nocapture
-./cargo nightly hack --features frozen-abi --ignore-unknown-features test --lib -- test_api_digest --nocapture
+./cargo nightly test --features frozen-abi --lib -- test_abi_digest --nocapture
+./cargo nightly test --features frozen-abi --lib -- test_api_digest --nocapture


### PR DESCRIPTION
#### Problem

After merging https://github.com/anza-xyz/solana-sdk/pull/440 some frozen-abi tests are skipped which results in, not checked digest.

I discovered this issue accidentially on `solana-transaction::Transaction`, where after changing digest, frozen-abi script still pass green.

#### Summary of changes
Brought back `cargo test` instead of `cargo hack`.