### PR TITLE
wincode API compatible v1::Message SchemaRead impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -235,7 +235,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -310,7 +310,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -569,7 +569,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -647,7 +647,7 @@ checksum = "3fa76293b4f7bb636ab88fd78228235b5248b4d05cc589aed610f954af5d7c7a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -706,7 +706,7 @@ checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1006,7 +1006,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1040,7 +1040,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1054,7 +1054,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1065,7 +1065,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1076,7 +1076,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1128,7 +1128,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1151,7 +1151,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1220,7 +1220,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1271,7 +1271,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1838,7 +1838,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2206,7 +2206,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2255,7 +2255,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2302,7 +2302,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2533,7 +2533,7 @@ checksum = "9e2e25ee72f5b24d773cae88422baddefff7714f97aab68d96fe2b6fc4a28fb2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2555,7 +2555,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.8",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2593,16 +2593,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.8",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -3102,7 +3102,7 @@ checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3146,7 +3146,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3171,7 +3171,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3732,7 +3732,7 @@ version = "3.2.1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4052,7 +4052,7 @@ version = "3.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "toml",
 ]
 
@@ -4197,7 +4197,7 @@ version = "1.0.0"
 dependencies = [
  "quote",
  "regex",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4308,7 +4308,7 @@ dependencies = [
  "bs58",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4821,9 +4821,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4847,7 +4847,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4887,7 +4887,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4898,7 +4898,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "test-case-core",
 ]
 
@@ -4928,7 +4928,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4939,7 +4939,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5322,7 +5322,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -5357,7 +5357,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5411,9 +5411,9 @@ dependencies = [
 
 [[package]]
 name = "wincode"
-version = "0.4.4"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "466e67917609b2d40a838a5b972d1a6237c9749600cb8de8f65559b90d48485b"
+checksum = "9b591a322f17191f9a62acbc15df6a0699f63475d28a3113c2ed0774f62a5522"
 dependencies = [
  "pastey",
  "proc-macro2",
@@ -5425,14 +5425,14 @@ dependencies = [
 
 [[package]]
 name = "wincode-derive"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26a7a568eda854acc9945ed136a9d50b8c6d31911584624958808ae96eee3912"
+checksum = "fca057fc9a13dd19cdb64ef558635d43c42667c0afa1ae7915ea1fa66993fd1a"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5728,7 +5728,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5750,7 +5750,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5770,7 +5770,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5791,7 +5791,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5813,5 +5813,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,7 +203,7 @@ proc-macro2 = "1.0.106"
 proptest = "1.9"
 qstring = "0.7.2"
 qualifier_attr = { version = "0.2.2", default-features = false }
-quote = "1.0.44"
+quote = "1.0.45"
 rand = "0.9.2"
 rand_chacha = "0.9.0"
 rayon = "1.10.0"
@@ -329,7 +329,7 @@ static_assertions = "1.1.0"
 strum = "0.24"
 strum_macros = "0.24"
 subtle = "2.6.1"
-syn = "2.0.114"
+syn = "2.0.117"
 tempfile = "3.20.0"
 test-case = "3.3.1"
 thiserror = { version = "2.0.18", default-features = false }
@@ -337,7 +337,7 @@ tiny-bip39 = "2.0.0"
 toml = "0.8.23"
 uriparse = "0.6.4"
 wasm-bindgen = "0.2.100"
-wincode = { version = "0.4.4", features = ["derive"], default-features = false }
+wincode = { version = "0.4.7", features = ["derive"], default-features = false }
 
 [profile.release]
 split-debuginfo = "unpacked"

--- a/message/src/versions/mod.rs
+++ b/message/src/versions/mod.rs
@@ -1,15 +1,5 @@
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::{frozen_abi, AbiEnumVisitor, AbiExample};
-#[cfg(feature = "wincode")]
-use {
-    crate::v1::deserialize,
-    core::mem::MaybeUninit,
-    wincode::{
-        config::Config,
-        io::{Reader, Writer},
-        ReadResult, SchemaRead, SchemaWrite, WriteResult,
-    },
-};
 use {
     crate::{
         compiled_instruction::CompiledInstruction, legacy::Message as LegacyMessage,
@@ -19,6 +9,15 @@ use {
     solana_hash::Hash,
     solana_sanitize::{Sanitize, SanitizeError},
     std::collections::HashSet,
+};
+#[cfg(feature = "wincode")]
+use {
+    core::mem::MaybeUninit,
+    wincode::{
+        config::Config,
+        io::{Reader, Writer},
+        ReadResult, SchemaRead, SchemaWrite, WriteResult,
+    },
 };
 #[cfg(feature = "serde")]
 use {
@@ -412,7 +411,7 @@ unsafe impl<'de, C: Config> SchemaRead<'de, C> for VersionedMessage {
         // which message version is serialized starting from version `0`. If the first
         // is bit is not set, all bytes are used to encode the legacy `Message`
         // format.
-        let variant = *reader.peek()?;
+        let variant = reader.peek_byte()?;
 
         if variant & MESSAGE_VERSION_PREFIX != 0 {
             // Safety: at least 1 byte can be consumed, since it was peeked
@@ -427,14 +426,7 @@ unsafe impl<'de, C: Config> SchemaRead<'de, C> for VersionedMessage {
                     Ok(())
                 }
                 1 => {
-                    // -1 for already-read variant byte
-                    let bytes = reader.fill_buf(v1::MAX_TRANSACTION_SIZE - 1)?;
-                    let (message, consumed) =
-                        deserialize(bytes).map_err(|_| invalid_tag_encoding(1))?;
-
-                    // SAFETY: `deserialize` validates that we read `consumed` bytes.
-                    unsafe { reader.consume_unchecked(consumed) };
-
+                    let message = <v1::Message as SchemaRead<C>>::get(reader)?;
                     dst.write(VersionedMessage::V1(message));
 
                     Ok(())
@@ -648,10 +640,11 @@ mod tests {
             // Serialize V1 to raw bytes.
             let bytes = v1::serialize(&message);
             // Deserialize from raw bytes.
-            let (parsed, _) = v1::deserialize(&bytes).unwrap();
+            let parsed = v1::deserialize(&bytes).unwrap();
 
             // Messages should match.
             assert_eq!(message, parsed);
+            assert_eq!(message, wincode::deserialize(&bytes).unwrap());
 
             // Wrap in VersionedMessage and test `serialize()`.
             let versioned = VersionedMessage::V1(message);

--- a/message/src/versions/v1/message.rs
+++ b/message/src/versions/v1/message.rs
@@ -41,11 +41,10 @@ use serde_derive::{Deserialize, Serialize};
 use solana_frozen_abi_macro::AbiExample;
 #[cfg(feature = "wincode")]
 use {
-    crate::v1::MAX_TRANSACTION_SIZE,
-    core::slice::from_raw_parts,
+    crate::v1::{InstructionHeader, FIXED_HEADER_SIZE},
+    core::{mem::MaybeUninit, ptr::copy_nonoverlapping, slice::from_raw_parts},
     wincode::{
-        config::ConfigCore,
-        error::invalid_tag_encoding,
+        config::{Config, ConfigCore},
         io::{Reader, Writer},
         ReadResult, SchemaRead, SchemaWrite, WriteResult,
     },
@@ -55,17 +54,17 @@ use {
         compiled_instruction::CompiledInstruction,
         compiled_keys::CompiledKeys,
         v1::{
-            InstructionHeader, MessageError, TransactionConfig, TransactionConfigMask,
-            FIXED_HEADER_SIZE, MAX_ADDRESSES, MAX_INSTRUCTIONS, MAX_SIGNATURES,
+            MessageError, TransactionConfig, TransactionConfigMask, MAX_ADDRESSES,
+            MAX_INSTRUCTIONS, MAX_SIGNATURES,
         },
         AccountKeys, CompileError, MessageHeader,
     },
-    core::{mem::size_of, ptr::copy_nonoverlapping},
+    core::mem::size_of,
     solana_address::Address,
     solana_hash::Hash,
     solana_instruction::Instruction,
     solana_sanitize::{Sanitize, SanitizeError},
-    std::{collections::HashSet, mem::MaybeUninit},
+    std::collections::HashSet,
 };
 
 /// A V1 transaction message (SIMD-0385) supporting 4KB transactions with inline compute budget.
@@ -516,7 +515,6 @@ impl Sanitize for Message {
 unsafe impl<C: ConfigCore> SchemaWrite<C> for Message {
     type Src = Self;
 
-    #[allow(clippy::arithmetic_side_effects)]
     #[inline(always)]
     fn size_of(src: &Self::Src) -> WriteResult<usize> {
         Ok(src.size())
@@ -575,23 +573,6 @@ unsafe impl<C: ConfigCore> SchemaWrite<C> for Message {
     }
 }
 
-#[cfg(feature = "wincode")]
-unsafe impl<'de, C: ConfigCore> SchemaRead<'de, C> for Message {
-    type Dst = Self;
-
-    fn read(mut reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
-        let bytes = reader.fill_buf(MAX_TRANSACTION_SIZE)?;
-        let (message, consumed) = deserialize(bytes).map_err(|_| invalid_tag_encoding(1))?;
-
-        // SAFETY: `deserialize` validates that we read `consumed` bytes.
-        unsafe { reader.consume_unchecked(consumed) };
-
-        dst.write(message);
-
-        Ok(())
-    }
-}
-
 /// Serialize the message.
 #[cfg(feature = "wincode")]
 #[inline]
@@ -599,191 +580,116 @@ pub fn serialize(message: &Message) -> Vec<u8> {
     wincode::serialize(message).unwrap()
 }
 
-/// Deserialize the message from the provided input buffer, returning the message and
-/// the number of bytes read.
-#[allow(clippy::arithmetic_side_effects)]
-pub fn deserialize(input: &[u8]) -> Result<(Message, usize), MessageError> {
-    if input.len() < FIXED_HEADER_SIZE {
-        return Err(MessageError::BufferTooSmall);
-    }
+#[cfg(feature = "wincode")]
+unsafe impl<'de, C: Config> SchemaRead<'de, C> for Message {
+    type Dst = Message;
 
-    let mut input_ptr = input.as_ptr();
-
-    // SAFETY: input length has been checked against `FIXED_HEADER_SIZE`.
-    let header = unsafe {
-        let mut header = MaybeUninit::<MessageHeader>::uninit();
-        let dst = header.as_mut_ptr() as *mut u8;
-
-        // num_required_signatures
-        dst.write(input_ptr.read());
-        // num_readonly_signed_accounts
-        dst.add(1).write(input_ptr.add(1).read());
-        // num_readonly_unsigned_accounts
-        dst.add(2).write(input_ptr.add(2).read());
-
-        // Advance input pointer past header.
-        input_ptr = input_ptr.add(3);
-
-        header.assume_init()
-    };
-
-    // config mask
-    //
-    // SAFETY: input length has been checked against `FIXED_HEADER_SIZE`.
-    let config_mask = unsafe {
-        let mask = TransactionConfigMask(u32::from_le_bytes(*(input_ptr as *const [u8; 4])));
-        input_ptr = input_ptr.add(4);
-
-        mask
-    };
-
-    // lifetime specifier
-    //
-    // SAFETY: input length has been checked against `FIXED_HEADER_SIZE`.
-    let lifetime_specifier = unsafe {
-        let specifier = Hash::new_from_array(*(input_ptr as *const [u8; 32]));
-        input_ptr = input_ptr.add(32);
-
-        specifier
-    };
-
-    // counts
-    //
-    // SAFETY: input length has been checked against `FIXED_HEADER_SIZE`.
-    let num_instructions = unsafe {
-        let num_instructions = input_ptr.read() as usize;
-        input_ptr = input_ptr.add(1);
-
-        num_instructions
-    };
-    // SAFETY: input length has been checked against `FIXED_HEADER_SIZE`.
-    let num_addresses = unsafe {
-        let num_addresses = input_ptr.read() as usize;
-        input_ptr = input_ptr.add(1);
-
-        num_addresses
-    };
-
-    // Track the offset for input. This is the value returned to indicate
-    // how many bytes were read.
-    let mut offset = FIXED_HEADER_SIZE + num_addresses * size_of::<Address>();
-
-    // addresses
-
-    if input.len() < offset {
-        return Err(MessageError::BufferTooSmall);
-    }
-
-    let mut account_keys = Vec::with_capacity(num_addresses);
-    // SAFETY: input length has been checked against the required size
-    // for the addresses.
-    unsafe {
-        let dst = account_keys.as_mut_ptr();
-        copy_nonoverlapping(input_ptr as *const Address, dst, num_addresses);
-        account_keys.set_len(num_addresses);
-        input_ptr = input_ptr.add(num_addresses * size_of::<Address>());
-    }
-
-    // config values
-    offset += config_mask.size_of_config();
-
-    if input.len() < offset {
-        return Err(MessageError::BufferTooSmall);
-    }
-
-    let mut config = TransactionConfig::empty();
-
-    if config_mask.has_priority_fee() {
-        // SAFETY: input length has been checked against the required size
-        // for the config.
-        let value = unsafe { u64::from_le_bytes(*(input_ptr as *const [u8; 8])) };
-        config = config.with_priority_fee(value);
-        input_ptr = unsafe { input_ptr.add(size_of::<u64>()) };
-    }
-
-    if config_mask.has_compute_unit_limit() {
-        // SAFETY: input length has been checked against the required size
-        // for the config.
-        let value = unsafe { u32::from_le_bytes(*(input_ptr as *const [u8; 4])) };
-        config = config.with_compute_unit_limit(value);
-        input_ptr = unsafe { input_ptr.add(size_of::<u32>()) };
-    }
-
-    if config_mask.has_loaded_accounts_data_size() {
-        // SAFETY: input length has been checked against the required size
-        // for the config.
-        let value = unsafe { u32::from_le_bytes(*(input_ptr as *const [u8; 4])) };
-        config = config.with_loaded_accounts_data_size_limit(value);
-        input_ptr = unsafe { input_ptr.add(size_of::<u32>()) };
-    }
-
-    if config_mask.has_heap_size() {
-        // SAFETY: input length has been checked against the required size
-        // for the config.
-        let value = unsafe { u32::from_le_bytes(*(input_ptr as *const [u8; 4])) };
-        config = config.with_heap_size(value);
-        input_ptr = unsafe { input_ptr.add(size_of::<u32>()) };
-    }
-
-    // instruction headers
-
-    offset += num_instructions * size_of::<InstructionHeader>();
-
-    if input.len() < offset {
-        return Err(MessageError::BufferTooSmall);
-    }
-
-    // SAFETY: input length has been checked against the required size
-    // for the instruction headers.
-    let instruction_headers: &[InstructionHeader] = unsafe {
-        core::slice::from_raw_parts(input_ptr as *const InstructionHeader, num_instructions)
-    };
-
-    input_ptr = unsafe { input_ptr.add(num_instructions * size_of::<InstructionHeader>()) };
-
-    // instruction payloads
-
-    let mut instructions = Vec::with_capacity(num_instructions);
-
-    for header in instruction_headers {
-        let program_id_index = header.0;
-        let num_accounts = header.1 as usize;
-        let data_len = u16::from_le_bytes(header.2) as usize;
-
-        offset += num_accounts + data_len;
-
-        if input.len() < offset {
-            return Err(MessageError::BufferTooSmall);
-        }
-
-        // SAFETY: input length has been checked against the required size
-        // for the instruction payload.
-        let accounts = unsafe { core::slice::from_raw_parts(input_ptr, num_accounts).to_vec() };
-
-        let data = unsafe {
-            input_ptr = input_ptr.add(num_accounts);
-            core::slice::from_raw_parts(input_ptr, data_len).to_vec()
+    #[expect(clippy::arithmetic_side_effects)]
+    fn read(mut reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        let (header, lifetime_specifier, config_mask, num_instructions, num_addresses) = {
+            // SAFETY: the following reads consume exactly `FIXED_HEADER_SIZE` bytes.
+            // - MessageHeader (3 bytes)
+            // - TransactionConfigMask (4 bytes)
+            // - Hash (32 bytes)
+            // - num_instructions (1 byte)
+            // - num_addresses (1 byte)
+            let mut reader = unsafe { reader.as_trusted_for(FIXED_HEADER_SIZE)? };
+            let header = <MessageHeader as SchemaRead<C>>::get(reader.by_ref())?;
+            let config_mask = TransactionConfigMask(u32::from_le_bytes(reader.take_array()?));
+            let lifetime_specifier = <Hash as SchemaRead<C>>::get(reader.by_ref())?;
+            let num_instructions = reader.take_byte()? as usize;
+            let num_addresses = reader.take_byte()? as usize;
+            (
+                header,
+                lifetime_specifier,
+                config_mask,
+                num_instructions,
+                num_addresses,
+            )
         };
 
-        input_ptr = unsafe { input_ptr.add(data_len) };
+        let account_keys_bytes = reader.take_scoped(num_addresses * size_of::<Address>())?;
+        let mut account_keys = Vec::with_capacity(num_addresses);
+        // SAFETY:
+        // - `take_scoped(num_addresses * size_of::<Address>())` returns
+        //   exactly the requested number of bytes, or errors.
+        // - `Address` is `#[repr(transparent)]` over `[u8; 32]`, so it has alignment 1
+        //   and any 32-byte sequence is a valid in-memory representation.
+        // - `num_addresses * size_of::<Address>()` is exactly the number of bytes
+        //   needed to fill `num_addresses` elements into the `account_keys` vector.
+        // - `account_keys` was allocated with capacity for `num_addresses` elements.
+        unsafe {
+            copy_nonoverlapping(
+                account_keys_bytes.as_ptr().cast::<Address>(),
+                account_keys.as_mut_ptr(),
+                num_addresses,
+            );
+            account_keys.set_len(num_addresses);
+        }
 
-        instructions.push(CompiledInstruction {
-            program_id_index,
-            accounts,
-            data,
-        });
-    }
+        let mut config = TransactionConfig::empty();
+        if config_mask.has_priority_fee() {
+            config.priority_fee = Some(u64::from_le_bytes(reader.take_array()?));
+        }
+        if config_mask.has_compute_unit_limit() {
+            config.compute_unit_limit = Some(u32::from_le_bytes(reader.take_array()?));
+        }
+        if config_mask.has_loaded_accounts_data_size() {
+            config.loaded_accounts_data_size_limit = Some(u32::from_le_bytes(reader.take_array()?));
+        }
+        if config_mask.has_heap_size() {
+            config.heap_size = Some(u32::from_le_bytes(reader.take_array()?));
+        }
 
-    Ok((
-        Message {
+        // SAFETY:
+        // - `take_borrowed(num_instructions * size_of::<InstructionHeader>())` returns
+        //   exactly the requested number of bytes, or errors.
+        // - `take_borrowed` returns a stable borrow from the backing buffer, so the
+        //   resulting slice remains valid across subsequent reader operations.
+        // - `InstructionHeader` has alignment 1 and is encoded exactly as
+        //   4 bytes `(u8, u8, [u8; 2])`.
+        let instruction_headers = unsafe {
+            from_raw_parts(
+                reader
+                    .take_borrowed(num_instructions * size_of::<InstructionHeader>())?
+                    .as_ptr() as *const InstructionHeader,
+                num_instructions,
+            )
+        };
+        let mut instructions = Vec::with_capacity(num_instructions);
+        for header in instruction_headers {
+            let program_id_index = header.0;
+            let num_accounts = header.1 as usize;
+            let data_len = u16::from_le_bytes(header.2) as usize;
+
+            let accounts = reader.take_scoped(num_accounts)?.to_vec();
+            let data = reader.take_scoped(data_len)?.to_vec();
+
+            instructions.push(CompiledInstruction {
+                program_id_index,
+                accounts,
+                data,
+            });
+        }
+
+        dst.write(Message {
             header,
-            config,
             lifetime_specifier,
+            config,
             account_keys,
             instructions,
-        },
-        offset,
-    ))
+        });
+
+        Ok(())
+    }
+}
+
+/// Deserialize the message from the provided input buffer, returning the message and
+/// the number of bytes read.
+#[cfg(feature = "wincode")]
+#[inline]
+pub fn deserialize(input: &[u8]) -> wincode::ReadResult<Message> {
+    wincode::deserialize(input)
 }
 
 #[cfg(test)]
@@ -1397,7 +1303,7 @@ mod tests {
             .unwrap();
 
         let serialized = serialize(&message);
-        let (deserialized, _) = deserialize(&serialized).unwrap();
+        let deserialized = deserialize(&serialized).unwrap();
         assert_eq!(message.config, deserialized.config);
     }
 }

--- a/transaction/src/versioned/mod.rs
+++ b/transaction/src/versioned/mod.rs
@@ -301,7 +301,7 @@ unsafe impl<'de, C: Config> SchemaRead<'de, C> for VersionedTransaction {
         //   `> 128` and the top bit is always `1`.
 
         use solana_message::v1::V1_PREFIX;
-        let discriminator = reader.peek()?;
+        let discriminator = reader.peek_byte()?;
         let mut builder = VersionedTransactionUninitBuilder::<C>::from_maybe_uninit_mut(dst);
 
         if discriminator & MESSAGE_VERSION_PREFIX == 0 {
@@ -323,7 +323,7 @@ unsafe impl<'de, C: Config> SchemaRead<'de, C> for VersionedTransaction {
             }
 
             builder.finish();
-        } else if *discriminator == V1_PREFIX {
+        } else if discriminator == V1_PREFIX {
             // V1 transaction
 
             builder.read_message(&mut reader)?;
@@ -339,7 +339,7 @@ unsafe impl<'de, C: Config> SchemaRead<'de, C> for VersionedTransaction {
             let expected_signatures_len = message.header().num_required_signatures as usize;
 
             let bytes_to_read = expected_signatures_len.saturating_mul(SIGNATURE_SIZE);
-            let bytes = reader.fill_exact(bytes_to_read)?;
+            let bytes = reader.take_scoped(bytes_to_read)?;
             let mut signatures = Vec::with_capacity(expected_signatures_len);
 
             // SAFETY: signatures vector is allocated with enough capacity to hold
@@ -353,9 +353,6 @@ unsafe impl<'de, C: Config> SchemaRead<'de, C> for VersionedTransaction {
                     expected_signatures_len,
                 );
                 signatures.set_len(expected_signatures_len);
-                // Advance the reader by the number of bytes we just consumed
-                // for the signatures.
-                reader.consume_unchecked(bytes_to_read);
             }
 
             builder.write_signatures(signatures);


### PR DESCRIPTION
wincode's `Reader` trait currently allows arbitrary buffering from its implementation back-end (via `fill_buf`, `fill_exact`, etc). This is being removed in the next version so that wincode can support a wider variety of `Reader` back-ends, and is now deprecated as of `0.4.6`.

This requires rewriting the current `v1::Message` `SchemaRead` implementation because it currently uses `fill_buf` and operates directly on that slice.
https://github.com/anza-xyz/solana-sdk/blob/94e0202ceab167596a176c25ca09b96755885b24/message/src/versions/v1/message.rs#L540-L543

The rewrite follows the same deserialization scheme as the existing manual `deserialize` function, but uses wincode's supported `Reader` APIs. The manual reference implementation can be seen here:
https://github.com/anza-xyz/solana-sdk/blob/94e0202ceab167596a176c25ca09b96755885b24/message/src/versions/v1/message.rs#L652-L834

The resulting assembly of both implementations is nearly identical, with the `SchemaRead` implementation having a slightly smaller stack frame. Local micro-benchmarks corroborate this, as performance is basically identical, with the `SchemaRead` implementation being slightly faster on larger payloads and the manual impl being slightly faster on smaller payloads, but the difference was on the order of nanoseconds, so likely benchmark noise.
```
v1_deserialize/manual/small
                        time:   [36.012 ns 36.278 ns 36.567 ns]
                        thrpt:  [2.9035 GiB/s 2.9266 GiB/s 2.9482 GiB/s]
v1_deserialize/schema/small
                        time:   [39.239 ns 39.523 ns 39.792 ns]
                        thrpt:  [2.6682 GiB/s 2.6863 GiB/s 2.7057 GiB/s]
v1_deserialize/manual/large
                        time:   [164.67 ns 166.15 ns 167.68 ns]
                        thrpt:  [9.8920 GiB/s 9.9832 GiB/s 10.073 GiB/s]
v1_deserialize/schema/large
                        time:   [148.30 ns 149.25 ns 150.39 ns]
                        thrpt:  [11.029 GiB/s 11.114 GiB/s 11.185 GiB/s]
```

There are some other very minor deprecations with the 0.4.6 release -- those have been included here as well since they are just a simple rename `peek` -> `peek_byte`, or switching from `fill_exact` to `take_scoped`. I can do these changes in a separate PR, but we will have to `#[allow(deprecated)]` on not-yet-migrated parts.