### PR TITLE
message: Pre-allocate capacity in `LoadedMessage`

### DIFF
--- a/message/src/versions/v0/loaded.rs
+++ b/message/src/versions/v0/loaded.rs
@@ -109,7 +109,7 @@ impl<'a> LoadedMessage<'a> {
 
     /// Returns true if any account keys are duplicates
     pub fn has_duplicates(&self) -> bool {
-        let mut uniq = HashSet::new();
+        let mut uniq = HashSet::with_capacity(self.account_keys().len());
         self.account_keys().iter().any(|x| !uniq.insert(x))
     }
 


### PR DESCRIPTION
### Problem

The method to detect whether a message has duplicated account keys or not uses a `HashSet` without specifying a capacity. This might lead to unwanted reallocations.

### Solution

Use `HashSet::with_capacity` with the maximum number of accounts as capacity.