### PR TITLE
Add wincode support to `bls-signatures`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3432,6 +3432,7 @@ dependencies = [
  "subtle",
  "tempfile",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]

--- a/bls-signatures/Cargo.toml
+++ b/bls-signatures/Cargo.toml
@@ -25,7 +25,8 @@ frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "std"]
 parallel = ["dep:rayon"]
 serde = ["dep:cfg_eval", "dep:serde", "dep:serde_with"]
 solana-signer-derive = ["dep:solana-signer", "dep:solana-signature", "dep:subtle"]
-std = ["dep:serde_json"]
+std = ["dep:serde_json", "wincode?/std"]
+wincode = ["dep:wincode"]
 
 [dependencies]
 base64 = { workspace = true }
@@ -38,6 +39,7 @@ serde_with = { workspace = true, features = ["macros"], optional = true }
 solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
 solana-frozen-abi-macro = { workspace = true, optional = true, features = ["frozen-abi"] }
 thiserror = { workspace = true }
+wincode = { workspace = true, optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 blst = { workspace = true }

--- a/bls-signatures/src/proof_of_possession/bytes.rs
+++ b/bls-signatures/src/proof_of_possession/bytes.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "bytemuck")]
 use bytemuck::{Pod, PodInOption, Zeroable, ZeroableInOption};
+#[cfg(feature = "wincode")]
+use wincode::{SchemaRead, SchemaWrite};
 use {
     base64::{prelude::BASE64_STANDARD, Engine},
     core::fmt,
@@ -26,6 +28,7 @@ pub const BLS_PROOF_OF_POSSESSION_AFFINE_BASE64_SIZE: usize = 256;
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_as)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "wincode", derive(SchemaRead, SchemaWrite))]
 #[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(transparent)]
 pub struct ProofOfPossessionCompressed(
@@ -58,6 +61,7 @@ impl_from_str!(
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_as)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "wincode", derive(SchemaRead, SchemaWrite))]
 #[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(transparent)]
 pub struct ProofOfPossession(

--- a/bls-signatures/src/pubkey/bytes.rs
+++ b/bls-signatures/src/pubkey/bytes.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "bytemuck")]
 use bytemuck::{Pod, PodInOption, Zeroable, ZeroableInOption};
+#[cfg(feature = "wincode")]
+use wincode::{SchemaRead, SchemaWrite};
 use {
     base64::{prelude::BASE64_STANDARD, Engine},
     core::fmt,
@@ -26,6 +28,7 @@ pub const BLS_PUBLIC_KEY_AFFINE_BASE64_SIZE: usize = 256;
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_as)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "wincode", derive(SchemaRead, SchemaWrite))]
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[repr(transparent)]
 pub struct PubkeyCompressed(
@@ -58,6 +61,7 @@ impl_from_str!(
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_as)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "wincode", derive(SchemaRead, SchemaWrite))]
 #[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(transparent)]
 pub struct Pubkey(

--- a/bls-signatures/src/signature/bytes.rs
+++ b/bls-signatures/src/signature/bytes.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "bytemuck")]
 use bytemuck::{Pod, PodInOption, Zeroable, ZeroableInOption};
+#[cfg(feature = "wincode")]
+use wincode::{SchemaRead, SchemaWrite};
 use {
     base64::{prelude::BASE64_STANDARD, Engine},
     core::fmt,
@@ -26,6 +28,7 @@ pub const BLS_SIGNATURE_AFFINE_BASE64_SIZE: usize = 256;
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_as)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "wincode", derive(SchemaRead, SchemaWrite))]
 #[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(transparent)]
 pub struct SignatureCompressed(
@@ -55,6 +58,7 @@ impl_from_str!(
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_as)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "wincode", derive(SchemaRead, SchemaWrite))]
 #[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
 #[repr(transparent)]
 pub struct Signature(


### PR DESCRIPTION
Adds wincode derive annotations to the following types in the `bls-signatures` crate:
- `ProofOfPossessionCompressed`
- `ProofOfPossession`
- `PubkeyCompressed`
- `Pubkey`
- `SignatureCompressed`
- `Signature`