### PR TITLE
[epoch-rewards] Make solana-sdk-ids dependency optional

### DIFF
--- a/epoch-rewards/Cargo.toml
+++ b/epoch-rewards/Cargo.toml
@@ -23,7 +23,7 @@ frozen-abi = [
 ]
 serde = ["dep:serde", "dep:serde_derive", "serde/alloc", "solana-hash/serde"]
 std = ["serde?/std"]
-sysvar = ["dep:solana-sysvar-id"]
+sysvar = ["dep:solana-sdk-ids", "dep:solana-sysvar-id"]
 
 [dependencies]
 serde = { workspace = true, optional = true }
@@ -31,7 +31,7 @@ serde_derive = { workspace = true, optional = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-hash = { workspace = true, features = ["decode"] }
-solana-sdk-ids = { workspace = true }
+solana-sdk-ids = { workspace = true, optional = true }
 solana-sdk-macro = { workspace = true }
 solana-sysvar-id = { workspace = true, optional = true }
 


### PR DESCRIPTION
`solana-sdk-ids` dependency is used only in `sysvar` module that is under `sysvar` feature, so can be made optional.