### PR TITLE
CI: Don't document dependencies

### DIFF
--- a/scripts/check-doc.sh
+++ b/scripts/check-doc.sh
@@ -6,4 +6,4 @@ src_root="$(readlink -f "${here}/..")"
 cd "${src_root}"
 
 export RUSTDOCFLAGS="-D warnings"
-./cargo nightly hack doc --all-features
+./cargo nightly hack doc --all-features --no-deps


### PR DESCRIPTION
#### Problem

The docs check in CI is quite slow, probably because we're also documenting dependencies.

#### Summary of changes

Don't document dependencies using `--no-deps`