### PR TITLE
[bn254] Remove subgroup check on G2 addition

### DIFF
--- a/bn254/src/addition.rs
+++ b/bn254/src/addition.rs
@@ -67,10 +67,6 @@ pub enum VersionedG2Addition {
 /// for validator code. Solana programs or other downstream projects should use
 /// `alt_bn128_g1_addition_be` or `alt_bn128_g1_addition_le` instead.
 ///
-/// # Security Note: Unlike G2 addition, G1 addition validates both the curve equation
-/// and the subgroup (coset). Future versions may relax this to check only the
-/// curve equation.
-///
 /// # Warning
 ///
 /// Developers should be extremely careful when modifying this function, as a breaking change
@@ -219,8 +215,9 @@ pub fn alt_bn128_g1_addition_le(
 /// for validator code. Solana programs or other downstream projects should use
 /// `alt_bn128_g2_addition_be` or `alt_bn128_g2_addition_le` instead.
 ///
-/// # Security Note: Unlike G1 addition, G2 addition validates only the curve equation;
-/// it does not perform a subgroup (coset) check.
+/// # Security Note: Unlike G1, which has cofactor 1, the group G2 has a high cofactor.
+/// This G2 addition function validates only the curve equation; it does not perform
+/// a subgroup (coset) check.
 ///
 /// # Warning
 ///

--- a/bn254/src/lib.rs
+++ b/bn254/src/lib.rs
@@ -237,8 +237,7 @@ mod target_arch {
     }
 
     impl PodG2 {
-        /// Takes in an EIP-197 (big-endian) byte encoding of a group element in G2
-        /// and constructs a `PodG2` struct that encodes the same bytes in little-endian.
+        /// Deserializes to an affine point in G2.
         /// This function performs the curve equation check, but skips the subgroup check.
         pub(crate) fn into_affine_unchecked(self) -> Result<G2, AltBn128Error> {
             if self.0 == [0u8; 128] {


### PR DESCRIPTION
#### Problem

I benchmarked the G2 addition and multiplication to assign their compute units. However, it seems like G2 addition performs about 20x that of G1 addition. We can go ahead and assign appropriate CUs, but 20x seems a little too much.

The reason why G2 addition is so much slower than G1 addition is due to the subgroup (coset) check. The subgroup validity check is almost trivial for G1 (has cofactor of 1), but computationally very expensive for G2 since the cofactor is quite large.

We can assign the higher CUs for Agave 4.0 and relax the check in 4.1 (and lower CU then), but given the demand for this feature in Agave 4.0, I think it is preferable to ship with optimal CUs now for 4.0.

After the subgroup check is removed, the G2 addition costs about x2.15 that of G1 addition.

#### Summary of Changes

I removed the subgroup check for G2. Changing the subgroup check for G1 will be a breaking change and will require a SIMD, so I left it the same.

Let's relax G2 addition and merge it to agave 4.0. Then let's add a SIMD to relax G1 subgroup check for agave 4.1.

Related discussion: https://github.com/anza-xyz/solana-sdk/pull/494#discussion_r2683751718

cc: @0x0ece 