### PR TITLE
Remove dead code in alt_bn128_pairing

### DIFF
--- a/bn254/src/pairing.rs
+++ b/bn254/src/pairing.rs
@@ -158,13 +158,6 @@ pub fn alt_bn128_pairing(input: &[u8]) -> Result<Vec<u8>, AltBn128Error> {
     }
     #[cfg(target_os = "solana")]
     {
-        if input
-            .len()
-            .checked_rem(ALT_BN128_PAIRING_ELEMENT_LEN)
-            .is_none()
-        {
-            return Err(AltBn128Error::InvalidInputData);
-        }
         let mut result_buffer = [0u8; 32];
         let result = unsafe {
             syscalls::sol_alt_bn128_group_op(


### PR DESCRIPTION
Removes unreachable code. This is not a consensus breaking change

See [usize::checked_rem](https://doc.rust-lang.org/std/primitive.usize.html#method.checked_rem):

> Checked integer remainder. Computes self % rhs, returning None if rhs == 0.

And rhs is a non-zero constant.