### PR TITLE
file-download: Optimize file download with buffered writer

### DIFF
--- a/file-download/src/lib.rs
+++ b/file-download/src/lib.rs
@@ -6,7 +6,7 @@ use {
     log::*,
     std::{
         fs::{self, File},
-        io::{self, Read},
+        io::{self, BufWriter, Read},
         path::Path,
         str::FromStr,
         time::{Duration, Instant},


### PR DESCRIPTION
Specify a buffer of 8MB instead of the default 8kb. This increases download speed to be similar to wget.