### PR TITLE
Revert "vote: use `InvalidAccountData` for v0_23_5 vsv deserializing (#447)"

### DIFF
--- a/vote-interface/src/state/vote_state_versions.rs
+++ b/vote-interface/src/state/vote_state_versions.rs
@@ -351,7 +351,7 @@ mod tests {
         // Tag 0 (V0_23_5 — explicitly rejected).
         assert_eq!(
             VoteStateVersions::deserialize(&buf),
-            Err(InstructionError::InvalidAccountData)
+            Err(InstructionError::UninitializedAccount)
         );
 
         // Tag 4 (unknown).

--- a/vote-interface/src/state/vote_state_versions.rs
+++ b/vote-interface/src/state/vote_state_versions.rs
@@ -152,7 +152,7 @@ impl VoteStateVersions {
         let variant = solana_serialize_utils::cursor::read_u32(&mut cursor)?;
         match variant {
             // V0_23_5 not supported.
-            0 => Err(InstructionError::InvalidAccountData),
+            0 => Err(InstructionError::UninitializedAccount),
             // V1_14_11
             1 => {
                 let mut vote_state = Box::new(MaybeUninit::uninit());


### PR DESCRIPTION
Unfortunately this change would result in a consensus issue if we bumped the validator to use solana-vote-interface >5.1.0 and the vote state v4 feature was active.

https://github.com/anza-xyz/agave/blob/b26916630e415c9b526fb317263ae90627b7a859/programs/vote/src/vote_state/mod.rs#L75-L78

Note we should yank 5.1.0 and 5.1.1 and release a new 5.2.0.