### PR TITLE
Bump thiserror to 2.0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -327,7 +327,7 @@ subtle = "2.6.1"
 syn = "2.0.106"
 tempfile = "3.20.0"
 test-case = "3.3.1"
-thiserror = { version = "2.0.16", default-features = false }
+thiserror = { version = "2.0.17", default-features = false }
 tiny-bip39 = "2.0.0"
 toml = "0.8.23"
 uriparse = "0.6.4"


### PR DESCRIPTION
#### Summary of Changes

Bumping `thiserror` to v2.0.17. Seems like `Cargo.lock` already uses v2.0.17, so not need to update `Cargo.lock`.