### PR TITLE
feat: add no_std support for program-pack crate

### DIFF
--- a/program-pack/src/lib.rs
+++ b/program-pack/src/lib.rs
@@ -5,6 +5,7 @@
 //! serialization format.
 //!
 //! [spl]: https://github.com/solana-labs/solana-program-library
+#![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 use solana_program_error::ProgramError;

--- a/scripts/check-no-std.sh
+++ b/scripts/check-no-std.sh
@@ -28,6 +28,7 @@ no_std_crates=(
   -p solana-program-log
   -p solana-program-log-macro
   -p solana-program-memory
+  -p solana-program-pack
   -p solana-pubkey
   -p solana-rent
   -p solana-sanitize


### PR DESCRIPTION
`solana-program-pack` can be `no_std`