### PR TITLE
rent: Deprecate the concept of paying rent, prep for SIMD-0194

### DIFF
--- a/rent/src/lib.rs
+++ b/rent/src/lib.rs
@@ -77,7 +77,7 @@ pub const DEFAULT_LAMPORTS_PER_BYTE_YEAR: u64 = 1_000_000_000 / 100 * 365 / (102
 /// - $1 per SOL
 /// - $0.01 per megabyte day
 /// - $7.30 per megabyte
-pub const DEFAULT_LAMPORTS_PER_BYTE: u64 = 2 * 1_000_000_000 / 100 * 365 / (1024 * 1024);
+pub const DEFAULT_LAMPORTS_PER_BYTE: u64 = 6_960;
 
 /// Default amount of time (in years) the balance has to include rent for the
 /// account to be rent exempt.


### PR DESCRIPTION
#### Problem

The concept of rent no longer exists in Solana clusters, but we still have the types and functions related to it.

Additionally, with SIMD-0194, we're eliminating the concept of `exemption_threshold`, but the field still exists.

#### Summary of changes

Prepare solana-rent for SIMD-0194, by deprecating
`lamports_per_byte_year` (will be renamed to `lamports_per_byte`), `exemption_threshold` (will just become a `[u8; 8]`), and `burn_percent` (will just go unused). Also deprecate functions and types related to paying rent.

Once this lands, we can do a breaking release that removes types and changes variable names.

This is a part of #275