### PR TITLE
vote-interface: fix incorrect doc comments and typo

### DIFF
--- a/vote-interface/src/state/vote_state_deserialize.rs
+++ b/vote-interface/src/state/vote_state_deserialize.rs
@@ -127,7 +127,7 @@ pub(super) fn deserialize_vote_state_into_v3(
     vote_state: *mut VoteStateV3,
     has_latency: bool,
 ) -> Result<(), InstructionError> {
-    // General safety note: we must use add_or_mut! to access the `vote_state` fields as the value
+    // General safety note: we must use addr_of_mut! to access the `vote_state` fields as the value
     // is assumed to be _uninitialized_, so creating references to the state or any of its inner
     // fields is UB.
 

--- a/vote-interface/src/state/vote_state_v3.rs
+++ b/vote-interface/src/state/vote_state_v3.rs
@@ -115,8 +115,7 @@ impl VoteStateV3 {
 
     /// Deserializes the input `VoteStateVersions` buffer directly into the provided `VoteStateV3`.
     ///
-    /// In a SBPF context, V0_23_5 is not supported, but in non-SBPF, all versions are supported for
-    /// compatibility with `bincode::deserialize`.
+    /// V0_23_5 is not supported. Supported versions: V1_14_11, V3.
     ///
     /// On success, `vote_state` reflects the state of the input data. On failure, `vote_state` is
     /// reset to `VoteStateV3::default()`.
@@ -132,8 +131,7 @@ impl VoteStateV3 {
     /// Deserializes the input `VoteStateVersions` buffer directly into the provided
     /// `MaybeUninit<VoteStateV3>`.
     ///
-    /// In a SBPF context, V0_23_5 is not supported, but in non-SBPF, all versions are supported for
-    /// compatibility with `bincode::deserialize`.
+    /// V0_23_5 is not supported. Supported versions: V1_14_11, V3.
     ///
     /// On success, `vote_state` is fully initialized and can be converted to
     /// `VoteStateV3` using

--- a/vote-interface/src/state/vote_state_v4.rs
+++ b/vote-interface/src/state/vote_state_v4.rs
@@ -115,8 +115,7 @@ impl VoteStateV4 {
 
     /// Deserializes the input `VoteStateVersions` buffer directly into the provided `VoteStateV4`.
     ///
-    /// In a SBPF context, V0_23_5 is not supported, but in non-SBPF, all versions are supported for
-    /// compatibility with `bincode::deserialize`.
+    /// V0_23_5 is not supported. Supported versions: V1_14_11, V3, V4.
     ///
     /// On success, `vote_state` reflects the state of the input data. On failure, `vote_state` is
     /// reset to `VoteStateV4::default()`.
@@ -135,8 +134,7 @@ impl VoteStateV4 {
     /// Deserializes the input `VoteStateVersions` buffer directly into the provided
     /// `MaybeUninit<VoteStateV4>`.
     ///
-    /// In a SBPF context, V0_23_5 is not supported, but in non-SBPF, all versions are supported for
-    /// compatibility with `bincode::deserialize`.
+    /// V0_23_5 is not supported. Supported versions: V1_14_11, V3, V4.
     ///
     /// On success, `vote_state` is fully initialized and can be converted to
     /// `VoteStateV4` using


### PR DESCRIPTION
#### Problem

A few of the doc comments around the deserialization API are incorrect or
misleading, mainly around their support for vote state `V0_23_5`.

#### Summary of Changes

Update the comments. Includes one typo fix. :)

Broken off #588 