### PR TITLE
frozen-abi: add wincode SchemaWrite support to StableAbi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3728,6 +3728,7 @@ dependencies = [
  "sha2",
  "solana-frozen-abi-macro",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]

--- a/frozen-abi-macro/src/lib.rs
+++ b/frozen-abi-macro/src/lib.rs
@@ -347,7 +347,6 @@ fn quote_for_test(
             fn test_abi_digest() {
                 use ::solana_frozen_abi::rand::{SeedableRng, RngCore};
                 use ::solana_frozen_abi::rand_chacha::ChaCha8Rng;
-                use ::solana_frozen_abi::bincode;
                 use ::solana_frozen_abi::stable_abi::StableAbi;
 
                 let mut rng = ChaCha8Rng::seed_from_u64(20666175621446498);
@@ -355,7 +354,7 @@ fn quote_for_test(
 
                 for _ in 0..10_000 {
                     let val = <#type_name>::random(&mut rng);
-                    digester.hash(&bincode::serialize(&val).unwrap());
+                    digester.hash(&val.serialize_for_abi());
                 }
                 assert_eq!(#expected_abi_digest, ::std::format!("{}", digester.result()), "ABI layout has changed!");
             }

--- a/frozen-abi-macro/src/lib.rs
+++ b/frozen-abi-macro/src/lib.rs
@@ -32,16 +32,11 @@ pub fn derive_stable_abi(_item: TokenStream) -> TokenStream {
 #[cfg(feature = "frozen-abi")]
 #[proc_macro_derive(StableAbi)]
 pub fn derive_stable_abi(item: TokenStream) -> TokenStream {
-    use {
-        quote::quote,
-        syn::{parse_macro_input, Error, Item},
-    };
-
     let item = parse_macro_input!(item as Item);
-    let ident = match item {
-        Item::Struct(ref s) => &s.ident,
-        Item::Enum(ref e) => &e.ident,
-        Item::Type(ref t) => &t.ident,
+    let (ident, generics) = match &item {
+        Item::Struct(s) => (&s.ident, &s.generics),
+        Item::Enum(e) => (&e.ident, &e.generics),
+        Item::Type(t) => (&t.ident, &t.generics),
         _ => {
             return Error::new_spanned(
                 item,
@@ -51,10 +46,11 @@ pub fn derive_stable_abi(item: TokenStream) -> TokenStream {
             .into();
         }
     };
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     let expanded = quote! {
         #[automatically_derived]
-        impl ::solana_frozen_abi::stable_abi::StableAbi for #ident {}
+        impl #impl_generics ::solana_frozen_abi::stable_abi::StableAbi for #ident #ty_generics #where_clause {}
     };
     expanded.into()
 }
@@ -68,6 +64,12 @@ use syn::{
     parse_macro_input, Attribute, Error, Fields, Ident, Item, ItemEnum, ItemStruct, ItemType,
     LitStr, Variant,
 };
+
+#[cfg(feature = "frozen-abi")]
+enum AbiSerializer {
+    Bincode,
+    Wincode,
+}
 
 #[cfg(feature = "frozen-abi")]
 fn filter_serde_attrs(attrs: &[Attribute]) -> bool {
@@ -311,6 +313,7 @@ fn quote_for_test(
     type_name: &Ident,
     expected_api_digest: &str,
     expected_abi_digest: Option<&str>,
+    abi_serializer: AbiSerializer,
 ) -> TokenStream2 {
     let test_api = quote! {
             #[test]
@@ -341,6 +344,15 @@ fn quote_for_test(
             }
     };
 
+    let abi_serialize_expr = match abi_serializer {
+        AbiSerializer::Bincode => {
+            quote! { ::solana_frozen_abi::bincode::serialize(&val).unwrap() }
+        }
+        AbiSerializer::Wincode => {
+            quote! { ::solana_frozen_abi::wincode::serialize(&val).unwrap() }
+        }
+    };
+
     let test_abi = if expected_abi_digest.is_some() {
         quote! {
             #[test]
@@ -354,7 +366,7 @@ fn quote_for_test(
 
                 for _ in 0..10_000 {
                     let val = <#type_name>::random(&mut rng);
-                    digester.hash(&val.serialize_for_abi());
+                    digester.hash(&#abi_serialize_expr);
                 }
                 assert_eq!(#expected_abi_digest, ::std::format!("{}", digester.result()), "ABI layout has changed!");
             }
@@ -383,6 +395,7 @@ fn frozen_abi_type_alias(
     input: ItemType,
     expected_api_digest: &str,
     expected_abi_digest: Option<&str>,
+    abi_serializer: AbiSerializer,
 ) -> TokenStream {
     let type_name = &input.ident;
     let test = quote_for_test(
@@ -390,6 +403,7 @@ fn frozen_abi_type_alias(
         type_name,
         expected_api_digest,
         expected_abi_digest,
+        abi_serializer,
     );
     let result = quote! {
         #input
@@ -403,6 +417,7 @@ fn frozen_abi_struct_type(
     input: ItemStruct,
     expected_api_digest: &str,
     expected_abi_digest: Option<&str>,
+    abi_serializer: AbiSerializer,
 ) -> TokenStream {
     let type_name = &input.ident;
     let test = quote_for_test(
@@ -410,6 +425,7 @@ fn frozen_abi_struct_type(
         type_name,
         expected_api_digest,
         expected_abi_digest,
+        abi_serializer,
     );
     let result = quote! {
         #input
@@ -469,6 +485,7 @@ fn frozen_abi_enum_type(
     input: ItemEnum,
     expected_api_digest: &str,
     expected_abi_digest: Option<&str>,
+    abi_serializer: AbiSerializer,
 ) -> TokenStream {
     let type_name = &input.ident;
     let test = quote_for_test(
@@ -476,6 +493,7 @@ fn frozen_abi_enum_type(
         type_name,
         expected_api_digest,
         expected_abi_digest,
+        abi_serializer,
     );
     let result = quote! {
         #input
@@ -489,6 +507,7 @@ fn frozen_abi_enum_type(
 pub fn frozen_abi(attrs: TokenStream, item: TokenStream) -> TokenStream {
     let mut api_expected_digest: Option<String> = None;
     let mut abi_expected_digest: Option<String> = None;
+    let mut abi_serializer = AbiSerializer::Bincode;
 
     let attrs_parser = syn::meta::parser(|meta| {
         if meta.path.is_ident("digest") || meta.path.is_ident("api_digest") {
@@ -496,6 +515,17 @@ pub fn frozen_abi(attrs: TokenStream, item: TokenStream) -> TokenStream {
             Ok(())
         } else if meta.path.is_ident("abi_digest") {
             abi_expected_digest = Some(meta.value()?.parse::<LitStr>()?.value());
+            Ok(())
+        } else if meta.path.is_ident("abi_serializer") {
+            abi_serializer = match meta.value()?.parse::<LitStr>()?.value().as_str() {
+                "bincode" => AbiSerializer::Bincode,
+                "wincode" => AbiSerializer::Wincode,
+                other => {
+                    return Err(meta.error(format!(
+                        "unsupported `abi_serializer` value `{other}`; expected `bincode` or `wincode`"
+                    )));
+                }
+            };
             Ok(())
         } else {
             Err(meta.error("unsupported \"frozen_abi\" property"))
@@ -514,15 +544,24 @@ pub fn frozen_abi(attrs: TokenStream, item: TokenStream) -> TokenStream {
 
     let item = parse_macro_input!(item as Item);
     match item {
-        Item::Struct(input) => {
-            frozen_abi_struct_type(input, &api_expected_digest, abi_expected_digest.as_deref())
-        }
-        Item::Enum(input) => {
-            frozen_abi_enum_type(input, &api_expected_digest, abi_expected_digest.as_deref())
-        }
-        Item::Type(input) => {
-            frozen_abi_type_alias(input, &api_expected_digest, abi_expected_digest.as_deref())
-        }
+        Item::Struct(input) => frozen_abi_struct_type(
+            input,
+            &api_expected_digest,
+            abi_expected_digest.as_deref(),
+            abi_serializer,
+        ),
+        Item::Enum(input) => frozen_abi_enum_type(
+            input,
+            &api_expected_digest,
+            abi_expected_digest.as_deref(),
+            abi_serializer,
+        ),
+        Item::Type(input) => frozen_abi_type_alias(
+            input,
+            &api_expected_digest,
+            abi_expected_digest.as_deref(),
+            abi_serializer,
+        ),
         _ => Error::new_spanned(
             item,
             "frozen_abi isn't applicable; only for struct, enum and type",

--- a/frozen-abi/Cargo.toml
+++ b/frozen-abi/Cargo.toml
@@ -45,7 +45,7 @@ memmap2 = { workspace = true }
 # to avoid version skew and keep digest computation stable regardless of consumer dependencies.
 rand = { workspace = true }
 rand_chacha = { workspace = true }
-wincode = { workspace = true, features = ["alloc"], optional = true }
+wincode = { workspace = true, features = ["alloc", "derive"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dev-dependencies]
 bitflags = { workspace = true, features = ["serde"] }

--- a/frozen-abi/Cargo.toml
+++ b/frozen-abi/Cargo.toml
@@ -45,6 +45,7 @@ memmap2 = { workspace = true }
 # to avoid version skew and keep digest computation stable regardless of consumer dependencies.
 rand = { workspace = true }
 rand_chacha = { workspace = true }
+wincode = { workspace = true, features = ["alloc"] }
 
 [target.'cfg(not(target_os = "solana"))'.dev-dependencies]
 bitflags = { workspace = true, features = ["serde"] }

--- a/frozen-abi/Cargo.toml
+++ b/frozen-abi/Cargo.toml
@@ -18,7 +18,7 @@ rustdoc-args = ["--cfg=docsrs"]
 default = []
 # activate the frozen-abi feature when we actually want to do frozen-abi testing,
 # otherwise leave it off because it requires nightly Rust
-frozen-abi = []
+frozen-abi = ["dep:wincode", "solana-frozen-abi-macro/frozen-abi"]
 
 [dependencies]
 boxcar = { workspace = true }
@@ -45,7 +45,7 @@ memmap2 = { workspace = true }
 # to avoid version skew and keep digest computation stable regardless of consumer dependencies.
 rand = { workspace = true }
 rand_chacha = { workspace = true }
-wincode = { workspace = true, features = ["alloc"] }
+wincode = { workspace = true, features = ["alloc"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dev-dependencies]
 bitflags = { workspace = true, features = ["serde"] }

--- a/frozen-abi/src/hash.rs
+++ b/frozen-abi/src/hash.rs
@@ -4,7 +4,7 @@ use {
 };
 
 const HASH_BYTES: usize = 32;
-#[derive(AbiExample)]
+#[derive(AbiExample, Debug, PartialEq)]
 pub struct Hash(pub [u8; HASH_BYTES]);
 
 #[derive(Default)]

--- a/frozen-abi/src/lib.rs
+++ b/frozen-abi/src/lib.rs
@@ -16,7 +16,8 @@
 //! The macro would generate the `test_abi_digest` test that verifies binary layout stability:
 //! - Initializes a deterministic random number generator with fixed seed
 //! - Generates 10_000 instances of the type via `StableAbi::random()`
-//! - Serializes each instance with bincode
+//! - Serializes each instance with `wincode` when the type implements `SchemaWrite`;
+//!   otherwise it falls back to `bincode`
 //! - Hashes all serialized bytes together
 //! - Compares the resulting hash against the provided in `abi_digest` attribute
 //!
@@ -58,6 +59,10 @@
 //! impl ::solana_frozen_abi::stable_abi::StableAbi for MyType {}
 //! ```
 //!
+//! For types that cannot use the blanket ABI serializer selection, you can implement
+//! `solana_frozen_abi::stable_abi::StableSerialize` manually and return the bytes that should
+//! participate in the ABI digest.
+//!
 //! ## Edge Cases
 //!
 //! 1. It will not detect field name or order changes, nor same size type swaps (e.g., `i64`
@@ -96,4 +101,4 @@ pub mod stable_abi;
 extern crate solana_frozen_abi_macro;
 
 #[cfg(all(feature = "frozen-abi", not(target_os = "solana")))]
-pub use {bincode, rand, rand_chacha};
+pub use {bincode, rand, rand_chacha, wincode};

--- a/frozen-abi/src/lib.rs
+++ b/frozen-abi/src/lib.rs
@@ -16,8 +16,9 @@
 //! The macro would generate the `test_abi_digest` test that verifies binary layout stability:
 //! - Initializes a deterministic random number generator with fixed seed
 //! - Generates 10_000 instances of the type via `StableAbi::random()`
-//! - Serializes each instance with `wincode` when the type implements `SchemaWrite`;
-//!   otherwise it falls back to `bincode`
+//! - Serializes each instance with `bincode` by default
+//! - Types using `wincode` can switch the ABI test to `wincode` with
+//!   `#[frozen_abi(abi_serializer = "wincode", ...)]`
 //! - Hashes all serialized bytes together
 //! - Compares the resulting hash against the provided in `abi_digest` attribute
 //!
@@ -59,9 +60,7 @@
 //! impl ::solana_frozen_abi::stable_abi::StableAbi for MyType {}
 //! ```
 //!
-//! For types that cannot use the blanket ABI serializer selection, you can implement
-//! `solana_frozen_abi::stable_abi::StableSerialize` manually and return the bytes that should
-//! participate in the ABI digest.
+//! For `wincode`-based types, add `abi_serializer = "wincode"` to `#[frozen_abi(...)]`.
 //!
 //! ## Edge Cases
 //!

--- a/frozen-abi/src/stable_abi.rs
+++ b/frozen-abi/src/stable_abi.rs
@@ -1,4 +1,8 @@
-use rand::{distr::StandardUniform, Rng, RngCore};
+use {
+    rand::{distr::StandardUniform, Rng, RngCore},
+    serde::Serialize,
+    wincode::{config::DefaultConfig, SchemaWrite},
+};
 
 pub trait StableAbi: Sized {
     fn random(rng: &mut impl RngCore) -> Self
@@ -6,5 +10,92 @@ pub trait StableAbi: Sized {
         StandardUniform: rand::distr::Distribution<Self>,
     {
         rng.random::<Self>()
+    }
+
+    fn serialize_for_abi(&self) -> Vec<u8>
+    where
+        Self: StableSerialize,
+    {
+        StableSerialize::serialize_for_abi(self)
+    }
+}
+
+// Escape hatch for types migrating to wincode that cannot use the blanket impls,
+// for example when they drop serde or need a custom schema adapter.
+#[doc(hidden)]
+pub trait StableSerialize {
+    fn serialize_for_abi(&self) -> Vec<u8>;
+}
+
+impl<T> StableSerialize for T
+where
+    T: Serialize,
+{
+    default fn serialize_for_abi(&self) -> Vec<u8> {
+        bincode::serialize(self).unwrap()
+    }
+}
+
+impl<T> StableSerialize for T
+where
+    T: Serialize + SchemaWrite<DefaultConfig, Src = T>,
+{
+    fn serialize_for_abi(&self) -> Vec<u8> {
+        wincode::serialize(self).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(serde_derive::Serialize)]
+    struct SerdeOnly {
+        value: u64,
+    }
+
+    #[derive(serde_derive::Serialize, wincode::SchemaWrite)]
+    #[wincode(tag_encoding = "u8")]
+    enum BothFormats {
+        A,
+        B,
+    }
+
+    #[derive(wincode::SchemaWrite)]
+    struct ManualWincodeOnly {
+        value: u64,
+    }
+
+    impl StableSerialize for ManualWincodeOnly {
+        fn serialize_for_abi(&self) -> Vec<u8> {
+            wincode::serialize(self).unwrap()
+        }
+    }
+
+    #[test]
+    fn stable_abi_falls_back_to_bincode_for_serde_types() {
+        let value = SerdeOnly { value: 42 };
+        assert_eq!(
+            value.serialize_for_abi(),
+            bincode::serialize(&value).unwrap()
+        );
+    }
+
+    #[test]
+    fn stable_abi_prefers_wincode_when_schema_write_is_available() {
+        let value = BothFormats::B;
+        let abi_bytes = value.serialize_for_abi();
+
+        assert_eq!(abi_bytes, wincode::serialize(&value).unwrap());
+        assert_ne!(abi_bytes, bincode::serialize(&value).unwrap());
+    }
+
+    #[test]
+    fn stable_abi_allows_manual_wincode_serialization_for_non_serde_types() {
+        let value = ManualWincodeOnly { value: 42 };
+        assert_eq!(
+            value.serialize_for_abi(),
+            wincode::serialize(&value).unwrap()
+        );
     }
 }

--- a/frozen-abi/src/stable_abi.rs
+++ b/frozen-abi/src/stable_abi.rs
@@ -8,3 +8,68 @@ pub trait StableAbi: Sized {
         rng.random::<Self>()
     }
 }
+
+#[cfg(all(test, feature = "frozen-abi"))]
+mod tests {
+    #[derive(Debug, serde_derive::Serialize, wincode::SchemaWrite)]
+    #[cfg_attr(
+        feature = "frozen-abi",
+        derive(
+            solana_frozen_abi_macro::AbiExample,
+            solana_frozen_abi_macro::StableAbi
+        ),
+        solana_frozen_abi_macro::frozen_abi(
+            api_digest = "2cJjhqi4hsJ3Y5HeT8fYE6YzDPdWnKAmbVHcw75rG1ky",
+            abi_digest = "AgNkEpErnFBuy7iTAEUUAC1fbvokEkhbsfFnx4DtXAvY", // keep same as bincode
+            abi_serializer = "wincode",
+        )
+    )]
+    struct TestStructWincode {
+        a: u64,
+        b: bool,
+        c: [u8; 32],
+        d: (u8, u8),
+    }
+
+    impl crate::rand::distr::Distribution<TestStructWincode> for crate::rand::distr::StandardUniform {
+        fn sample<R: crate::rand::Rng + ?Sized>(&self, rng: &mut R) -> TestStructWincode {
+            TestStructWincode {
+                a: rng.random(),
+                b: rng.random(),
+                c: rng.random(),
+                d: rng.random(),
+            }
+        }
+    }
+
+    #[derive(Debug, serde_derive::Serialize)]
+    #[cfg_attr(
+        feature = "frozen-abi",
+        derive(
+            solana_frozen_abi_macro::AbiExample,
+            solana_frozen_abi_macro::StableAbi
+        ),
+        solana_frozen_abi_macro::frozen_abi(
+            api_digest = "ARDLdidYVUVVNNHgHx1Uf8Ec2dDdDyYAzNsAtm4oB494",
+            abi_digest = "AgNkEpErnFBuy7iTAEUUAC1fbvokEkhbsfFnx4DtXAvY", // keep same as wincode
+            abi_serializer = "bincode",
+        )
+    )]
+    struct TestStructBincode {
+        a: u64,
+        b: bool,
+        c: [u8; 32],
+        d: (u8, u8),
+    }
+
+    impl crate::rand::distr::Distribution<TestStructBincode> for crate::rand::distr::StandardUniform {
+        fn sample<R: crate::rand::Rng + ?Sized>(&self, rng: &mut R) -> TestStructBincode {
+            TestStructBincode {
+                a: rng.random(),
+                b: rng.random(),
+                c: rng.random(),
+                d: rng.random(),
+            }
+        }
+    }
+}

--- a/frozen-abi/src/stable_abi.rs
+++ b/frozen-abi/src/stable_abi.rs
@@ -11,65 +11,87 @@ pub trait StableAbi: Sized {
 
 #[cfg(all(test, feature = "frozen-abi"))]
 mod tests {
-    #[derive(Debug, serde_derive::Serialize, wincode::SchemaWrite)]
-    #[cfg_attr(
-        feature = "frozen-abi",
-        derive(
-            solana_frozen_abi_macro::AbiExample,
-            solana_frozen_abi_macro::StableAbi
-        ),
-        solana_frozen_abi_macro::frozen_abi(
-            api_digest = "2cJjhqi4hsJ3Y5HeT8fYE6YzDPdWnKAmbVHcw75rG1ky",
-            abi_digest = "AgNkEpErnFBuy7iTAEUUAC1fbvokEkhbsfFnx4DtXAvY", // keep same as bincode
-            abi_serializer = "wincode",
-        )
-    )]
-    struct TestStructWincode {
-        a: u64,
-        b: bool,
-        c: [u8; 32],
-        d: (u8, u8),
-    }
-
-    impl crate::rand::distr::Distribution<TestStructWincode> for crate::rand::distr::StandardUniform {
-        fn sample<R: crate::rand::Rng + ?Sized>(&self, rng: &mut R) -> TestStructWincode {
-            TestStructWincode {
-                a: rng.random(),
-                b: rng.random(),
-                c: rng.random(),
-                d: rng.random(),
+    // Keep the bincode and wincode test fixtures structurally identical so their
+    // derived `test_abi_digest` checks enforce one shared ABI digest across serializers.
+    #[rustfmt::skip]
+    macro_rules! linked_stable_abi_pair {
+        (
+            api_digest_wincode = $api_wincode:literal,
+            api_digest_bincode = $api_bincode:literal,
+            abi_digest = $abi:literal,
+        ) => {
+            #[derive(Debug, serde_derive::Serialize, wincode::SchemaWrite)]
+            #[cfg_attr(
+                feature = "frozen-abi",
+                derive(
+                    solana_frozen_abi_macro::AbiExample,
+                    solana_frozen_abi_macro::StableAbi
+                ),
+                solana_frozen_abi_macro::frozen_abi(
+                    api_digest = $api_wincode,
+                    abi_digest = $abi,
+                    abi_serializer = "wincode",
+                )
+            )]
+            struct TestStructWincode {
+                a: u64,
+                b: bool,
+                c: [u8; 32],
+                d: (u8, u8),
             }
-        }
-    }
 
-    #[derive(Debug, serde_derive::Serialize)]
-    #[cfg_attr(
-        feature = "frozen-abi",
-        derive(
-            solana_frozen_abi_macro::AbiExample,
-            solana_frozen_abi_macro::StableAbi
-        ),
-        solana_frozen_abi_macro::frozen_abi(
-            api_digest = "ARDLdidYVUVVNNHgHx1Uf8Ec2dDdDyYAzNsAtm4oB494",
-            abi_digest = "AgNkEpErnFBuy7iTAEUUAC1fbvokEkhbsfFnx4DtXAvY", // keep same as wincode
-            abi_serializer = "bincode",
-        )
-    )]
-    struct TestStructBincode {
-        a: u64,
-        b: bool,
-        c: [u8; 32],
-        d: (u8, u8),
-    }
-
-    impl crate::rand::distr::Distribution<TestStructBincode> for crate::rand::distr::StandardUniform {
-        fn sample<R: crate::rand::Rng + ?Sized>(&self, rng: &mut R) -> TestStructBincode {
-            TestStructBincode {
-                a: rng.random(),
-                b: rng.random(),
-                c: rng.random(),
-                d: rng.random(),
+            impl crate::rand::distr::Distribution<TestStructWincode>
+                for crate::rand::distr::StandardUniform
+            {
+                fn sample<R: crate::rand::Rng + ?Sized>(&self, rng: &mut R) -> TestStructWincode {
+                    TestStructWincode {
+                        a: rng.random(),
+                        b: rng.random(),
+                        c: rng.random(),
+                        d: rng.random(),
+                    }
+                }
             }
-        }
+
+            #[derive(Debug, serde_derive::Serialize)]
+            #[cfg_attr(
+                feature = "frozen-abi",
+                derive(
+                    solana_frozen_abi_macro::AbiExample,
+                    solana_frozen_abi_macro::StableAbi
+                ),
+                solana_frozen_abi_macro::frozen_abi(
+                    api_digest = $api_bincode,
+                    abi_digest = $abi,
+                    abi_serializer = "bincode",
+                )
+            )]
+            struct TestStructBincode {
+                a: u64,
+                b: bool,
+                c: [u8; 32],
+                d: (u8, u8),
+            }
+
+            impl crate::rand::distr::Distribution<TestStructBincode>
+                for crate::rand::distr::StandardUniform
+            {
+                fn sample<R: crate::rand::Rng + ?Sized>(&self, rng: &mut R) -> TestStructBincode {
+                    TestStructBincode {
+                        a: rng.random(),
+                        b: rng.random(),
+                        c: rng.random(),
+                        d: rng.random(),
+                    }
+                }
+            }
+        };
     }
+
+    linked_stable_abi_pair!(
+        api_digest_wincode = "2cJjhqi4hsJ3Y5HeT8fYE6YzDPdWnKAmbVHcw75rG1ky",
+        api_digest_bincode = "ARDLdidYVUVVNNHgHx1Uf8Ec2dDdDyYAzNsAtm4oB494",
+        // shared by bincode and wincode
+        abi_digest = "AgNkEpErnFBuy7iTAEUUAC1fbvokEkhbsfFnx4DtXAvY",
+    );
 }

--- a/frozen-abi/src/stable_abi.rs
+++ b/frozen-abi/src/stable_abi.rs
@@ -1,8 +1,4 @@
-use {
-    rand::{distr::StandardUniform, Rng, RngCore},
-    serde::Serialize,
-    wincode::{config::DefaultConfig, SchemaWrite},
-};
+use rand::{distr::StandardUniform, Rng, RngCore};
 
 pub trait StableAbi: Sized {
     fn random(rng: &mut impl RngCore) -> Self
@@ -10,92 +6,5 @@ pub trait StableAbi: Sized {
         StandardUniform: rand::distr::Distribution<Self>,
     {
         rng.random::<Self>()
-    }
-
-    fn serialize_for_abi(&self) -> Vec<u8>
-    where
-        Self: StableSerialize,
-    {
-        StableSerialize::serialize_for_abi(self)
-    }
-}
-
-// Escape hatch for types migrating to wincode that cannot use the blanket impls,
-// for example when they drop serde or need a custom schema adapter.
-#[doc(hidden)]
-pub trait StableSerialize {
-    fn serialize_for_abi(&self) -> Vec<u8>;
-}
-
-impl<T> StableSerialize for T
-where
-    T: Serialize,
-{
-    default fn serialize_for_abi(&self) -> Vec<u8> {
-        bincode::serialize(self).unwrap()
-    }
-}
-
-impl<T> StableSerialize for T
-where
-    T: Serialize + SchemaWrite<DefaultConfig, Src = T>,
-{
-    fn serialize_for_abi(&self) -> Vec<u8> {
-        wincode::serialize(self).unwrap()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[derive(serde_derive::Serialize)]
-    struct SerdeOnly {
-        value: u64,
-    }
-
-    #[derive(serde_derive::Serialize, wincode::SchemaWrite)]
-    #[wincode(tag_encoding = "u8")]
-    enum BothFormats {
-        A,
-        B,
-    }
-
-    #[derive(wincode::SchemaWrite)]
-    struct ManualWincodeOnly {
-        value: u64,
-    }
-
-    impl StableSerialize for ManualWincodeOnly {
-        fn serialize_for_abi(&self) -> Vec<u8> {
-            wincode::serialize(self).unwrap()
-        }
-    }
-
-    #[test]
-    fn stable_abi_falls_back_to_bincode_for_serde_types() {
-        let value = SerdeOnly { value: 42 };
-        assert_eq!(
-            value.serialize_for_abi(),
-            bincode::serialize(&value).unwrap()
-        );
-    }
-
-    #[test]
-    fn stable_abi_prefers_wincode_when_schema_write_is_available() {
-        let value = BothFormats::B;
-        let abi_bytes = value.serialize_for_abi();
-
-        assert_eq!(abi_bytes, wincode::serialize(&value).unwrap());
-        assert_ne!(abi_bytes, bincode::serialize(&value).unwrap());
-    }
-
-    #[test]
-    fn stable_abi_allows_manual_wincode_serialization_for_non_serde_types() {
-        let value = ManualWincodeOnly { value: 42 };
-        assert_eq!(
-            value.serialize_for_abi(),
-            wincode::serialize(&value).unwrap()
-        );
     }
 }


### PR DESCRIPTION
### Description 

This PR unlocks StableAbi usage on types migrated to Wincode.

### Changes

- Updated docs; added re-export for wincode
- Macros now use Wincode as serializer conditionally, when privided with `abi_serializer = "wincode"` in `#[frozen_abi(...)]`
- Tests

### Example
https://github.com/anza-xyz/solana-sdk/compare/master...puhtaytow:solana-sdk:frozen-abi-wincode-1-example?expand=1#diff-4c32c52b0558ba75f13f46d2de9cc023c317d0504279def7f4ae424ba9ea095eR1-R70