### PR TITLE
vote-interface: add test coverage for VoteStateVersions

### DIFF
--- a/vote-interface/src/state/vote_state_versions.rs
+++ b/vote-interface/src/state/vote_state_versions.rs
@@ -204,11 +204,13 @@ mod tests {
     use {
         super::*,
         crate::state::{VoteInit, BLS_PUBLIC_KEY_COMPRESSED_SIZE, DEFAULT_PRIOR_VOTERS_OFFSET},
+        rand::Rng,
         solana_clock::Clock,
+        solana_instruction::error::InstructionError,
     };
 
     #[test]
-    fn test_default_vote_state_is_uninitialized() {
+    fn test_v3_default_vote_state_is_uninitialized() {
         // The default `VoteStateV3` is stored to de-initialize a zero-balance vote account,
         // so must remain such that `VoteStateVersions::is_uninitialized()` returns true
         // when called on a `VoteStateVersions` that stores it
@@ -216,7 +218,13 @@ mod tests {
     }
 
     #[test]
-    fn test_is_correct_size_and_initialized() {
+    fn test_v4_default_vote_state_is_always_initialized() {
+        // Per SIMD-0185, V4 is always initialized.
+        assert!(!VoteStateVersions::new_v4(VoteStateV4::default()).is_uninitialized());
+    }
+
+    #[test]
+    fn test_is_correct_size_and_initialized_v3() {
         // Check all zeroes
         let mut vote_account_data = vec![0; VoteStateV3::size_of()];
         assert!(!VoteStateVersions::is_correct_size_and_initialized(
@@ -271,6 +279,45 @@ mod tests {
     }
 
     #[test]
+    fn test_is_correct_size_and_initialized_v4() {
+        // All zeros at V4 size — false (discriminant is 0, not 3).
+        let zeros = vec![0u8; VoteStateV4::size_of()];
+        assert!(!VoteStateVersions::is_correct_size_and_initialized(&zeros));
+
+        // Valid serialized V4 — true.
+        let versioned = VoteStateVersions::new_v4(VoteStateV4::default());
+        let mut buf = vec![0u8; VoteStateV4::size_of()];
+        VoteStateV4::serialize(&versioned, &mut buf).unwrap();
+        assert!(VoteStateVersions::is_correct_size_and_initialized(&buf));
+
+        // Populated V4 — true.
+        let vote_state = VoteStateV4::new_with_defaults(
+            &Pubkey::new_unique(),
+            &VoteInit {
+                node_pubkey: Pubkey::new_unique(),
+                authorized_voter: Pubkey::new_unique(),
+                authorized_withdrawer: Pubkey::new_unique(),
+                commission: 50,
+            },
+            &Clock::default(),
+        );
+        let versioned = VoteStateVersions::new_v4(vote_state);
+        let mut buf = vec![0u8; VoteStateV4::size_of()];
+        VoteStateV4::serialize(&versioned, &mut buf).unwrap();
+        assert!(VoteStateVersions::is_correct_size_and_initialized(&buf));
+
+        // Wrong length — false.
+        assert!(!VoteStateVersions::is_correct_size_and_initialized(
+            &buf[..buf.len() - 1]
+        ));
+        let mut extended = buf.clone();
+        extended.push(0);
+        assert!(!VoteStateVersions::is_correct_size_and_initialized(
+            &extended
+        ));
+    }
+
+    #[test]
     fn test_vote_state_version_conversion_bls_pubkey() {
         let vote_pubkey = Pubkey::new_unique();
 
@@ -298,7 +345,72 @@ mod tests {
     }
 
     #[test]
-    fn test_vote_state_versions_deserialize() {
+    fn test_versions_deserialize_invalid_variant_tags() {
+        let mut buf = vec![0u8; VoteStateV3::size_of()];
+
+        // Tag 0 (V0_23_5 — explicitly rejected).
+        assert_eq!(
+            VoteStateVersions::deserialize(&buf),
+            Err(InstructionError::InvalidAccountData)
+        );
+
+        // Tag 4 (unknown).
+        buf[..4].copy_from_slice(&4u32.to_le_bytes());
+        assert_eq!(
+            VoteStateVersions::deserialize(&buf),
+            Err(InstructionError::InvalidAccountData)
+        );
+
+        // Tag u32::MAX.
+        buf[..4].copy_from_slice(&u32::MAX.to_le_bytes());
+        assert_eq!(
+            VoteStateVersions::deserialize(&buf),
+            Err(InstructionError::InvalidAccountData)
+        );
+    }
+
+    #[test]
+    fn test_versions_deserialize_error_paths() {
+        // Empty input.
+        assert_eq!(
+            VoteStateVersions::deserialize(&[]),
+            Err(InstructionError::InvalidAccountData)
+        );
+
+        // Too short for variant tag.
+        assert_eq!(
+            VoteStateVersions::deserialize(&[1, 0, 0]),
+            Err(InstructionError::InvalidAccountData)
+        );
+
+        // Valid tag, truncated body.
+        let vote_state = VoteStateV3::new(
+            &VoteInit {
+                node_pubkey: Pubkey::new_unique(),
+                authorized_voter: Pubkey::new_unique(),
+                authorized_withdrawer: Pubkey::new_unique(),
+                commission: 50,
+            },
+            &Clock::default(),
+        );
+        let mut buf = bincode::serialize(&VoteStateVersions::new_v3(vote_state)).unwrap();
+        buf.truncate(buf.len() / 2);
+        assert_eq!(
+            VoteStateVersions::deserialize(&buf),
+            Err(InstructionError::InvalidAccountData)
+        );
+
+        // Random bytes — must not panic.
+        let mut rng = rand::rng();
+        for _ in 0..100 {
+            let len = rng.random_range(0u64..512);
+            let random_data: Vec<u8> = (0..len).map(|_| rng.random::<u8>()).collect();
+            let _ = VoteStateVersions::deserialize(&random_data);
+        }
+    }
+
+    #[test]
+    fn test_versions_deserialize_default() {
         let ser_deser = |original: VoteStateVersions| {
             let serialized = bincode::serialize(&original).unwrap();
             VoteStateVersions::deserialize(&serialized)
@@ -321,5 +433,71 @@ mod tests {
             ser_deser(v4.clone()),
             Ok(v4), // <-- Matches original
         );
+    }
+
+    #[test]
+    fn test_versions_deserialize_non_default() {
+        let vote_init = VoteInit {
+            node_pubkey: Pubkey::new_unique(),
+            authorized_voter: Pubkey::new_unique(),
+            authorized_withdrawer: Pubkey::new_unique(),
+            commission: 50,
+        };
+
+        let ser_deser = |original: VoteStateVersions| {
+            let serialized = bincode::serialize(&original).unwrap();
+            let deserialized = VoteStateVersions::deserialize(&serialized).unwrap();
+            assert_eq!(original, deserialized);
+        };
+
+        // Populated V1_14_11 round-trip.
+        let vote_state = VoteState1_14_11::from(VoteStateV3::new(&vote_init, &Clock::default()));
+        ser_deser(VoteStateVersions::V1_14_11(Box::new(vote_state)));
+
+        // Populated V3 round-trip.
+        let vote_state = VoteStateV3::new(&vote_init, &Clock::default());
+        ser_deser(VoteStateVersions::new_v3(vote_state));
+
+        // Populated V4 round-trip.
+        let vote_state =
+            VoteStateV4::new_with_defaults(&Pubkey::new_unique(), &vote_init, &Clock::default());
+        ser_deser(VoteStateVersions::new_v4(vote_state));
+    }
+
+    #[test]
+    fn test_versions_deserialize_arbitrary() {
+        let struct_bytes_x4 = std::mem::size_of::<VoteStateV4>() * 4;
+        for _ in 0..1000 {
+            let raw_data: Vec<u8> = (0..struct_bytes_x4).map(|_| rand::random::<u8>()).collect();
+            let mut unstructured = Unstructured::new(&raw_data);
+            let original = VoteStateVersions::arbitrary(&mut unstructured).unwrap();
+            let serialized = bincode::serialize(&original).unwrap();
+            let deserialized = VoteStateVersions::deserialize(&serialized).unwrap();
+            assert_eq!(original, deserialized);
+        }
+    }
+
+    #[test]
+    fn test_collection_count_exceeding_max() {
+        // Deserialization reads unbounded Vec/VecDeque lengths from the input,
+        // so it must handle counts that exceed the compile-time capacity hints
+        // (MAX_LOCKOUT_HISTORY, MAX_EPOCH_CREDITS_HISTORY) without panicking.
+
+        let mut vote_state = VoteStateV3::default();
+        // 100 votes > MAX_LOCKOUT_HISTORY (31).
+        for i in 0..100u64 {
+            vote_state.votes.push_back(LandedVote {
+                latency: 0,
+                lockout: Lockout::new(i),
+            });
+        }
+        // 100 epoch credits > MAX_EPOCH_CREDITS_HISTORY (64).
+        for i in 0..100u64 {
+            vote_state.epoch_credits.push((i, i * 10, i * 5));
+        }
+        let versioned = VoteStateVersions::new_v3(vote_state);
+        let serialized = bincode::serialize(&versioned).unwrap();
+        let deserialized = VoteStateVersions::deserialize(&serialized).unwrap();
+        assert_eq!(versioned, deserialized);
     }
 }


### PR DESCRIPTION
#### Problem

The vote-interface crate - especially the deserialization API - could use more
test coverage.

#### Summary of Changes

Add more comprehensive test coverage to `vote_state_versions.rs`.

Broke off #588