### PR TITLE
account-view!: Use byte array for padding

### DIFF
--- a/account-view/src/lib.rs
+++ b/account-view/src/lib.rs
@@ -61,7 +61,7 @@ pub struct RuntimeAccount {
     /// The value of this field is not directly used and always set to `0`.
     /// Entrypoint implementations may use this space for their own purposes,
     /// e.g., to track account resizing.
-    pub padding: u32,
+    pub padding: [u8; 4],
 
     /// Address of the account.
     pub address: Address,


### PR DESCRIPTION
### Problem

PR #569 renamed `resize_delta` field to `padding`, changing the field type to `u32`. This has the drawback of assuming that any use of the padding field would have type `u32`. It would be more flexible to type the field as `[u8; 4]` instead.

### Solution

Change the padding field type to `[u8; 4]`.