### PR TITLE
v3.x: ci: Partition powerset job (#505)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -233,6 +233,9 @@ jobs:
     name: Cargo check powerset
     runs-on: ubuntu-latest
     needs: [sanity]
+    strategy:
+      matrix:
+        partition: [1, 2, 3, 4, 5, 6]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v4
@@ -251,7 +254,7 @@ jobs:
           tool: cargo-hack
 
       - name: Check feature powerset
-        run: ./scripts/check-powerset.sh
+        run: ./scripts/check-powerset.sh --partition ${{ matrix.partition }}/6
 
   msrv:
     name: Check minimum supported Rust version
@@ -573,3 +576,32 @@ jobs:
 
       - name: Run check
         run: ./scripts/check-no-std.sh
+
+  all-jobs-done:
+    name: Run when all jobs done
+    runs-on: ubuntu-latest
+    needs:
+      - sanity
+      - check-crates
+      - audit
+      - format
+      - clippy
+      - check
+      - check-dcou
+      - check-crate-order-for-publishing
+      - check-no-std
+      - minimal-versions
+      - powerset
+      - msrv
+      - doc
+      - sort
+      - frozen-abi
+      - miri
+      - build-sbf
+      - test-bench
+      - test-coverage
+      - test-doc
+      - test-stable
+      - test-wasm
+    steps:
+      - run: echo "All done"

--- a/scripts/check-powerset.sh
+++ b/scripts/check-powerset.sh
@@ -5,4 +5,4 @@ here="$(dirname "$0")"
 src_root="$(readlink -f "${here}/..")"
 cd "${src_root}"
 
-./cargo nightly hack clippy --feature-powerset --no-dev-deps -- --deny=warnings
+./cargo nightly hack clippy --feature-powerset --no-dev-deps "${@}" -- --deny=warnings


### PR DESCRIPTION
Manual backport of #505, needed to do some releases on the maintenance v3.x branch

* ci: Partition powerset job

#### Problem

The powerset job takes a long time in the 30-40 minutes range. This is annoying for development.

#### Summary of changes

We could eventually look into only running on `--each-feature`, but for now, let's partition the powerset job into 6, which should make things much faster for devs.

* Add a `all-jobs-done` job at the end