### PR TITLE
reward-info: remove `RewardInfo` struct

### DIFF
--- a/reward-info/src/lib.rs
+++ b/reward-info/src/lib.rs
@@ -30,17 +30,3 @@ impl fmt::Display for RewardType {
         )
     }
 }
-
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub struct RewardInfo {
-    pub reward_type: RewardType,
-    /// Reward amount
-    pub lamports: i64,
-    /// Account balance in lamports after `lamports` was applied
-    pub post_balance: u64,
-    /// Vote account commission in basis points when the reward was credited,
-    /// only present for voting and staking rewards.
-    pub commission_bps: Option<u16>,
-}


### PR DESCRIPTION
#### Problem

Unlike `RewardType`, the `RewardInfo` struct isn't used anywhere throughout the outward-facing (stable) API of Agave. It will make our lives easier to make changes to `RewardInfo` as we roll out SIMD-0123 (Block Revenue Distribution).

#### Summary of Changes

Drop `RewardInfo` from the `reward-info` crate and move it to Agave: https://github.com/anza-xyz/agave/pull/9858