### PR TITLE
[bls-signatures] Update verification to take in references to byte arrays

### DIFF
--- a/bls-signatures/src/macros.rs
+++ b/bls-signatures/src/macros.rs
@@ -279,6 +279,22 @@ macro_rules! impl_bls_conversions {
             }
         }
 
+        impl $as_projective_trait for &[u8; $uncompressed_size] {
+            fn try_as_projective(&self) -> Result<$projective, crate::error::BlsError> {
+                // self is &&[u8; N], so **self gets [u8; N]
+                let wrapper = $uncompressed(**self);
+                $projective::try_from(&wrapper)
+            }
+        }
+
+        impl $as_projective_trait for &[u8; $compressed_size] {
+            fn try_as_projective(&self) -> Result<$projective, crate::error::BlsError> {
+                // self is &&[u8; N], so **self gets [u8; N]
+                let wrapper = $compressed(**self);
+                $projective::try_from(&wrapper)
+            }
+        }
+
         // AsAffine
         impl $as_affine_trait for $affine {
             fn try_as_affine(&self) -> Result<$affine, crate::error::BlsError> {
@@ -309,6 +325,20 @@ macro_rules! impl_bls_conversions {
         impl $as_affine_trait for [u8; $compressed_size] {
             fn try_as_affine(&self) -> Result<$affine, crate::error::BlsError> {
                 let wrapper = $compressed(*self);
+                $affine::try_from(&wrapper)
+            }
+        }
+
+        impl $as_affine_trait for &[u8; $uncompressed_size] {
+            fn try_as_affine(&self) -> Result<$affine, crate::error::BlsError> {
+                let wrapper = $uncompressed(**self);
+                $affine::try_from(&wrapper)
+            }
+        }
+
+        impl $as_affine_trait for &[u8; $compressed_size] {
+            fn try_as_affine(&self) -> Result<$affine, crate::error::BlsError> {
+                let wrapper = $compressed(**self);
                 $affine::try_from(&wrapper)
             }
         }


### PR DESCRIPTION
#### Problem

I tried upgrading agave to use the `bls-signatures` v2.0 locally on my machine and I noticed a small annoyance.

In the vote program, we have a function that we most likely want to write it as follows:

```
pub fn verify_bls_proof_of_possession(
    vote_account_pubkey: &Pubkey,
    bls_pubkey_compressed_bytes: &[u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
    bls_proof_of_possession_compressed_bytes: &[u8; BLS_PROOF_OF_POSSESSION_COMPRESSED_SIZE],
) -> Result<(), InstructionError> {
    let message = generate_pop_message(vote_account_pubkey, bls_pubkey_compressed_bytes);

    // this works
    (*bls_proof_of_possession_compressed_bytes)
        .verify(bls_pubkey_compressed_bytes, Some(&message))
        .map_err(|_| InstructionError::InvalidArgument)

    // but this does not work
    // bls_proof_of_possession_compressed_bytes
    //     .verify(bls_pubkey_compressed_bytes, Some(&message))
    //    .map_err(|_| InstructionError::InvalidArgument)
}
```

In https://github.com/anza-xyz/solana-sdk/pull/493, we added support to verify signatures and PoPs directly from byte arrays. However, the `verify(...)` function accepts only byte arrays as inputs, not references to byte arrays, which is actually what we need to get a clean implementation.

#### Summary of Changes

Added support for verifying signatures and PoPs directly from references to byte arrays as well.