### PR TITLE
Fix toml formating errors

### DIFF
--- a/address-lookup-table-interface/Cargo.toml
+++ b/address-lookup-table-interface/Cargo.toml
@@ -46,9 +46,7 @@ solana-slot-hashes = { workspace = true }
 solana-pubkey = { workspace = true, features = ["curve25519"] }
 
 [dev-dependencies]
-solana-address-lookup-table-interface = { path = ".", features = [
-    "dev-context-only-utils",
-] }
+solana-address-lookup-table-interface = { path = ".", features = ["dev-context-only-utils"] }
 solana-hash = { workspace = true, features = ["atomic"] }
 solana-pubkey = { workspace = true, features = ["std"] }
 

--- a/address/Cargo.toml
+++ b/address/Cargo.toml
@@ -73,18 +73,7 @@ solana-sha256-hasher = { workspace = true, features = ["sha2"], optional = true 
 [dev-dependencies]
 anyhow = { workspace = true }
 solana-account-info = { path = "../account-info" }
-solana-address = { path = ".", features = [
-    "atomic",
-    "borsh",
-    "curve25519",
-    "decode",
-    "dev-context-only-utils",
-    "error",
-    "sanitize",
-    "sha2",
-    "std",
-    "syscalls",
-] }
+solana-address = { path = ".", features = ["atomic", "borsh", "curve25519", "decode", "dev-context-only-utils", "error", "sanitize", "sha2", "std", "syscalls"] }
 solana-cpi = { path = "../cpi" }
 solana-example-mocks = { path = "../example-mocks" }
 solana-hash = { workspace = true }

--- a/bls-signatures/Cargo.toml
+++ b/bls-signatures/Cargo.toml
@@ -35,12 +35,8 @@ pairing = { workspace = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 serde_json = { workspace = true, optional = true }
 serde_with = { workspace = true, features = ["macros"], optional = true }
-solana-frozen-abi = { workspace = true, optional = true, features = [
-    "frozen-abi",
-] }
-solana-frozen-abi-macro = { workspace = true, optional = true, features = [
-    "frozen-abi",
-] }
+solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
+solana-frozen-abi-macro = { workspace = true, optional = true, features = ["frozen-abi"] }
 thiserror = { workspace = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]

--- a/compute-budget-interface/Cargo.toml
+++ b/compute-budget-interface/Cargo.toml
@@ -24,12 +24,8 @@ serde = ["dep:serde", "dep:serde_derive"]
 borsh = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-solana-frozen-abi = { workspace = true, features = [
-    "frozen-abi",
-], optional = true }
-solana-frozen-abi-macro = { workspace = true, features = [
-    "frozen-abi",
-], optional = true }
+solana-frozen-abi = { workspace = true, features = ["frozen-abi"], optional = true }
+solana-frozen-abi-macro = { workspace = true, features = ["frozen-abi"], optional = true }
 solana-instruction = { workspace = true, features = ["std"] }
 solana-sdk-ids = { workspace = true }
 

--- a/define-syscall/Cargo.toml
+++ b/define-syscall/Cargo.toml
@@ -18,6 +18,4 @@ targets = ["x86_64-unknown-linux-gnu"]
 unstable-static-syscalls = []
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = [
-  'cfg(target_feature, values("static-syscalls"))',
-] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_feature, values("static-syscalls"))'] }

--- a/feature-gate-interface/Cargo.toml
+++ b/feature-gate-interface/Cargo.toml
@@ -37,9 +37,7 @@ solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true, optional = true }
 solana-sdk-ids = { workspace = true }
-solana-system-interface = { workspace = true, optional = true, features = [
-    "bincode",
-] }
+solana-system-interface = { workspace = true, optional = true, features = ["bincode"] }
 
 [dev-dependencies]
 solana-feature-gate-interface = { path = ".", features = ["dev-context-only-utils"] }

--- a/fee-structure/Cargo.toml
+++ b/fee-structure/Cargo.toml
@@ -21,9 +21,7 @@ serde = ["dep:serde", "dep:serde_derive"]
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-solana-frozen-abi = { workspace = true, optional = true, features = [
-    "frozen-abi",
-] }
+solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
 
 [lints]
 workspace = true

--- a/loader-v3-interface/Cargo.toml
+++ b/loader-v3-interface/Cargo.toml
@@ -24,12 +24,8 @@ serde = ["dep:serde", "dep:serde_bytes", "dep:serde_derive", "solana-pubkey/serd
 serde = { workspace = true, optional = true }
 serde_bytes = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-solana-frozen-abi = { workspace = true, features = [
-    "frozen-abi",
-], optional = true }
-solana-frozen-abi-macro = { workspace = true, features = [
-    "frozen-abi",
-], optional = true }
+solana-frozen-abi = { workspace = true, features = ["frozen-abi"], optional = true }
+solana-frozen-abi-macro = { workspace = true, features = ["frozen-abi"], optional = true }
 solana-instruction = { workspace = true, features = ["std"] }
 solana-pubkey = { workspace = true, features = ["curve25519"] }
 solana-sdk-ids = { workspace = true }

--- a/loader-v4-interface/Cargo.toml
+++ b/loader-v4-interface/Cargo.toml
@@ -24,12 +24,8 @@ serde = ["dep:serde", "dep:serde_bytes", "dep:serde_derive", "solana-pubkey/serd
 serde = { workspace = true, optional = true }
 serde_bytes = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-solana-frozen-abi = { workspace = true, features = [
-    "frozen-abi",
-], optional = true }
-solana-frozen-abi-macro = { workspace = true, features = [
-    "frozen-abi",
-], optional = true }
+solana-frozen-abi = { workspace = true, features = ["frozen-abi"], optional = true }
+solana-frozen-abi-macro = { workspace = true, features = ["frozen-abi"], optional = true }
 solana-instruction = { workspace = true, features = ["std"] }
 solana-pubkey = { workspace = true }
 solana-sdk-ids = { workspace = true }

--- a/message/Cargo.toml
+++ b/message/Cargo.toml
@@ -51,10 +51,7 @@ solana-sanitize = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-short-vec = { workspace = true, optional = true }
 solana-transaction-error = { workspace = true }
-wincode = { workspace = true, optional = true, features = [
-    "std",
-    "solana-short-vec",
-] }
+wincode = { workspace = true, optional = true, features = ["std", "solana-short-vec"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -64,10 +61,7 @@ borsh = { workspace = true }
 itertools = { workspace = true }
 proptest = { workspace = true }
 serde_json = { workspace = true }
-solana-address-lookup-table-interface = { workspace = true, features = [
-    "bincode",
-    "bytemuck",
-] }
+solana-address-lookup-table-interface = { workspace = true, features = ["bincode", "bytemuck"] }
 solana-example-mocks = { path = "../example-mocks" }
 solana-hash = { workspace = true, features = ["atomic"] }
 solana-instruction = { workspace = true, features = ["borsh"] }

--- a/poh-config/Cargo.toml
+++ b/poh-config/Cargo.toml
@@ -21,12 +21,8 @@ serde = ["dep:serde", "dep:serde_derive"]
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-solana-frozen-abi = { workspace = true, optional = true, features = [
-    "frozen-abi",
-] }
-solana-frozen-abi-macro = { workspace = true, optional = true, features = [
-    "frozen-abi",
-] }
+solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
+solana-frozen-abi-macro = { workspace = true, optional = true, features = ["frozen-abi"] }
 
 [dev-dependencies]
 solana-clock = { workspace = true }

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -62,17 +62,8 @@ solana-epoch-stake = { workspace = true }
 solana-fee-calculator = { workspace = true, features = ["serde"] }
 solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
 solana-frozen-abi-macro = { workspace = true, optional = true, features = ["frozen-abi"] }
-solana-hash = { workspace = true, features = [
-    "bytemuck",
-    "serde",
-    "std",
-] }
-solana-instruction = { workspace = true, default-features = false, features = [
-    "bincode",
-    "serde",
-    "std",
-    "syscalls",
-] }
+solana-hash = { workspace = true, features = ["bytemuck", "serde", "std"] }
+solana-instruction = { workspace = true, default-features = false, features = ["bincode", "serde", "std", "syscalls"] }
 solana-instruction-error = { workspace = true, features = ["num-traits"] }
 solana-instructions-sysvar = { workspace = true }
 solana-keccak-hasher = { workspace = true, features = ["sha3"] }

--- a/pubkey/Cargo.toml
+++ b/pubkey/Cargo.toml
@@ -31,13 +31,7 @@ wincode = ["solana-address/wincode"]
 
 [dependencies]
 rand = { workspace = true, optional = true }
-solana-address = { workspace = true, features = [
-    "copy",
-    "decode",
-    "error",
-    "sanitize",
-    "syscalls",
-] }
+solana-address = { workspace = true, features = ["copy", "decode", "error", "sanitize", "syscalls"] }
 
 [lints]
 workspace = true

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -64,17 +64,13 @@ solana-epoch-info = { workspace = true, features = ["serde"] }
 solana-epoch-rewards-hasher = { workspace = true }
 solana-fee-structure = { workspace = true, features = ["serde"] }
 solana-inflation = { workspace = true, features = ["serde"] }
-solana-keypair = { workspace = true, optional = true, features = [
-    "seed-derivable",
-] }
+solana-keypair = { workspace = true, optional = true, features = ["seed-derivable"] }
 solana-message = { workspace = true, features = ["serde"] }
 solana-offchain-message = { workspace = true, optional = true, features = ["verify"] }
 solana-presigner = { workspace = true, optional = true }
 solana-program = { workspace = true }
 solana-program-memory = { workspace = true }
-solana-pubkey = { workspace = true, default-features = false, features = [
-    "std",
-] }
+solana-pubkey = { workspace = true, default-features = false, features = ["std"] }
 solana-sanitize = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-sdk-macro = { workspace = true }
@@ -84,22 +80,11 @@ solana-serde = { workspace = true }
 solana-serde-varint = { workspace = true }
 solana-short-vec = { workspace = true }
 solana-shred-version = { workspace = true, optional = true }
-solana-signature = { workspace = true, features = [
-    "rand",
-    "serde",
-    "std",
-    "verify",
-], optional = true }
+solana-signature = { workspace = true, features = ["rand", "serde", "std", "verify"], optional = true }
 solana-signer = { workspace = true, optional = true }
 solana-time-utils = { workspace = true }
-solana-transaction = { workspace = true, features = [
-    "blake3",
-    "serde",
-    "verify"
-], optional = true }
-solana-transaction-error = { workspace = true, features = [
-    "serde",
-], optional = true }
+solana-transaction = { workspace = true, features = ["blake3", "serde", "verify"], optional = true }
+solana-transaction-error = { workspace = true, features = ["serde"], optional = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/secp256k1-recover/Cargo.toml
+++ b/secp256k1-recover/Cargo.toml
@@ -18,12 +18,8 @@ frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 
 [dependencies]
 borsh = { workspace = true, optional = true }
-solana-frozen-abi = { workspace = true, optional = true, features = [
-    "frozen-abi",
-] }
-solana-frozen-abi-macro = { workspace = true, optional = true, features = [
-    "frozen-abi",
-] }
+solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
+solana-frozen-abi-macro = { workspace = true, optional = true, features = ["frozen-abi"] }
 thiserror = { workspace = true }
 
 [target.'cfg(any(target_os = "solana", target_arch = "bpf"))'.dependencies]

--- a/serialize-utils/Cargo.toml
+++ b/serialize-utils/Cargo.toml
@@ -22,7 +22,4 @@ bincode = { workspace = true }
 borsh = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
-solana-pubkey = { workspace = true, default-features = false, features = [
-    "borsh",
-    "serde",
-] }
+solana-pubkey = { workspace = true, default-features = false, features = ["borsh", "serde"] }

--- a/short-vec/Cargo.toml
+++ b/short-vec/Cargo.toml
@@ -19,12 +19,8 @@ frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 
 [dependencies]
 serde_core = { workspace = true, optional = true }
-solana-frozen-abi = { workspace = true, optional = true, features = [
-    "frozen-abi",
-] }
-solana-frozen-abi-macro = { workspace = true, optional = true, features = [
-    "frozen-abi",
-] }
+solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
+solana-frozen-abi-macro = { workspace = true, optional = true, features = ["frozen-abi"] }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/stable-layout/Cargo.toml
+++ b/stable-layout/Cargo.toml
@@ -15,9 +15,7 @@ all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
 [dependencies]
-solana-instruction = { workspace = true, default-features = false, features = [
-    "std",
-] }
+solana-instruction = { workspace = true, default-features = false, features = ["std"] }
 solana-pubkey = { workspace = true, default-features = false }
 
 [dev-dependencies]

--- a/transaction/Cargo.toml
+++ b/transaction/Cargo.toml
@@ -58,10 +58,7 @@ solana-short-vec = { workspace = true, optional = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true, optional = true }
 solana-transaction-error = { workspace = true }
-wincode = { workspace = true, optional = true, features = [
-    "solana-short-vec",
-    "alloc",
-] }
+wincode = { workspace = true, optional = true, features = ["solana-short-vec", "alloc"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -78,10 +75,7 @@ solana-presigner = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-sha256-hasher = { workspace = true, features = ["sha2"] }
 solana-system-interface = { workspace = true, features = ["bincode"] }
-solana-transaction = { path = ".", features = [
-    "dev-context-only-utils",
-    "wincode",
-] }
+solana-transaction = { path = ".", features = ["dev-context-only-utils", "wincode"] }
 solana-vote-interface = { workspace = true, features = ["bincode"] }
 static_assertions = { workspace = true }
 test-case = { workspace = true }


### PR DESCRIPTION
cargo-sort version appears to have been upgraded remotely: https://github.com/anza-xyz/solana-sdk/actions/runs/22683068419/job/65758634400?pr=605. New failures due to stricter manifest formatting expectations.

- No functional/runtime behavior changes
- No dependency graph changes
