### PR TITLE
reorganize frozen-abi dep features in solana-transaction

### DIFF
--- a/transaction-error/Cargo.toml
+++ b/transaction-error/Cargo.toml
@@ -16,7 +16,7 @@ all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
 [features]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "serde"]
 serde = ["dep:serde", "dep:serde_derive", "solana-instruction-error/serde"]
 
 [dependencies]

--- a/transaction/Cargo.toml
+++ b/transaction/Cargo.toml
@@ -27,6 +27,8 @@ frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
     "solana-transaction-error/frozen-abi",
+    "solana-signature/frozen-abi",
+    "solana-message/frozen-abi",
 ]
 serde = [
     "dep:serde",
@@ -43,8 +45,8 @@ bincode = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 solana-address = { workspace = true }
-solana-frozen-abi = { workspace = true, optional = true }
-solana-frozen-abi-macro = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
+solana-frozen-abi-macro = { workspace = true, optional = true, features = ["frozen-abi"] }
 solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-instruction-error = { workspace = true }


### PR DESCRIPTION


#### Problem

Frozen-abi was not actually enforced in one of the crates during CI tests. 

After merging https://github.com/anza-xyz/solana-sdk/pull/440 some frozen-abi tests are skipped which results in, not checked digest.

@puhtaytow  discovered this issue on `solana-transaction::Transaction`, where after changing digest, frozen-abi script still pass green.

#### Summary of changes

reorganize the cargo deps to pull in the correct features for frozen-abi