### PR TITLE
[bls-signatures] Add interface to pre-hash message

### DIFF
--- a/bls-signatures/src/hash.rs
+++ b/bls-signatures/src/hash.rs
@@ -1,4 +1,7 @@
-use {crate::proof_of_possession::POP_DST, blstrs::G2Projective};
+use {
+    crate::proof_of_possession::POP_DST,
+    blstrs::{G2Affine, G2Projective},
+};
 
 /// Domain separation tag used for hashing messages to curve points to prevent
 /// potential conflicts between different BLS implementations. This is defined
@@ -10,14 +13,43 @@ pub const HASH_TO_POINT_DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NU
 ///
 /// If hashing a payload for a Proof-of-Possession (PoP), use
 /// `hash_pop_payload_to_point` instead.
+#[deprecated(since = "3.1.0", note = "Use `HashedMessage::new` instead")]
 pub fn hash_signature_message_to_point(message: &[u8]) -> G2Projective {
     G2Projective::hash_to_curve(message, HASH_TO_POINT_DST, &[])
 }
 
-/// Hash a message to a G2 point for proof-of-possession generation and verification
-///
-/// If hashing a message for a standard BLS signature, use
-/// `hash_signature_message_to_point` instead.
-pub(crate) fn hash_pop_payload_to_point(payload: &[u8]) -> G2Projective {
+/// A pre-hashed message (G2 point) for optimized verification.
+/// For certain applications, re-using hash-to-curve operation can be used as a form of
+/// optimization.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct HashedMessage(pub(crate) G2Affine);
+
+impl HashedMessage {
+    /// Hash a message to a curve point (G2) and prepare it for verification.
+    pub fn new(message: &[u8]) -> Self {
+        let point = G2Projective::hash_to_curve(message, HASH_TO_POINT_DST, &[]);
+        Self(point.into())
+    }
+}
+
+/// A pre-hashed Proof-of-Possession (G2 point) for optimized verification.
+/// For certain applications, re-using hash-to-curve operation can be used as a form of
+/// optimization.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct HashedPoPPayload(pub(crate) G2Affine);
+
+impl HashedPoPPayload {
+    /// Hash a message to a curve point (G2) and prepare it for verification.
+    pub fn new(payload: &[u8]) -> Self {
+        let point = G2Projective::hash_to_curve(payload, POP_DST, &[]);
+        Self(point.into())
+    }
+}
+
+pub(crate) fn hash_message_to_projective(message: &[u8]) -> G2Projective {
+    G2Projective::hash_to_curve(message, HASH_TO_POINT_DST, &[])
+}
+
+pub(crate) fn hash_pop_to_projective(payload: &[u8]) -> G2Projective {
     G2Projective::hash_to_curve(payload, POP_DST, &[])
 }

--- a/bls-signatures/src/secret_key.rs
+++ b/bls-signatures/src/secret_key.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         error::BlsError,
-        hash::{hash_pop_payload_to_point, hash_signature_message_to_point},
+        hash::{hash_message_to_projective, hash_pop_to_projective},
         proof_of_possession::ProofOfPossessionProjective,
         pubkey::PubkeyProjective,
         signature::SignatureProjective,
@@ -69,11 +69,11 @@ impl SecretKey {
     #[allow(clippy::arithmetic_side_effects)]
     pub fn proof_of_possession(&self, payload: Option<&[u8]>) -> ProofOfPossessionProjective {
         let hashed_point = if let Some(bytes) = payload {
-            hash_pop_payload_to_point(bytes)
+            hash_pop_to_projective(bytes)
         } else {
             let pubkey = PubkeyProjective::from_secret(self);
             let pubkey_bytes = pubkey.to_bytes_compressed();
-            hash_pop_payload_to_point(&pubkey_bytes)
+            hash_pop_to_projective(&pubkey_bytes)
         };
         ProofOfPossessionProjective(hashed_point * self.0)
     }
@@ -81,7 +81,7 @@ impl SecretKey {
     /// Sign a message using the provided secret key
     #[allow(clippy::arithmetic_side_effects)]
     pub fn sign(&self, message: &[u8]) -> SignatureProjective {
-        let hashed_message = hash_signature_message_to_point(message);
+        let hashed_message = hash_message_to_projective(message);
         SignatureProjective(hashed_message * self.0)
     }
 }

--- a/bls-signatures/src/signature/points.rs
+++ b/bls-signatures/src/signature/points.rs
@@ -11,7 +11,7 @@ use blstrs::G1Projective;
 use {
     crate::{
         error::BlsError,
-        hash::hash_signature_message_to_point,
+        hash::HashedMessage,
         pubkey::{AddToPubkeyProjective, AsPubkeyAffine, PubkeyProjective, VerifiablePubkey},
         signature::bytes::{Signature, SignatureCompressed},
     },
@@ -147,7 +147,7 @@ impl SignatureProjective {
 
         let mut prepared_hashes = alloc::vec::Vec::with_capacity(messages.len());
         for message in messages {
-            let hashed_message: G2Affine = hash_signature_message_to_point(message).into();
+            let hashed_message = HashedMessage::new(message).0;
             prepared_hashes.push(G2Prepared::from(hashed_message));
         }
 
@@ -292,8 +292,7 @@ impl SignatureProjective {
                     messages
                         .par_iter()
                         .map(|msg| {
-                            let hashed_message: G2Affine =
-                                hash_signature_message_to_point(msg).into();
+                            let hashed_message: G2Affine = HashedMessage::new(msg).0;
                             Ok::<_, BlsError>(G2Prepared::from(hashed_message))
                         })
                         .collect()


### PR DESCRIPTION
#### Problem

For BLS signatures verification, hashing a message to a point on the curve is an expensive operation. Therefore, caching these messages is a popular optimization. However, the current verification API doesn't expose functions that take in pre-hashed messages.

#### Summary of Changes

Add functions that take in pre-hashed messages and PoP payloads.