### PR TITLE
account-view!: Remove resize

### DIFF
--- a/account-view/src/lib.rs
+++ b/account-view/src/lib.rs
@@ -355,10 +355,6 @@ impl AccountView {
     /// The lamports must be moved from the account prior to closing it to prevent
     /// an unbalanced instruction error.
     ///
-    /// If [`Self::resize`] is called after closing the account, it might incorrectly
-    /// return an error for going over the limit if the account previously had space
-    /// allocated since this method does not update the [`Self::resize_delta`] value.
-    ///
     /// # Safety
     ///
     /// This method is unsafe because it does not check if the account data is already


### PR DESCRIPTION
### Problem

Currently account resizing is implemented by tracking the difference in length, which is updated in every call to `resize`. This logic does not work when the account is resized via a CPI before any call to `resize`.

1. account is passed to instruction with len = 0
2. program invokes `system_program::create_account` and initializes the account with space (len = 10240 )
3. program then resizes account to anything `> 10240` – allowed since `resize_delta = 0`
4. program now in UB since account data pointer goes over the `10240` account padding

### Solution

Since the resize logic is closely related to how an entrypoint parses the program input, this PR removes the resize functionality from the `AccountView`. Entrypoints like pinocchio should implemented their own logic.