### PR TITLE
frozen-abi: migrate StableAbi to rand v0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -384,7 +384,7 @@ dependencies = [
  "ff",
  "group",
  "pairing",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "subtle",
 ]
@@ -754,7 +754,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -780,7 +780,7 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
- "rand_core",
+ "rand_core 0.6.4",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -928,7 +928,7 @@ checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -978,7 +978,7 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -1054,7 +1054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "bitvec",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1266,8 +1266,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "rand_xorshift",
  "subtle",
 ]
@@ -1573,7 +1573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
 dependencies = [
  "bitmaps",
- "rand_core",
+ "rand_core 0.6.4",
  "rand_xoshiro",
  "rayon",
  "serde",
@@ -2123,8 +2123,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2134,7 +2144,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2147,12 +2167,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2161,7 +2190,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2574,7 +2603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2669,7 +2698,7 @@ dependencies = [
  "curve25519-dalek",
  "five8",
  "five8_const",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_derive",
  "solana-account-info",
@@ -2765,7 +2794,7 @@ dependencies = [
  "ff",
  "group",
  "pairing",
- "rand",
+ "rand 0.8.5",
  "rayon",
  "serde",
  "serde_json",
@@ -3051,8 +3080,8 @@ dependencies = [
  "im",
  "log",
  "memmap2",
- "rand",
- "rand_chacha",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "serde",
  "serde_bytes",
  "serde_derive",
@@ -3211,7 +3240,7 @@ dependencies = [
  "ed25519-dalek",
  "ed25519-dalek-bip32",
  "five8",
- "rand",
+ "rand 0.8.5",
  "serde_json",
  "solana-address",
  "solana-derivation-path",
@@ -3538,7 +3567,7 @@ dependencies = [
 name = "solana-pubkey"
 version = "4.0.0"
 dependencies = [
- "rand",
+ "rand 0.8.5",
  "solana-address",
 ]
 
@@ -3675,7 +3704,7 @@ dependencies = [
  "digest",
  "hex",
  "k256",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_derive",
  "sha3",
@@ -3698,7 +3727,7 @@ dependencies = [
  "anyhow",
  "borsh",
  "k256",
- "rand",
+ "rand 0.8.5",
  "solana-define-syscall",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
@@ -3746,7 +3775,7 @@ name = "solana-serde-varint"
 version = "3.0.0"
 dependencies = [
  "bincode",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_derive",
  "solana-short-vec",
@@ -3758,7 +3787,7 @@ version = "3.1.0"
 dependencies = [
  "bincode",
  "borsh",
- "rand",
+ "rand 0.8.5",
  "serde",
  "solana-instruction-error",
  "solana-pubkey",
@@ -3807,7 +3836,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
  "five8",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde-big-array",
  "serde_derive",
@@ -3837,7 +3866,7 @@ dependencies = [
  "criterion",
  "num-derive",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "thiserror 2.0.12",
 ]
 
@@ -4038,7 +4067,7 @@ dependencies = [
  "itertools 0.12.1",
  "num-derive",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_derive",
  "serde_with",
@@ -4281,7 +4310,7 @@ checksum = "a30fd743a02bf35236f6faf99adb03089bb77e91c998dac2c2ad76bb424f668c"
 dependencies = [
  "once_cell",
  "pbkdf2 0.12.2",
- "rand",
+ "rand 0.8.5",
  "rustc-hash",
  "sha2",
  "thiserror 1.0.69",

--- a/frozen-abi/Cargo.toml
+++ b/frozen-abi/Cargo.toml
@@ -42,8 +42,8 @@ im = { workspace = true, features = ["rayon", "serde"] }
 memmap2 = { workspace = true }
 # These dependencies are used only to back `frozen-abi` StableAbi API,
 # to avoid version skew and keep digest computation stable regardless of consumer dependencies.
-rand = "0.8.5"
-rand_chacha = "0.3.1"
+rand = "0.9.2"
+rand_chacha = "0.9.0"
 
 [target.'cfg(not(target_os = "solana"))'.dev-dependencies]
 bitflags = { workspace = true, features = ["serde"] }

--- a/frozen-abi/src/stable_abi.rs
+++ b/frozen-abi/src/stable_abi.rs
@@ -1,10 +1,10 @@
-use rand::{distributions::Standard, Rng, RngCore};
+use rand::{distr::StandardUniform, Rng, RngCore};
 
 pub trait StableAbi: Sized {
     fn random(rng: &mut impl RngCore) -> Self
     where
-        Standard: rand::distributions::Distribution<Self>,
+        StandardUniform: rand::distr::Distribution<Self>,
     {
-        rng.r#gen::<Self>()
+        rng.random::<Self>()
     }
 }


### PR DESCRIPTION
#### Problem
The `frozen-abi` crate has in place `rand` dependency v0.8 while **agave** and **solana-sdk** are moving towards v0.9.

#### Summary of changes
Trait `StableAbi` has been updated to use v0.9 API