### PR TITLE
message: make `is_writable_index` pub

### DIFF
--- a/message/src/legacy.rs
+++ b/message/src/legacy.rs
@@ -520,7 +520,7 @@ impl Message {
 
     /// Returns true if the account at the specified index was requested to be
     /// writable. This method should not be used directly.
-    pub(super) fn is_writable_index(&self, i: usize) -> bool {
+    pub fn is_writable_index(&self, i: usize) -> bool {
         i < (self.header.num_required_signatures as usize)
             .saturating_sub(self.header.num_readonly_signed_accounts as usize)
             || (i >= self.header.num_required_signatures as usize


### PR DESCRIPTION
#### Problem
In testing tools like [Mollusk](https://github.com/anza-xyz/mollusk), we currently reimplement lots of the message compilation strategy in order to merge privileges and lookup account indices - primarily to compile instruction and transaction accounts.

https://github.com/anza-xyz/mollusk/blob/main/keys/src/keys.rs
https://github.com/anza-xyz/mollusk/blob/main/keys/src/accounts.rs

However, it would be super nice to just use `Message` directly from the SDK and delete all of the above linked code! Instead, we could just do something like this:

```rust
let message = Message::new(&[instruction], None);
let accounts: Vec<_> = message.account_keys.iter().enumerate()
  .map(|(i, key)| {
      InstructionAccount::new(i as IndexOfAccount, message.is_signer(i), message.is_writable_index(i))
  })
  .collect();
```

However, we need public access to `Message::is_writable_index`.

#### Summary of Changes
Make `Message::is_writable_index` public.