### PR TITLE
program-log: Add log wrappers

### DIFF
--- a/program-log/src/lib.rs
+++ b/program-log/src/lib.rs
@@ -57,7 +57,7 @@ mod wrapper;
 #[cfg(feature = "macro")]
 pub use solana_program_log_macro::*;
 pub use {
-    logger::{log_message as log, Argument, Logger},
+    logger::{Argument, Logger},
     wrapper::*,
 };
 

--- a/program-log/src/wrapper.rs
+++ b/program-log/src/wrapper.rs
@@ -3,11 +3,13 @@
 #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
 use core::hint::black_box;
 #[cfg(any(target_os = "solana", target_arch = "bpf"))]
-use solana_define_syscall::definitions::{sol_log_, sol_log_64_, sol_log_compute_units_};
+use solana_define_syscall::definitions::{
+    sol_log_, sol_log_64_, sol_log_compute_units_, sol_log_data,
+};
 
 /// Print a string to the log.
 #[inline(always)]
-pub fn sol_log(message: &str) {
+pub fn log(message: &str) {
     #[cfg(any(target_os = "solana", target_arch = "bpf"))]
     unsafe {
         sol_log_(message.as_ptr(), message.len() as u64);
@@ -19,7 +21,7 @@ pub fn sol_log(message: &str) {
 
 /// Print 64-bit values represented as hexadecimal to the log.
 #[inline(always)]
-pub fn sol_log_64(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) {
+pub fn log_64(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) {
     #[cfg(any(target_os = "solana", target_arch = "bpf"))]
     unsafe {
         sol_log_64_(arg1, arg2, arg3, arg4, arg5);
@@ -31,30 +33,19 @@ pub fn sol_log_64(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) {
 
 /// Print some slices as `base64`.
 #[inline(always)]
-pub fn sol_log_data(data: &[&[u8]]) {
+pub fn log_data(data: &[&[u8]]) {
     #[cfg(any(target_os = "solana", target_arch = "bpf"))]
     unsafe {
-        solana_define_syscall::definitions::sol_log_data(
-            data as *const _ as *const u8,
-            data.len() as u64,
-        )
+        sol_log_data(data as *const _ as *const u8, data.len() as u64)
     };
 
     #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
     black_box(data);
 }
 
-/// Print the hexadecimal representation of a slice.
-#[inline(always)]
-pub fn sol_log_slice(slice: &[u8]) {
-    for (i, s) in slice.iter().enumerate() {
-        sol_log_64(0, 0, 0, i as u64, *s as u64);
-    }
-}
-
 /// Print the remaining compute units available to the program.
 #[inline]
-pub fn sol_log_compute_units() {
+pub fn log_compute_units() {
     #[cfg(any(target_os = "solana", target_arch = "bpf"))]
     unsafe {
         sol_log_compute_units_();


### PR DESCRIPTION
### Problem

There are a few more log syscalls available on the runtime, but in order to use them it is necessary to pass raw pointers.

### Solution

Add wrapper functions to simplify their use.