### PR TITLE
[bls-signatures] Fix a small compile error in the bls bench code

### DIFF
--- a/bls-signatures/benches/bls_signatures.rs
+++ b/bls-signatures/benches/bls_signatures.rs
@@ -70,7 +70,7 @@ fn bench_aggregate(c: &mut Criterion) {
 
         #[cfg(feature = "parallel")]
         {
-            let pubkey_refs: Vec<&PubkeyProjective> = pubkeys.iter().collect();
+            let pubkey_refs: Vec<&PubkeyAffine> = pubkeys.iter().collect();
 
             group.bench_function(
                 format!("{num_validators} parallel pubkey aggregation"),


### PR DESCRIPTION
#### Problem

In the current bench code, it seems like we are collecting references of `PubkeyAffine` into a vector typed as `Vec<&PubkeyProjective>`, which results in a compile error for the `parallel` feature of the branch (`cargo bench --features parallel`).

#### Summary of Changes

Fixed the problematic line.