### PR TITLE
Remove `fn create` from `WritableAccount`

### DIFF
--- a/account/src/lib.rs
+++ b/account/src/lib.rs
@@ -211,14 +211,6 @@ pub trait WritableAccount: ReadableAccount {
     fn copy_into_owner_from_slice(&mut self, source: &[u8]);
     fn set_executable(&mut self, executable: bool);
     fn set_rent_epoch(&mut self, epoch: Epoch);
-    #[deprecated(since = "3.3.0")]
-    fn create(
-        lamports: u64,
-        data: Vec<u8>,
-        owner: Pubkey,
-        executable: bool,
-        rent_epoch: Epoch,
-    ) -> Self;
 }
 
 pub trait ReadableAccount: Sized {
@@ -266,21 +258,6 @@ impl WritableAccount for Account {
     fn set_rent_epoch(&mut self, epoch: Epoch) {
         self.rent_epoch = epoch;
     }
-    fn create(
-        lamports: u64,
-        data: Vec<u8>,
-        owner: Pubkey,
-        executable: bool,
-        rent_epoch: Epoch,
-    ) -> Self {
-        Account {
-            lamports,
-            data,
-            owner,
-            executable,
-            rent_epoch,
-        }
-    }
 }
 
 impl WritableAccount for AccountSharedData {
@@ -301,21 +278,6 @@ impl WritableAccount for AccountSharedData {
     }
     fn set_rent_epoch(&mut self, epoch: Epoch) {
         self.rent_epoch = epoch;
-    }
-    fn create(
-        lamports: u64,
-        data: Vec<u8>,
-        owner: Pubkey,
-        executable: bool,
-        rent_epoch: Epoch,
-    ) -> Self {
-        AccountSharedData {
-            lamports,
-            data: Arc::new(data),
-            owner,
-            executable,
-            rent_epoch,
-        }
     }
 }
 


### PR DESCRIPTION
`fn create` has been deprecated in https://github.com/anza-xyz/solana-sdk/pull/488, its usages have been removed from Agave in https://github.com/anza-xyz/agave/pull/9279 and the monorepo dependency has been bumped in https://github.com/anza-xyz/agave/pull/9706, so it is now safe to remove the function from the crate.

This is a follow up to https://github.com/anza-xyz/solana-sdk/pull/386.