### PR TITLE
deps: Bump wincode version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4991,9 +4991,9 @@ dependencies = [
 
 [[package]]
 name = "wincode"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f3b138135dd5aff3f86354f80737426b3ae2283270ab5aa0f8cbc800482650"
+checksum = "d5cec722a3274e47d1524cbe2cea762f2c19d615bd9d73ada21db9066349d57e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5004,9 +5004,9 @@ dependencies = [
 
 [[package]]
 name = "wincode-derive"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f691c8531d0cbf1bc097c6e7e8651c4ac6a29e41b80f523b8b774d93cbbf491e"
+checksum = "8961eb04054a1b2e026b5628e24da7e001350249a787e1a85aa961f33dc5f286"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -335,7 +335,7 @@ tiny-bip39 = "2.0.0"
 toml = "0.8.23"
 uriparse = "0.6.4"
 wasm-bindgen = "0.2.100"
-wincode = { version = "0.2.2", features = ["derive"], default-features = false }
+wincode = { version = "0.2.5", features = ["derive"], default-features = false }
 
 [profile.release]
 split-debuginfo = "unpacked"


### PR DESCRIPTION
### Problem

Currently any crate that enables wincode by default will probably fail the check-minimum-versions since wincode-derive version (`v0.2.3`) used is not compatible with the minimum wincode version (`v0.2.2`). A failed run can be seen here: https://github.com/anza-xyz/solana-sdk/actions/runs/21654623180/job/62426768758?pr=542

### Solution

Bump wincode to `v0.2.5`.