### PR TITLE
[bls-signatures] Make domain separation tags for signatures and PoP consistent

### DIFF
--- a/bls-signatures/src/hash.rs
+++ b/bls-signatures/src/hash.rs
@@ -7,7 +7,7 @@ use {
 /// potential conflicts between different BLS implementations. This is defined
 /// as the ciphersuite ID string as recommended in the
 /// [standard](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#section-4.2.1).
-pub const HASH_TO_POINT_DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_";
+pub const HASH_TO_POINT_DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_POP_";
 
 /// Hash a message to a G2 point for signature generation and verification
 ///

--- a/bls-signatures/src/proof_of_possession/mod.rs
+++ b/bls-signatures/src/proof_of_possession/mod.rs
@@ -16,7 +16,7 @@ pub use points::{
 /// Domain separation tag used when hashing public keys to G2 in the proof of
 /// possession signing and verification functions. See the
 /// [standard](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#section-4.2.3).
-pub const POP_DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
+pub const POP_DST: &[u8] = b"BLS_POP_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
#### Problem

We used an inconsistent domain separation tag compared to specification.

#### Summary of Changes

Fixed the constants:
- `BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_` -> `BLS_POP_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_` for PoP
- In our crate, we assume that public keys are PoP, updated `BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_` -> BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_POP_` for hash to point dst for signatures.