### PR TITLE
[bls-signatures] Avoid redundant multiplication when generating PoP from keypair

### DIFF
--- a/bls-signatures/src/keypair.rs
+++ b/bls-signatures/src/keypair.rs
@@ -126,7 +126,7 @@ impl Keypair {
 
     pub fn write_json<W: Write>(&self, writer: &mut W) -> Result<String, Box<dyn error::Error>> {
         let json = serde_json::to_string(&Into::<[u8; BLS_KEYPAIR_SIZE]>::into(self).as_slice())?;
-        writer.write_all(&json.clone().into_bytes())?;
+        writer.write_all(json.as_bytes())?;
         Ok(json)
     }
 


### PR DESCRIPTION
#### Problem

Currently, when we call the `proof_of_possession` function on a BLS `Keypair` struct, it internally computes the public key from the private key to derive the message to hash for PoP. This is redundant since the public key is already available as part of the keypair.

#### Summary of Changes

Updated the code so that we avoid this redundant public key calculation.

It is an unrelated change, but there is also an unnecessary cloning happening when we write keypair as json, so I removed this too.