### PR TITLE
sdk-macro: Bump workspace version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -294,7 +294,7 @@ solana-reward-info = { path = "reward-info", version = "5.0.0" }
 solana-sanitize = { path = "sanitize", version = "3.0.0" }
 solana-sdk = { path = "sdk", version = "4.0.1" }
 solana-sdk-ids = { path = "sdk-ids", version = "3.0.0" }
-solana-sdk-macro = { path = "sdk-macro", version = "3.0.0" }
+solana-sdk-macro = { path = "sdk-macro", version = "3.0.1" }
 solana-sdk-wasm-js = { path = "sdk-wasm-js", version = "2.0.0" }
 solana-secp256k1-program = { path = "secp256k1-program", version = "3.0.0" }
 solana-secp256k1-recover = { path = "secp256k1-recover", version = "3.0.0" }


### PR DESCRIPTION
### Problem

Latest sdk-macro removed the requirement of having `Copy` implemented for fields when the `CloneZeroed` is used, but the workspace still one patch version behind. This generates an error in the minimal-versions check.

### Solution

Bump the workspace version.