### PR TITLE
address: enable Arbitrary for frozen-abi feature

### DIFF
--- a/address/Cargo.toml
+++ b/address/Cargo.toml
@@ -28,6 +28,7 @@ frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
     "dep:solana-program-error",
+    "dep:arbitrary",
     "std",
 ]
 rand = ["dep:rand", "atomic", "std"]

--- a/address/src/lib.rs
+++ b/address/src/lib.rs
@@ -28,8 +28,6 @@ extern crate alloc;
 extern crate std;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
-#[cfg(feature = "dev-context-only-utils")]
-use arbitrary::Arbitrary;
 #[cfg(feature = "bytemuck")]
 use bytemuck_derive::{Pod, Zeroable};
 #[cfg(feature = "decode")]
@@ -92,9 +90,12 @@ pub const PDA_MARKER: &[u8; 21] = b"ProgramDerivedAddress";
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "bytemuck", derive(Pod, Zeroable))]
 #[cfg_attr(feature = "wincode", derive(SchemaWrite, SchemaRead))]
-#[cfg_attr(feature = "dev-context-only-utils", derive(Arbitrary))]
 #[cfg_attr(not(feature = "decode"), derive(Debug))]
 #[cfg_attr(feature = "copy", derive(Copy))]
+#[cfg_attr(
+    any(feature = "frozen-abi", feature = "dev-context-only-utils"),
+    derive(arbitrary::Arbitrary)
+)]
 #[derive(Clone, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Address(pub(crate) [u8; 32]);
 


### PR DESCRIPTION
#### Description

Address is commonly used among frozen-abi enabled types. Without an implementation of `arbitrary::Arbitrary`, they block other types from easy derivation.

#### Summary of changes

- `arbitrary::Arbitrary` being derived now not only in case of `DCOU` but `frozen-abi` as well.