### PR TITLE
[define-syscall] Update `sol_curve_pairing_map` and add `sol_curve_decompress` for SIMD-388

### DIFF
--- a/define-syscall/src/definitions.rs
+++ b/define-syscall/src/definitions.rs
@@ -25,6 +25,7 @@ define_syscall!(fn sol_curve_validate_point(curve_id: u64, point_addr: *const u8
 define_syscall!(fn sol_curve_group_op(curve_id: u64, group_op: u64, left_input_addr: *const u8, right_input_addr: *const u8, result_point_addr: *mut u8) -> u64);
 define_syscall!(fn sol_curve_multiscalar_mul(curve_id: u64, scalars_addr: *const u8, points_addr: *const u8, points_len: u64, result_point_addr: *mut u8) -> u64);
 define_syscall!(fn sol_curve_pairing_map(curve_id: u64, num_pairs: u64, g1_points: *const u8, g2_points: *const u8, result: *mut u8) -> u64);
+define_syscall!(fn sol_curve_decompress(curve_id: u64, point: *const u8, result: *mut u8) -> u64);
 define_syscall!(fn sol_alt_bn128_group_op(group_op: u64, input: *const u8, input_size: u64, result: *mut u8) -> u64);
 define_syscall!(fn sol_big_mod_exp(params: *const u8, result: *mut u8) -> u64);
 define_syscall!(fn sol_remaining_compute_units() -> u64);


### PR DESCRIPTION
#### Problem

SIMD-388 proposes adding a new set of syscalls for the BLS12-381 elliptic curve. In addition to extending some of the already existing elliptic curve syscall functions, it proposes to update the function signature of `sol_curve_pairing_map` ([here](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0388-bls12-381-syscalls.md#pairing-operation)) and add a new function `sol_curve_decompress` ([here](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0388-bls12-381-syscalls.md#decompression-operations-in-g1-and-g2)).

#### Summary of Changes

- Updated the function signature of `sol_curve_pairing_map`
- Added a new function `sol_curve_decompress`

Addition of `sol_curve_decompress` is relatively simple, but I am not 100% if we can update the function signature of an existing `sol_curve_pairing_map` function. If this is the case, please let me know so that I can update the SIMD. I do want to note that this function is never used and was never instantiated (i.e. [here](https://github.com/anza-xyz/agave/blob/master/syscalls/src/lib.rs)).