### PR TITLE
feat: make solana-inflation crate no_std compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1889,6 +1889,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "light-poseidon"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2027,6 +2033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3434,6 +3441,7 @@ dependencies = [
 name = "solana-inflation"
 version = "3.0.0"
 dependencies = [
+ "num-traits",
  "serde",
  "serde_derive",
  "solana-frozen-abi",

--- a/inflation/Cargo.toml
+++ b/inflation/Cargo.toml
@@ -17,6 +17,7 @@ frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 serde = ["dep:serde", "dep:serde_derive"]
 
 [dependencies]
+num-traits = { workspace = true, default-features = false, features = ["libm"] }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 solana-frozen-abi = { workspace = true, optional = true }

--- a/inflation/src/lib.rs
+++ b/inflation/src/lib.rs
@@ -1,8 +1,13 @@
 //! configuration for network inflation
+#![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
+
+// The import is required for no_std compilation because .powf() which comes from the Float trait (not from std's inherent f64 methods).
+#[allow(unused_imports)]
+use num_traits::Float;
 
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
@@ -89,7 +94,7 @@ impl Inflation {
     /// inflation rate at year
     pub fn total(&self, year: f64) -> f64 {
         assert!(year >= 0.0);
-        let tapered = self.initial * ((1.0 - self.taper).powf(year));
+        let tapered = self.initial * (1.0 - self.taper).powf(year);
 
         if tapered > self.terminal {
             tapered

--- a/scripts/check-no-std.sh
+++ b/scripts/check-no-std.sh
@@ -21,6 +21,7 @@ no_std_crates=(
   -p solana-epoch-stake
   -p solana-fee-calculator
   -p solana-hash
+  -p solana-inflation
   -p solana-instruction-view
   -p solana-keccak-hasher
   -p solana-msg


### PR DESCRIPTION
### Problem

`solana-inflation` crate is `no_std`-friendly but not really no_std compatible

the main obstacle in making this crate compatible with no_std environment is `powf()` method on `f64` type which doesn't exist.

### Proposed Solution

import `num_traits::Float` trait, which is accessible in `libm` feature.

### Alternatives

1. import `libm` directly
2. copy/paste only `powf()` function from `libm` crate, and use it instead