### PR TITLE
account: enable frozen-abi StableAbi

### DIFF
--- a/account/src/lib.rs
+++ b/account/src/lib.rs
@@ -7,7 +7,7 @@ use qualifier_attr::qualifiers;
 #[cfg(feature = "serde")]
 use serde::ser::{Serialize, Serializer};
 #[cfg(feature = "frozen-abi")]
-use solana_frozen_abi_macro::{frozen_abi, AbiExample};
+use solana_frozen_abi_macro::{frozen_abi, AbiExample, StableAbi};
 #[cfg(feature = "bincode")]
 use solana_sysvar::SysvarSerialize;
 use {
@@ -25,8 +25,11 @@ pub mod state_traits;
 #[repr(C)]
 #[cfg_attr(
     feature = "frozen-abi",
-    derive(AbiExample),
-    frozen_abi(digest = "62EqVoynUFvuui7DVfqWCvZP7bxKGJGioeSBnWrdjRME")
+    derive(AbiExample, StableAbi),
+    frozen_abi(
+        api_digest = "62EqVoynUFvuui7DVfqWCvZP7bxKGJGioeSBnWrdjRME",
+        abi_digest = "Cms628BvHUgXEPDU1qV6sAXNr875LnMAMLskNohMngu"
+    )
 )]
 #[cfg_attr(
     feature = "serde",
@@ -47,6 +50,21 @@ pub struct Account {
     pub executable: bool,
     /// the epoch at which this account will next owe rent
     pub rent_epoch: Epoch,
+}
+
+#[cfg(feature = "frozen-abi")]
+impl solana_frozen_abi::rand::prelude::Distribution<Account>
+    for solana_frozen_abi::rand::distr::StandardUniform
+{
+    fn sample<R: solana_frozen_abi::rand::Rng + ?Sized>(&self, rng: &mut R) -> Account {
+        Account {
+            lamports: rng.random(),
+            data: (0..1000).map(|_| rng.random()).collect(),
+            owner: Pubkey::new_from_array(rng.random()),
+            executable: rng.random(),
+            rent_epoch: rng.random(),
+        }
+    }
 }
 
 // mod because we need 'Account' below to have the name 'Account' to match expected serialization

--- a/account/src/lib.rs
+++ b/account/src/lib.rs
@@ -7,7 +7,7 @@ use qualifier_attr::qualifiers;
 #[cfg(feature = "serde")]
 use serde::ser::{Serialize, Serializer};
 #[cfg(feature = "frozen-abi")]
-use solana_frozen_abi_macro::{frozen_abi, AbiExample, StableAbi};
+use solana_frozen_abi_macro::{frozen_abi, AbiExample, StableAbi, StableAbiSample};
 #[cfg(feature = "bincode")]
 use solana_sysvar::SysvarSerialize;
 use {
@@ -25,10 +25,10 @@ pub mod state_traits;
 #[repr(C)]
 #[cfg_attr(
     feature = "frozen-abi",
-    derive(AbiExample, StableAbi),
+    derive(AbiExample, StableAbi, StableAbiSample),
     frozen_abi(
         api_digest = "62EqVoynUFvuui7DVfqWCvZP7bxKGJGioeSBnWrdjRME",
-        abi_digest = "Cms628BvHUgXEPDU1qV6sAXNr875LnMAMLskNohMngu"
+        abi_digest = "G4phLpfhujMpk4wS1WswCe4HqnQjCBPWjrXjvDZ6iUw8"
     )
 )]
 #[cfg_attr(
@@ -43,6 +43,12 @@ pub struct Account {
     pub lamports: u64,
     /// data held in this account
     #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))]
+    #[cfg_attr(
+        feature = "frozen-abi",
+        stable_abi_sample(
+            with = "(0..rng.random_range(0..=1000)).map(|_| rng.random()).collect()"
+        )
+    )]
     pub data: Vec<u8>,
     /// the program that owns this account. If executable, the program that loads this account.
     pub owner: Pubkey,
@@ -50,21 +56,6 @@ pub struct Account {
     pub executable: bool,
     /// the epoch at which this account will next owe rent
     pub rent_epoch: Epoch,
-}
-
-#[cfg(feature = "frozen-abi")]
-impl solana_frozen_abi::rand::prelude::Distribution<Account>
-    for solana_frozen_abi::rand::distr::StandardUniform
-{
-    fn sample<R: solana_frozen_abi::rand::Rng + ?Sized>(&self, rng: &mut R) -> Account {
-        Account {
-            lamports: rng.random(),
-            data: (0..1000).map(|_| rng.random()).collect(),
-            owner: Pubkey::new_from_array(rng.random()),
-            executable: rng.random(),
-            rent_epoch: rng.random(),
-        }
-    }
 }
 
 // mod because we need 'Account' below to have the name 'Account' to match expected serialization


### PR DESCRIPTION
#### Description

This PR enables `StableAbi`, functionality for frozen-abi types in the crate.

#### Summary of changes
All frozen-abi types got enabled `StableAbi`.