### PR TITLE
[bls-signatures] Add identity point checks when converting to affine or projective points

### DIFF
--- a/bls-signatures/src/proof_of_possession/conversion.rs
+++ b/bls-signatures/src/proof_of_possession/conversion.rs
@@ -24,5 +24,6 @@ impl_bls_conversions!(
     AsProofOfPossessionProjective,
     AsProofOfPossessionAffine,
     BLS_PROOF_OF_POSSESSION_COMPRESSED_SIZE,
-    BLS_PROOF_OF_POSSESSION_AFFINE_SIZE
+    BLS_PROOF_OF_POSSESSION_AFFINE_SIZE,
+    false
 );

--- a/bls-signatures/src/proof_of_possession/mod.rs
+++ b/bls-signatures/src/proof_of_possession/mod.rs
@@ -184,4 +184,32 @@ mod tests {
         let result = pubkey_bytes.verify_proof_of_possession(&bad_pop_bytes, None);
         assert!(result.is_err());
     }
+
+    #[test]
+    fn test_identity_pop_behavior() {
+        use {blstrs::G2Projective, group::Group};
+
+        let keypair = Keypair::new();
+
+        // Deserializing an identity PoP should succeed
+        let id_pop_proj = ProofOfPossessionProjective(G2Projective::identity());
+        let id_pop_compressed: ProofOfPossessionCompressed = (&id_pop_proj).into();
+        let id_pop_recovered: Result<ProofOfPossessionProjective, _> =
+            ProofOfPossessionProjective::try_from(&id_pop_compressed);
+        assert!(
+            id_pop_recovered.is_ok(),
+            "Identity PoPs must be allowed to deserialize"
+        );
+        assert_eq!(id_pop_proj, id_pop_recovered.unwrap());
+
+        // PoP Verification with an identity Pubkey must fail
+        let id_pubkey_proj = PubkeyProjective::identity();
+        let valid_pop = keypair.proof_of_possession(None);
+
+        let verify_result = id_pubkey_proj.verify_proof_of_possession(&valid_pop, None);
+        assert!(
+            verify_result.is_err(),
+            "PoP Verification with identity public key must fail"
+        );
+    }
 }

--- a/bls-signatures/src/pubkey/conversion.rs
+++ b/bls-signatures/src/pubkey/conversion.rs
@@ -20,5 +20,6 @@ impl_bls_conversions!(
     AsPubkeyProjective,
     AsPubkeyAffine,
     BLS_PUBLIC_KEY_COMPRESSED_SIZE,
-    BLS_PUBLIC_KEY_AFFINE_SIZE
+    BLS_PUBLIC_KEY_AFFINE_SIZE,
+    true
 );

--- a/bls-signatures/src/pubkey/mod.rs
+++ b/bls-signatures/src/pubkey/mod.rs
@@ -308,4 +308,22 @@ mod tests {
             "Mixed addition did not match projective addition for pubkeys"
         );
     }
+
+    #[test]
+    fn test_identity_pubkey_deserialization_fails() {
+        let id_pk_proj = PubkeyProjective::identity();
+
+        // Assert compressed byte conversion fails
+        let id_pk_compressed: PubkeyCompressed = (&id_pk_proj).into();
+        let recovered = PubkeyProjective::try_from(&id_pk_compressed);
+        assert_eq!(recovered.unwrap_err(), BlsError::PointConversion);
+
+        // Assert uncompressed byte conversion fails
+        let id_pk_uncompressed: Pubkey = (&id_pk_proj).into();
+        let recovered_uncompressed = PubkeyProjective::try_from(&id_pk_uncompressed);
+        assert_eq!(
+            recovered_uncompressed.unwrap_err(),
+            BlsError::PointConversion
+        );
+    }
 }

--- a/bls-signatures/src/pubkey/points.rs
+++ b/bls-signatures/src/pubkey/points.rs
@@ -13,7 +13,7 @@ use {
         signature::{AsSignatureAffine, SignatureAffine},
     },
     blstrs::{Bls12, G1Affine, G1Projective, G2Prepared, Gt, Scalar},
-    group::Group,
+    group::{prime::PrimeCurveAffine, Group},
     pairing::{MillerLoopResult, MultiMillerLoop},
 };
 
@@ -52,6 +52,10 @@ impl PubkeyProjective {
     }
 
     /// Aggregate a list of public keys into an existing aggregate
+    ///
+    /// Warning: This function performs mathematical point addition. It does not
+    /// perform public key validation (such as identity point checks) or Proof of
+    /// Possession (PoP) verification.
     #[allow(clippy::arithmetic_side_effects)]
     pub fn aggregate_with<'a, P: AddToPubkeyProjective + ?Sized + 'a>(
         &mut self,
@@ -64,6 +68,10 @@ impl PubkeyProjective {
     }
 
     /// Aggregate a list of public keys
+    ///
+    /// Warning: This function performs mathematical point addition. It does not
+    /// perform public key validation (such as identity point checks) or Proof of
+    /// Possession (PoP) verification.
     #[allow(clippy::arithmetic_side_effects)]
     pub fn aggregate<'a, P: AddToPubkeyProjective + ?Sized + 'a>(
         pubkeys: impl Iterator<Item = &'a P>,
@@ -111,6 +119,10 @@ impl PubkeyProjective {
     }
 
     /// Aggregate a list of public keys into an existing aggregate
+    ///
+    /// Warning: This function performs mathematical point addition. It does not
+    /// perform public key validation (such as identity point checks) or Proof of
+    /// Possession (PoP) verification.
     #[allow(clippy::arithmetic_side_effects)]
     #[cfg(feature = "parallel")]
     pub fn par_aggregate_with<'a, P: AddToPubkeyProjective + Sync + 'a>(
@@ -123,6 +135,10 @@ impl PubkeyProjective {
     }
 
     /// Aggregate a list of public keys
+    ///
+    /// Warning: This function performs mathematical point addition. It does not
+    /// perform public key validation (such as identity point checks) or Proof of
+    /// Possession (PoP) verification.
     #[allow(clippy::arithmetic_side_effects)]
     #[cfg(feature = "parallel")]
     pub fn par_aggregate<'a, P: AddToPubkeyProjective + Sync + 'a>(
@@ -230,6 +246,10 @@ impl PubkeyAffine {
         signature: &SignatureAffine,
         hashed_message: &HashedMessage,
     ) -> bool {
+        if bool::from(self.0.is_identity()) {
+            return false;
+        }
+
         // The verification equation is e(pubkey, H(m)) = e(g1, signature).
         // This can be rewritten as e(pubkey, H(m)) * e(-g1, signature) = 1, which
         // allows for a more efficient verification using a multi-miller loop.
@@ -257,6 +277,10 @@ impl PubkeyAffine {
         proof: &ProofOfPossessionAffine,
         hashed_payload: &HashedPoPPayload,
     ) -> bool {
+        if bool::from(self.0.is_identity()) {
+            return false;
+        }
+
         // The verification equation is e(pubkey, H(pubkey)) == e(g1, proof).
         // This is rewritten to e(pubkey, H(pubkey)) * e(-g1, proof) = 1 for batching.
         let hashed_pubkey = hashed_payload.0;

--- a/bls-signatures/src/secret_key.rs
+++ b/bls-signatures/src/secret_key.rs
@@ -97,7 +97,11 @@ impl TryFrom<&[u8]> for SecretKey {
         }
         // unwrap safe due to the length check above
         let scalar: Option<Scalar> = Scalar::from_bytes_le(bytes.try_into().unwrap()).into();
-        scalar.ok_or(BlsError::FieldDecode).map(Self)
+        let scalar = scalar.ok_or(BlsError::FieldDecode)?;
+        if bool::from(scalar.is_zero()) {
+            return Err(BlsError::FieldDecode);
+        }
+        Ok(Self(scalar))
     }
 }
 

--- a/bls-signatures/src/signature/conversion.rs
+++ b/bls-signatures/src/signature/conversion.rs
@@ -21,5 +21,6 @@ impl_bls_conversions!(
     AsSignatureProjective,
     AsSignatureAffine,
     BLS_SIGNATURE_COMPRESSED_SIZE,
-    BLS_SIGNATURE_AFFINE_SIZE
+    BLS_SIGNATURE_AFFINE_SIZE,
+    false
 );

--- a/bls-signatures/src/signature/mod.rs
+++ b/bls-signatures/src/signature/mod.rs
@@ -22,8 +22,8 @@ mod tests {
             error::BlsError,
             keypair::Keypair,
             pubkey::{
-                AsPubkeyProjective, Pubkey, PubkeyAffine, PubkeyCompressed, PubkeyProjective,
-                VerifiablePubkey,
+                AsPubkeyAffine, AsPubkeyProjective, Pubkey, PubkeyAffine, PubkeyCompressed,
+                PubkeyProjective, VerifiablePubkey,
             },
         },
         core::{iter::empty, str::FromStr},
@@ -528,5 +528,91 @@ mod tests {
         let mut acc = SignatureProjective::identity();
         unchecked_comp.add_to_accumulator(&mut acc).unwrap();
         assert_eq!(acc, sig_proj);
+    }
+
+    #[test]
+    fn test_identity_points_behavior() {
+        let keypair = Keypair::new();
+        let test_message = b"identity test message";
+
+        // Deserializing an identity Signature should succeed
+        let id_sig_proj = SignatureProjective::identity();
+        let id_sig_compressed: SignatureCompressed = (&id_sig_proj).into();
+        let id_sig_recovered: Result<SignatureProjective, _> =
+            SignatureProjective::try_from(&id_sig_compressed);
+        assert!(
+            id_sig_recovered.is_ok(),
+            "Identity signatures must be allowed to deserialize"
+        );
+        assert_eq!(id_sig_proj, id_sig_recovered.unwrap());
+
+        // Verifying with an identity Pubkey must fail
+        let id_pubkey_proj = PubkeyProjective::identity();
+        let valid_sig = keypair.sign(test_message);
+
+        let verify_result = id_pubkey_proj.verify_signature(&valid_sig, test_message);
+        assert!(
+            verify_result.is_err(),
+            "Verification with identity public key must fail"
+        );
+
+        // Aggregate public keys evaluating to identity must fail
+        assert!(id_pubkey_proj
+            .verify_signature(&id_sig_proj, test_message)
+            .is_err());
+
+        // Batch verification with an identity public key must fail
+        let pubkey_affine: PubkeyAffine = keypair.public;
+        let id_pubkey_affine: PubkeyAffine = id_pubkey_proj.try_as_affine().unwrap();
+
+        let dyn_pubkeys: std::vec::Vec<&dyn AsPubkeyProjective> =
+            std::vec![&pubkey_affine, &id_pubkey_affine];
+        let dyn_signatures: std::vec::Vec<&dyn AsSignatureProjective> =
+            std::vec![&valid_sig, &valid_sig];
+
+        assert!(
+            SignatureProjective::verify_aggregate(
+                dyn_pubkeys.into_iter(),
+                dyn_signatures.into_iter(),
+                test_message
+            )
+            .is_err(),
+            "Aggregate verification containing an identity public key must fail"
+        );
+
+        let pubkeys = [pubkey_affine, id_pubkey_affine];
+        let signatures = [Signature::from(&valid_sig), Signature::from(&valid_sig)];
+        let messages: std::vec::Vec<&[u8]> = std::vec![b"msg1", b"msg2"];
+
+        assert!(
+            SignatureProjective::verify_distinct(
+                pubkeys.iter(),
+                signatures.iter(),
+                messages.into_iter()
+            )
+            .is_err(),
+            "Batch distinct verification containing an identity public key must fail"
+        );
+    }
+
+    #[test]
+    fn test_aggregate_pubkeys_sum_to_identity() {
+        let keypair = Keypair::new();
+        let message = b"hello";
+
+        // An honest key and its exact opposite (negation)
+        let pk1 = PubkeyProjective::from(&keypair.public);
+        let mut pk2 = pk1;
+        pk2.0 = -pk2.0;
+
+        let id_sig = SignatureProjective::identity();
+
+        // Verify aggregate should definitively fail because the aggregated pubkey evaluates to identity
+        assert!(SignatureProjective::verify_aggregate(
+            [&pk1, &pk2].into_iter(),
+            [&id_sig].into_iter(),
+            message
+        )
+        .is_err());
     }
 }


### PR DESCRIPTION
#### Problem

The BLS spec requires that key validation rejects the identity point as a public key, but the current implementation accepts such keys.

#### Summary of Changes

- Added identity point checks on `TryFrom` implementations from either BLS `Pubkey` or `PubkeyCompressed`
- Updated the signature and PoP verification functions to explicitly reject identity public keys
- For the public key aggregation functions, I added warnings in the docs that the public keys are not checked to be non-identity points