### PR TITLE
Bump wincode version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5006,9 +5006,9 @@ dependencies = [
 
 [[package]]
 name = "wincode"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d1068d2b3145b56f47cd84e5eb99d3371bf03605bb4ee1b1efb519ff23d92f7"
+checksum = "466e67917609b2d40a838a5b972d1a6237c9749600cb8de8f65559b90d48485b"
 dependencies = [
  "pastey",
  "proc-macro2",
@@ -5020,9 +5020,9 @@ dependencies = [
 
 [[package]]
 name = "wincode-derive"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cfae870aaafeb47dd6eed6b48a945c3da75cc03ae6cbddc651bc3808526eadf"
+checksum = "26a7a568eda854acc9945ed136a9d50b8c6d31911584624958808ae96eee3912"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -335,7 +335,7 @@ tiny-bip39 = "2.0.0"
 toml = "0.8.23"
 uriparse = "0.6.4"
 wasm-bindgen = "0.2.100"
-wincode = { version = "0.4.3", features = ["derive"], default-features = false }
+wincode = { version = "0.4.4", features = ["derive"], default-features = false }
 
 [profile.release]
 split-debuginfo = "unpacked"


### PR DESCRIPTION
### Problem

Since wincode-derive `0.4.2` was released, the minimal versions check in CI is broken because it picks up the new wincode-derive version with an incompatible wincode one. A new `by_ref` method was added to wincode `0.4.4`, which is used by wincode-derive `0.4.2`, but currently the workspace is using wincode `0.4.3`.

### Solution

Bump wincode to `0.4.4`.