### PR TITLE
reward-info: change `commission` to `commission_bps`

### DIFF
--- a/reward-info/src/lib.rs
+++ b/reward-info/src/lib.rs
@@ -40,6 +40,7 @@ pub struct RewardInfo {
     pub lamports: i64,
     /// Account balance in lamports after `lamports` was applied
     pub post_balance: u64,
-    /// Vote account commission when the reward was credited, only present for voting and staking rewards
-    pub commission: Option<u8>,
+    /// Vote account commission in basis points when the reward was credited,
+    /// only present for voting and staking rewards.
+    pub commission_bps: Option<u16>,
 }


### PR DESCRIPTION
#### Problem
As part of the implementation of [SIMD-0291](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0291-commission-rate-in-basis-points.md), we'll need `RewardInfo` to track inflation rewards commission in basis points, since the runtime will be switching over to this accounting.

Draft implementation of SIMD-0291: https://github.com/anza-xyz/agave/pull/9668

#### Summary of Changes
Change the field on `RewardInfo` from `commission: Option<u8>` to `commission_bps: Option<u16>`.