### PR TITLE
ci: Add run-semver option

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -42,6 +42,14 @@ on:
         options:
           - fix
           - upgrade
+      run_semver:
+        description: |
+          Run semver checks.
+          Only disable checks if you are sure of the semver impact of your change and have a good reason
+          to skip it.
+        required: true
+        type: boolean
+        default: true
 
 jobs:
   sanity:
@@ -200,7 +208,7 @@ jobs:
           cargo release $LEVEL --manifest-path "${{ inputs.package_path }}/Cargo.toml" --no-tag --no-publish --no-push --no-confirm --execute
 
       - name: Check semver
-        if: ${{ steps.is_proc_macro.outputs.is_proc_macro == 'false' }}
+        if: ${{ steps.is_proc_macro.outputs.is_proc_macro == 'false' && github.event.inputs.run_semver == 'true'}}
         run: cargo semver-checks --manifest-path "${{ inputs.package_path }}/Cargo.toml"
 
   publish-crate:


### PR DESCRIPTION
### Problem

There are circumstances in which it’s necessary to disable semver checks during publishing. For example, when bumping “unstable” dependencies without creating a new major version for a crate.

### Solution

Add an option to disable running the semver check.