### PR TITLE
frozen-abi: fix for digester issues with rust 1.91

### DIFF
--- a/frozen-abi/src/abi_digester.rs
+++ b/frozen-abi/src/abi_digester.rs
@@ -53,7 +53,7 @@ pub(crate) fn shorten_serialize_with(type_name: &str) -> &str {
     // Fully qualified type names for the generated `__SerializeWith` types are very
     // long and do not add extra value to the digest. They also cause the digest
     // to change when a struct is moved to an inner module.
-    if type_name.ends_with("__SerializeWith") {
+    if type_name.contains("__SerializeWith") {
         "__SerializeWith"
     } else {
         type_name
@@ -118,7 +118,7 @@ impl AbiDigester {
 
     pub fn digest_data<T: ?Sized + Serialize>(&mut self, value: &T) -> DigestResult {
         let type_name = normalize_type_name(type_name::<T>());
-        if type_name.ends_with("__SerializeWith")
+        if type_name.contains("__SerializeWith")
             || (self.opaque_type_matcher.is_some()
                 && type_name.contains(self.opaque_type_matcher.as_ref().unwrap()))
         {


### PR DESCRIPTION
### Problem

As described here https://github.com/anza-xyz/agave/issues/8117#issuecomment-3572215435 

### Summary of changes

- Swapped `type_name.ends_with("__SerializeWith")` by `if type_name.contains("__SerializeWith")` in `abi_digester` to cover as well the cases with explicit life time.