### PR TITLE
fix: fix `Address::new_unique` doc comment typo

### DIFF
--- a/address/src/lib.rs
+++ b/address/src/lib.rs
@@ -204,7 +204,7 @@ impl Address {
     }
 
     #[cfg(feature = "atomic")]
-    /// Create an unique `Address` for tests and benchmarks.
+    /// Create a unique `Address` for tests and benchmarks.
     pub fn new_unique() -> Self {
         use solana_atomic_u64::AtomicU64;
         static I: AtomicU64 = AtomicU64::new(1);


### PR DESCRIPTION
Fix `Address::new_unique` doc comment typo