### PR TITLE
rust: Bump stable toolchain to 1.93

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.93.0"


### PR DESCRIPTION
#### Problem

The repo is on an older Rust version, but we should be running and testing against newer versions.

#### Summary of changes

Bump the stable toolchain to the newest release, 1.93.0. We'll take care of nightly later.