### PR TITLE
reward-info: Add variant for deactivated stake

### DIFF
--- a/reward-info/src/lib.rs
+++ b/reward-info/src/lib.rs
@@ -14,7 +14,7 @@ pub enum RewardType {
     Rent,
     Staking,
     Voting,
-    DeactivatingStake,
+    DeactivatedStake,
 }
 
 impl fmt::Display for RewardType {
@@ -27,7 +27,7 @@ impl fmt::Display for RewardType {
                 RewardType::Rent => "rent",
                 RewardType::Staking => "staking",
                 RewardType::Voting => "voting",
-                RewardType::DeactivatingStake => "deactivating-stake",
+                RewardType::DeactivatedStake => "deactivated-stake",
             }
         )
     }


### PR DESCRIPTION
#### Problem

As mentioned during this [SIMD-0392 amendment](https://github.com/solana-foundation/solana-improvement-documents/pull/488#discussion_r2962812011), block metadata should carry the information of when a stake account is deactivating.

#### Summary of changes

Add a new `DeactivatingStake` variant of `RewardType`, to be used in https://github.com/anza-xyz/agave/pull/11332.