### PR TITLE
ci: pin cargo-sort version to 2.1.1 and sort crates accordingly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -317,7 +317,7 @@ jobs:
       - name: Install cargo-sort
         uses: taiki-e/cache-cargo-install-action@v2
         with:
-          tool: cargo-sort
+          tool: cargo-sort@2.1.1
 
       - name: Check toml ordering
         run: ./scripts/check-sort.sh

--- a/account/Cargo.toml
+++ b/account/Cargo.toml
@@ -23,12 +23,7 @@ frozen-abi = [
     "dep:solana-frozen-abi-macro",
     "solana-pubkey/frozen-abi",
 ]
-serde = [
-    "dep:serde",
-    "dep:serde_bytes",
-    "dep:serde_derive",
-    "solana-pubkey/serde",
-]
+serde = ["dep:serde", "dep:serde_bytes", "dep:serde_derive", "solana-pubkey/serde"]
 
 [dependencies]
 bincode = { workspace = true, optional = true }

--- a/instruction-error/Cargo.toml
+++ b/instruction-error/Cargo.toml
@@ -16,11 +16,7 @@ all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
 [features]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "serde",
-]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "serde"]
 num-traits = ["dep:num-traits"]
 serde = ["dep:serde", "dep:serde_derive"]
 wincode = ["dep:wincode"]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -23,7 +23,8 @@ crate-type = ["rlib"]
 [features]
 default = [
     "borsh",
-    "full",  # functionality that is not compatible or needed for on-chain programs
+    # functionality that is not compatible or needed for on-chain programs
+    "full",
 ]
 full = [
     "solana-signature",

--- a/secp256k1-program/Cargo.toml
+++ b/secp256k1-program/Cargo.toml
@@ -15,12 +15,7 @@ all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
 [features]
-bincode = [
-    "dep:bincode",
-    "dep:solana-instruction",
-    "dep:solana-sdk-ids",
-    "serde",
-]
+bincode = ["dep:bincode", "dep:solana-instruction", "dep:solana-sdk-ids", "serde"]
 dev-context-only-utils = ["bincode"]
 serde = ["dep:serde", "dep:serde_derive"]
 

--- a/vote-interface/Cargo.toml
+++ b/vote-interface/Cargo.toml
@@ -22,11 +22,7 @@ bincode = [
     "dep:solana-system-interface",
     "serde",
 ]
-dev-context-only-utils = [
-    "bincode",
-    "dep:arbitrary",
-    "solana-pubkey/dev-context-only-utils",
-]
+dev-context-only-utils = ["bincode", "dep:arbitrary", "solana-pubkey/dev-context-only-utils"]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",


### PR DESCRIPTION
#### Problem
ci doesn't pin the `cargo-sort` version. latest release changed ordering

#### Changes
* pin `cargo-sort` to 2.1.1
* sort crates to match