### PR TITLE
SIMD-406: Restrict to 255 the number of accounts in instructions for transactions v0 and legacy

### DIFF
--- a/message/src/compiled_instruction.rs
+++ b/message/src/compiled_instruction.rs
@@ -4,7 +4,10 @@ use serde_derive::{Deserialize, Serialize};
 use solana_frozen_abi_macro::AbiExample;
 #[cfg(feature = "wincode")]
 use wincode::{containers, len::ShortU16Len, SchemaRead, SchemaWrite};
-use {solana_address::Address, solana_sanitize::Sanitize};
+use {
+    solana_address::Address,
+    solana_sanitize::{Sanitize, SanitizeError},
+};
 
 /// A compact encoding of an instruction.
 ///
@@ -34,7 +37,14 @@ pub struct CompiledInstruction {
     pub data: Vec<u8>,
 }
 
-impl Sanitize for CompiledInstruction {}
+impl Sanitize for CompiledInstruction {
+    fn sanitize(&self, limit_ix_accounts_simd_406: bool) -> Result<(), SanitizeError> {
+        if limit_ix_accounts_simd_406 && self.accounts.len() > 255 {
+            return Err(SanitizeError::ValueOutOfBounds);
+        }
+        Ok(())
+    }
+}
 
 impl CompiledInstruction {
     #[cfg(feature = "bincode")]

--- a/message/src/sanitized.rs
+++ b/message/src/sanitized.rs
@@ -110,8 +110,9 @@ impl SanitizedMessage {
     pub fn try_from_legacy_message(
         message: legacy::Message,
         reserved_account_keys: &HashSet<Address>,
+        limit_ix_accounts_simd_406: bool,
     ) -> Result<Self, SanitizeMessageError> {
-        message.sanitize()?;
+        message.sanitize(limit_ix_accounts_simd_406)?;
         Ok(Self::Legacy(LegacyMessage::new(
             message,
             reserved_account_keys,
@@ -456,6 +457,7 @@ mod tests {
             SanitizedMessage::try_from_legacy_message(
                 legacy_message_with_no_signers,
                 &HashSet::default(),
+                true,
             )
             .err(),
             Some(SanitizeMessageError::IndexOutOfBounds),
@@ -482,6 +484,7 @@ mod tests {
                 ..legacy::Message::default()
             },
             &HashSet::default(),
+            true,
         )
         .unwrap();
 
@@ -529,6 +532,7 @@ mod tests {
                 instructions,
             ),
             &HashSet::default(),
+            true,
         )
         .unwrap();
 
@@ -571,6 +575,7 @@ mod tests {
                 ..legacy::Message::default()
             },
             &HashSet::default(),
+            true,
         )
         .unwrap();
         match legacy_message {
@@ -655,6 +660,7 @@ mod tests {
                 ],
             ),
             &HashSet::new(),
+            true,
         )
         .unwrap();
 
@@ -688,6 +694,7 @@ mod tests {
                 ..legacy::Message::default()
             },
             &HashSet::default(),
+            true,
         )
         .unwrap();
         assert_eq!(legacy_message.static_account_keys(), &keys);

--- a/message/src/versions/mod.rs
+++ b/message/src/versions/mod.rs
@@ -59,10 +59,10 @@ pub enum VersionedMessage {
 }
 
 impl VersionedMessage {
-    pub fn sanitize(&self) -> Result<(), SanitizeError> {
+    pub fn sanitize(&self, limit_ix_accounts_simd_406: bool) -> Result<(), SanitizeError> {
         match self {
-            Self::Legacy(message) => message.sanitize(),
-            Self::V0(message) => message.sanitize(),
+            Self::Legacy(message) => message.sanitize(limit_ix_accounts_simd_406),
+            Self::V0(message) => message.sanitize(limit_ix_accounts_simd_406),
         }
     }
 

--- a/message/src/versions/sanitized.rs
+++ b/message/src/versions/sanitized.rs
@@ -12,13 +12,16 @@ pub struct SanitizedVersionedMessage {
 impl TryFrom<VersionedMessage> for SanitizedVersionedMessage {
     type Error = SanitizeError;
     fn try_from(message: VersionedMessage) -> Result<Self, Self::Error> {
-        Self::try_new(message)
+        Self::try_new(message, true)
     }
 }
 
 impl SanitizedVersionedMessage {
-    pub fn try_new(message: VersionedMessage) -> Result<Self, SanitizeError> {
-        message.sanitize()?;
+    pub fn try_new(
+        message: VersionedMessage,
+        limit_ix_accounts_simd_406: bool,
+    ) -> Result<Self, SanitizeError> {
+        message.sanitize(limit_ix_accounts_simd_406)?;
         Ok(Self { message })
     }
 

--- a/sanitize/src/lib.rs
+++ b/sanitize/src/lib.rs
@@ -34,15 +34,15 @@ impl fmt::Display for SanitizeError {
 /// - All index values are in range.
 /// - All values are within their static max/min bounds.
 pub trait Sanitize {
-    fn sanitize(&self) -> Result<(), SanitizeError> {
+    fn sanitize(&self, _limit_ix_accounts_simd_406: bool) -> Result<(), SanitizeError> {
         Ok(())
     }
 }
 
 impl<T: Sanitize> Sanitize for [T] {
-    fn sanitize(&self) -> Result<(), SanitizeError> {
+    fn sanitize(&self, limit_ix_accounts_simd_406: bool) -> Result<(), SanitizeError> {
         for x in self.iter() {
-            x.sanitize()?;
+            x.sanitize(limit_ix_accounts_simd_406)?;
         }
         Ok(())
     }

--- a/sdk/benches/serialize_instructions.rs
+++ b/sdk/benches/serialize_instructions.rs
@@ -33,6 +33,7 @@ fn bench_construct_instructions_data(b: &mut Bencher) {
     let message = SanitizedMessage::try_from_legacy_message(
         Message::new(&instructions, Some(&Pubkey::new_unique())),
         &HashSet::default(),
+        true,
     )
     .unwrap();
     b.iter(|| {
@@ -56,6 +57,7 @@ fn bench_manual_instruction_deserialize(b: &mut Bencher) {
     let message = SanitizedMessage::try_from_legacy_message(
         Message::new(&instructions, Some(&Pubkey::new_unique())),
         &HashSet::default(),
+        true,
     )
     .unwrap();
     let serialized = construct_instructions_data(&message.decompile_instructions());
@@ -73,6 +75,7 @@ fn bench_manual_instruction_deserialize_single(b: &mut Bencher) {
     let message = SanitizedMessage::try_from_legacy_message(
         Message::new(&instructions, Some(&Pubkey::new_unique())),
         &HashSet::default(),
+        true,
     )
     .unwrap();
     let serialized = construct_instructions_data(&message.decompile_instructions());

--- a/transaction/src/sanitized.rs
+++ b/transaction/src/sanitized.rs
@@ -122,8 +122,9 @@ impl SanitizedTransaction {
     pub fn try_from_legacy_transaction(
         tx: Transaction,
         reserved_account_keys: &HashSet<Address>,
+        limit_ix_accounts_simd_406: bool,
     ) -> TransactionResult<Self> {
-        tx.sanitize()?;
+        tx.sanitize(limit_ix_accounts_simd_406)?;
 
         Ok(Self {
             message_hash: tx.message.hash(),
@@ -140,7 +141,7 @@ impl SanitizedTransaction {
     #[cfg(feature = "blake3")]
     pub fn from_transaction_for_tests(tx: Transaction) -> Self {
         let empty_key_set = HashSet::default();
-        Self::try_from_legacy_transaction(tx, &empty_key_set).unwrap()
+        Self::try_from_legacy_transaction(tx, &empty_key_set, true).unwrap()
     }
 
     /// Create a sanitized transaction from fields.
@@ -410,6 +411,7 @@ mod tests {
                 ..legacy::Message::default()
             },
             &HashSet::default(),
+            true,
         )
         .unwrap();
 

--- a/transaction/src/versioned/mod.rs
+++ b/transaction/src/versioned/mod.rs
@@ -121,8 +121,11 @@ impl VersionedTransaction {
         })
     }
 
-    pub fn sanitize(&self) -> std::result::Result<(), SanitizeError> {
-        self.message.sanitize()?;
+    pub fn sanitize(
+        &self,
+        limit_ix_accounts_simd_406: bool,
+    ) -> std::result::Result<(), SanitizeError> {
+        self.message.sanitize(limit_ix_accounts_simd_406)?;
         self.sanitize_signatures()?;
         Ok(())
     }


### PR DESCRIPTION
In [SIMD-406](https://github.com/solana-foundation/solana-improvement-documents/pull/406), we proposed that v0 and legacy transaction sanitization must now have an extra check to limit the number of accounts per instruction to 255.

This PR implements this check behind a boolean flag that will be coupled with a feature gate in Agave.