### PR TITLE
feat(program-log): add efficient hex logging for Pubkey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3819,6 +3819,7 @@ version = "1.1.0"
 dependencies = [
  "solana-define-syscall",
  "solana-program-log-macro",
+ "solana-pubkey",
 ]
 
 [[package]]

--- a/bn254/src/pairing.rs
+++ b/bn254/src/pairing.rs
@@ -73,8 +73,8 @@ pub fn alt_bn128_versioned_pairing(
                 return Err(AltBn128Error::InvalidInputData);
             }
         }
-        VersionedPairing::V1 =>
-        {
+        VersionedPairing::V1 => {
+            #[allow(unknown_lints)]
             #[allow(clippy::manual_is_multiple_of)]
             if input.len() % ALT_BN128_PAIRING_ELEMENT_SIZE != 0 {
                 return Err(AltBn128Error::InvalidInputData);

--- a/program-log/Cargo.toml
+++ b/program-log/Cargo.toml
@@ -20,10 +20,14 @@ crate-type = ["rlib"]
 [features]
 default = ["macro"]
 macro = ["dep:solana-program-log-macro"]
+solana-pubkey = ["dep:solana-pubkey"]
+
 std = []
 
 [dependencies]
 solana-program-log-macro = { workspace = true, optional = true }
+solana-pubkey = { workspace = true, optional = true }
+
 
 [target.'cfg(any(target_os = "solana", target_arch = "bpf"))'.dependencies]
 solana-define-syscall = { workspace = true }

--- a/program-log/README.md
+++ b/program-log/README.md
@@ -5,6 +5,7 @@
 </p>
 
 # `solana-program-log`
+
 <a href="https://crates.io/crates/solana-program-log"><img src="https://img.shields.io/crates/v/solana-program-log?logo=rust" /></a>
 <a href="https://docs.rs/solana-program-log"><img src="https://img.shields.io/docsrs/solana-program-log?logo=docsdotrs" /></a>
 
@@ -16,32 +17,35 @@ Currently, logging messages that require formatting are a bit heavy on the CU co
 
 It is known that Rust formatting routines are CPU-intensive for constrained environments. This has been noted on both the `solana-program` [`msg!`](https://docs.rs/solana-program/latest/solana_program/macro.msg.html) documentation and more generally on [rust development](https://github.com/rust-lang/rust/issues/99012).
 
-While the cost related to (1) is *fixed*, in the sense that it does not change with the addition of formatting, it is possible to improve the overall cost of logging a formatted message using a lightweight formatting routine &mdash; this is what this crate does.
+While the cost related to (1) is _fixed_, in the sense that it does not change with the addition of formatting, it is possible to improve the overall cost of logging a formatted message using a lightweight formatting routine &mdash; this is what this crate does.
 
 This crate defines a lightweight `Logger` type to format log messages and a companion `log!` macro. The logger is a fixed size buffer that can be used to format log messages before sending them to the log output. Any type that implements the `Log` trait can be appended to the logger. Additionally, the logger can the dereferenced to a `&[u8]` slice, which can be used for other purposes &mdash; e.g., it can be used to create `&str` to be stored on an account or return data of programs.
 
 Below is a sample of the improvements observed when formatting log messages, measured in terms of compute units (CU):
-| Output message                      | `log!` | `msg!`          | Improvement (%) |
+| Output message | `log!` | `msg!` | Improvement (%) |
 |-------------------------------------|--------|-----------------|-----------------|
-| `"Hello world!"`                    | 104    | 104             | -               |
-| `"lamports={}"` + `u64`             | 286    | 625 (+339)      | 55%             |
-| `"{}"` + `[&str; 2]`                | 119    | 1610 (+1491)    | 93%             |
-| `"lamports={}"` + `i64`             | 299    | 659 (+360)      | 55%             |
-| `"{}"` + `[u8; 32]` (address bytes) | 2783   | 8397 (+5614)    | 67%             |
-| `"lamports={:.9}"` + `u64`          | 438    | 2656 (+2218)`*` | 84%             |
+| `"Hello world!"` | 104 | 104 | - |
+| `"lamports={}"` + `u64` | 286 | 625 (+339) | 55% |
+| `"{}"` + `[&str; 2]` | 119 | 1610 (+1491) | 93% |
+| `"lamports={}"` + `i64` | 299 | 659 (+360) | 55% |
+| `"{}"` + `[u8; 32]` (address bytes) | 2783 | 8397 (+5614) | 67% |
+| `"lamports={:.9}"` + `u64` | 438 | 2656 (+2218)`*` | 84% |
 
 `*` For `msg!`, the value is logged as a `f64` otherwise the precision formatting is ignored.
 
 ## Features
 
-* Zero dependencies and `no_std` crate
-* Independent of SDK (i.e., works with `pinocchio`, `solana-program` or `anchor`)
-* Support for `&str`, unsigned and signed integer types
-* `log!` macro to facilitate log message formatting
+- Zero dependencies and `no_std` crate
+- Independent of SDK (i.e., works with `pinocchio`, `solana-program` or `anchor`)
+- Connects optionally with `solana-pubkey` to log addresses efficiently
+- Support for `&str`, unsigned and signed integer types
+
+- `log!` macro to facilitate log message formatting
 
 ## Getting Started
 
 From your project folder:
+
 ```bash
 cargo add solana-program-log
 ```
@@ -49,6 +53,7 @@ cargo add solana-program-log
 ## Usage
 
 The `Logger` can be used directly:
+
 ```rust
 use solana_program_log::Logger;
 
@@ -58,14 +63,29 @@ logger.append("world!");
 logger.log();
 ```
 
- or via the `log!` macro:
- ```rust
+or via the `log!` macro:
+
+```rust
 use solana_program_log::log;
 
 let lamports = 1_000_000_000;
 log!("transfer amount: {}", lamports);
 // Logs the transfer amount in SOL (lamports with 9 decimal digits)
 log!("transfer amount (SOL): {:.9}", lamports);
+```
+
+When the `solana-pubkey` feature is enabled:
+
+```rust
+// In Cargo.toml:
+// solana-program-log = { version = "...", features = ["solana-pubkey"] }
+
+use solana_program_log::log;
+use solana_pubkey::Pubkey;
+
+let program_id = Pubkey::new_unique();
+// Logs the Pubkey in Hex format (saves ~2000 CUs vs msg!)
+log!("Program ID: {}", program_id);
 ```
 
 Since the formatting routine does not perform additional allocations, the `Logger` type has a fixed size specified on its creation. When using the `log!` macro, it is also possible to specify the size of the logger buffer:
@@ -78,6 +98,7 @@ log!(50, "transfer amount: {}", lamports);
 ```
 
 It is also possible to dereference the `Logger` into a `&[u8]` slice and use the result for other purposes:
+
 ```rust
 use solana_program_log::Logger;
 
@@ -90,6 +111,7 @@ let prize_title = core::str::from_utf8(&logger)?;
 ```
 
 When using the `Logger` directly, it is possible to include a precision formatting for numeric values:
+
 ```rust
 use solana_program_log::{Attribute, Logger};
 
@@ -101,6 +123,7 @@ logger.log();
 ```
 
 or a formatting string on the `log!` macro:
+
 ```rust
 use solana_program_log::log;
 
@@ -109,6 +132,7 @@ log!("transfer amount (SOL: {:.9}", lamports);
 ```
 
 For `&str` types, it is possible to specify a maximum length and a truncation strategy using one of the `Argument::Truncate*` variants:
+
 ```rust
 use solana_program_log::{Attribute, Logger};
 
@@ -125,6 +149,7 @@ logger.log();
 ```
 
 or a formatting string on the `log!` macro:
+
 ```rust
 use solana_program_log::log;
 
@@ -139,13 +164,15 @@ log!("{:>.10}", program_name);
 
 Formatting options are represented by `Attribute` variants and can be passed to the `Logger` when appending messages using `append_with_args`.
 
-| Variant                | Description                                     | Macro Format     |
-| ---------------------- | ----------------------------------------------- | ---------------- |
-| `Precision(u8)`        | Number of decimal places to display for numbers`*` | "{.*precision*}" |
-| `TruncateEnd(usize)`   | Truncate the output at the end when the specified maximum number of characters (size) is exceeded | "{>.*size*}"     |
-| `TruncateStart(usize)` | Truncate the output at the start when the specified maximum number of characters (size) is exceeded | "{<.*size*}"     |
+| Variant                | Description                                                                                         | Macro Format     |
+| ---------------------- | --------------------------------------------------------------------------------------------------- | ---------------- |
+| `Precision(u8)`        | Number of decimal places to display for numbers`*`                                                  | "{._precision_}" |
+| `TruncateEnd(usize)`   | Truncate the output at the end when the specified maximum number of characters (size) is exceeded   | "{>._size_}"     |
+| `TruncateStart(usize)` | Truncate the output at the start when the specified maximum number of characters (size) is exceeded | "{<._size_}"     |
 
 `*` The `Precision` adds a decimal formatting to integer numbers. This is useful to log numeric integer amounts that represent values with decimal precision.
+
+**Note**: `Pubkey`s are logged in **Hexadecimal** format to minimize Compute Unit usage. If you strictly require Base58, use `msg!("{}", pubkey)`.
 
 ## License
 


### PR DESCRIPTION
### Summary
- **solana-bn254**: Suppressed `unknown_lints` for `manual_is_multiple_of` to ensure build stability across different Rust toolchains.
- **solana-program-log**: Introduced an optional `solana-pubkey` feature to enable high-efficiency logging for addresses.

### Technical Details
- Implemented `Log` trait for `Pubkey` using **Hexadecimal encoding** ($O(N)$ complexity).
- This provides a significant Compute Unit (CU) saving compared to the standard Base58 ($O(N^2)$) used in `msg!`.
- **Zero-allocation**: Uses direct memory writes and bitwise operations to minimize stack and CPU overhead.
- The feature is gated behind `solana-pubkey` to maintain the crate's lightweight default state.