### PR TITLE
chore(frozen-abi): relax dashmap version to >=5.0.0, <7.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,7 +166,7 @@ console_error_panic_hook = "0.1.7"
 console_log = "0.2.2"
 criterion = "0.5.1"
 curve25519-dalek = { version = "4.1.3", features = ["digest", "rand_core"] }
-dashmap = { version = "5.5.3", features = ["serde"] }
+dashmap = { version = ">=5.0.0, <7.0.0", features = ["serde"] }
 derivation-path = { version = "0.2.0", default-features = false }
 digest = "0.10.7"
 ed25519-dalek = "2.1.1"


### PR DESCRIPTION
Bump `dashmap` to version `6.1.0`. This is the latest stable release since 2024 and brings performance improvements, see https://github.com/xacrimon/dashmap/releases/tag/v6.0.0

Note: dashmap is only used in frozen-abi to implement relevant support for the types. Bump of the dashmap version on users of this macro fails due to "unrecognized type":
```
AbiExample::example for struct: solana_runtime::serde_snapshot::obsolete_accounts::SerdeObsoleteAccountsMap

thread 'serde_snapshot::obsolete_accounts::SerdeObsoleteAccountsMap_frozen_abi::test_api_digest' (2106109) panicked at /home/nazgul/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/solana-frozen-abi-3.2.1/src/abi_example.rs:282:13:
new unrecognized type for ABI digest!: dashmap::DashMap<u64, solana_runtime::serde_snapshot::obsolete_accounts::SerdeObsoleteAccounts>
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/b33119ffdd483969934b10a886dc06dd29a473f9/library/std/src/panicking.rs:689:5
   1: core::panicking::panic_fmt
             at /rustc/b33119ffdd483969934b10a886dc06dd29a473f9/library/core/src/panicking.rs:80:14
   2: <() as solana_frozen_abi::abi_example::TypeErasedExample<dashmap::DashMap<u64, solana_runtime::serde_snapshot::obsolete_accounts::SerdeObsoleteAccounts>>>::type_erased_example
             at /home/nazgul/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/solana-frozen-abi-3.2.1/src/abi_example.rs:282:13
   3: <dashmap::DashMap<u64, solana_runtime::serde_snapshot::obsolete_accounts::SerdeObsoleteAccounts> as solana_frozen_abi::abi_example::AbiExample>::example
             at /home/nazgul/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/solana-frozen-abi-3.2.1/src/abi_example.rs:256:9
   4: <solana_runtime::serde_snapshot::obsolete_accounts::SerdeObsoleteAccountsMap as solana_frozen_abi::abi_example::AbiExample>::example
             at ./src/serde_snapshot/obsolete_accounts.rs:51:12
   5: test_api_digest
             at ./src/serde_snapshot/obsolete_accounts.rs:52:5
   6: solana_runtime::serde_snapshot::obsolete_accounts::SerdeObsoleteAccountsMap_frozen_abi::test_api_digest::{closure#0}
             at ./src/serde_snapshot/obsolete_accounts.rs:52:72
   7: <solana_runtime::serde_snapshot::obsolete_accounts::SerdeObsoleteAccountsMap_frozen_abi::test_api_digest::{closure#0} as core::ops::function::FnOnce<()>>::call_once
             at /rustc/b33119ffdd483969934b10a886dc06dd29a473f9/library/core/src/ops/function.rs:250:5
   8: <fn() -> core::result::Result<(), alloc::string::String> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/b33119ffdd483969934b10a886dc06dd29a473f9/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.


failures:
    serde_snapshot::obsolete_accounts::SerdeObsoleteAccountsMap_frozen_abi::test_api_digest

```

This change will allow matching update on the clients, seemingly it will also force it though.