### PR TITLE
bump wincode to 0.4.3; drop safety for VersionedTransaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4118,9 +4118,6 @@ name = "solana-short-vec"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3bd991c2cc415291c86bb0b6b4d53e93d13bb40344e4c5a2884e0e4f5fa93f"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "solana-shred-version"
@@ -5009,9 +5006,9 @@ dependencies = [
 
 [[package]]
 name = "wincode"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd358c35ea3fbf8590e8b9d9e7fe6450701c520c8b58c320aea0b8b75f8d9866"
+checksum = "6d1068d2b3145b56f47cd84e5eb99d3371bf03605bb4ee1b1efb519ff23d92f7"
 dependencies = [
  "pastey",
  "proc-macro2",
@@ -5023,9 +5020,9 @@ dependencies = [
 
 [[package]]
 name = "wincode-derive"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6505f603ab2302ff300837c3c96e5b1c6e4b65a66b756e3eb07376c935ff1907"
+checksum = "0cfae870aaafeb47dd6eed6b48a945c3da75cc03ae6cbddc651bc3808526eadf"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -335,7 +335,7 @@ tiny-bip39 = "2.0.0"
 toml = "0.8.23"
 uriparse = "0.6.4"
 wasm-bindgen = "0.2.100"
-wincode = { version = "0.4.1", features = ["derive"], default-features = false }
+wincode = { version = "0.4.3", features = ["derive"], default-features = false }
 
 [profile.release]
 split-debuginfo = "unpacked"

--- a/message/src/legacy.rs
+++ b/message/src/legacy.rs
@@ -16,7 +16,7 @@ use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::{frozen_abi, AbiExample};
 #[cfg(feature = "wincode")]
-use wincode::{containers, len::ShortU16, SchemaRead, SchemaWrite};
+use wincode::{containers, len::ShortU16, SchemaRead, SchemaWrite, UninitBuilder};
 use {
     crate::{
         compiled_instruction::CompiledInstruction, compiled_keys::CompiledKeys,
@@ -75,11 +75,7 @@ fn compile_instructions(ixs: &[Instruction], keys: &[Address]) -> Vec<CompiledIn
     derive(Deserialize, Serialize),
     serde(rename_all = "camelCase")
 )]
-#[cfg_attr(
-    feature = "wincode",
-    derive(SchemaWrite, SchemaRead),
-    wincode(struct_extensions)
-)]
+#[cfg_attr(feature = "wincode", derive(SchemaWrite, SchemaRead, UninitBuilder))]
 #[derive(Default, Debug, PartialEq, Eq, Clone)]
 pub struct Message {
     /// The message header, identifying signed and read-only `account_keys`.

--- a/message/src/lib.rs
+++ b/message/src/lib.rs
@@ -49,7 +49,7 @@ use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::AbiExample;
 #[cfg(feature = "wincode")]
-use wincode::{SchemaRead, SchemaWrite};
+use wincode::{SchemaRead, SchemaWrite, UninitBuilder};
 use {solana_sdk_ids::bpf_loader_upgradeable, std::collections::HashSet};
 
 #[cfg(not(target_os = "solana"))]
@@ -116,11 +116,7 @@ pub const MESSAGE_HEADER_LENGTH: usize = 3;
     derive(Deserialize, Serialize),
     serde(rename_all = "camelCase")
 )]
-#[cfg_attr(
-    feature = "wincode",
-    derive(SchemaWrite, SchemaRead),
-    wincode(struct_extensions)
-)]
+#[cfg_attr(feature = "wincode", derive(SchemaWrite, SchemaRead, UninitBuilder))]
 #[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
 pub struct MessageHeader {
     /// The number of signatures required for this message to be considered


### PR DESCRIPTION
wincode-derive 0.4.1 deprecates the `struct_extensions` derive attribute and exposes it as a standalone derive macro, `#[derive(UninitBuilder)]`.

`UninitBuilder` can significantly simplify manual `SchemaRead` implementations, as it provides methods for dealing with uninitialized fields and provides implicit drop-safety through an internal initialization bitset. It also plugs directly into derive attributions like `#[wincode(with)]` such that custom serialization (e.g., `Vec<u8, ShortU16>`) is respected in builder methods.

This PR does two things:
1. Converts existing `#[wincode(struct_extensions)]` to use `#[derive(UninitBuilder)]`
2. Updates the `SchemaRead` impl of `VersionedTransaction` to use the uninit builder.

This change also fixes a potential memory-leak in the current implementation.

https://github.com/anza-xyz/solana-sdk/blob/a1ca3879cbcd79cea2fa2a52af19049c2986e627/transaction/src/versioned/mod.rs#L309-L319

This (correctly) initializes the `Vec<Signature>` directly into the destination. But, if the second `VersionedMessage::read` were to fail, that `Vec<Signature>` would not be dropped, since it is initialized directly on the destination, which is a `MaybeUninit<VersionedTransaction>`.

The `UninitBuilder` solves this with its initialization tracking, such that on drop, all initialized fields are dropped.
