### PR TITLE
[bls-signatures] Remove `Debug` for secret key and implement `Zeroize` and `ZeroizeOnDrop`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3434,6 +3434,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "wincode",
+ "zeroize",
 ]
 
 [[package]]
@@ -5808,9 +5809,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -342,6 +342,7 @@ toml = "0.8.23"
 uriparse = "0.6.4"
 wasm-bindgen = "0.2.100"
 wincode = { version = "0.4.8", features = ["derive"], default-features = false }
+zeroize = "1.8.2"
 
 [profile.release]
 split-debuginfo = "unpacked"

--- a/bls-signatures/Cargo.toml
+++ b/bls-signatures/Cargo.toml
@@ -40,6 +40,7 @@ solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi
 solana-frozen-abi-macro = { workspace = true, optional = true, features = ["frozen-abi"] }
 thiserror = { workspace = true }
 wincode = { workspace = true, optional = true }
+zeroize = { workspace = true, features = ["zeroize_derive"] }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 blst = { workspace = true }

--- a/bls-signatures/src/keypair.rs
+++ b/bls-signatures/src/keypair.rs
@@ -1,12 +1,3 @@
-use crate::{
-    error::BlsError,
-    proof_of_possession::ProofOfPossessionProjective,
-    pubkey::{
-        PopVerified, PubkeyAffine, PubkeyProjective, VerifySignature, BLS_PUBLIC_KEY_AFFINE_SIZE,
-    },
-    secret_key::{SecretKey, BLS_SECRET_KEY_SIZE},
-    signature::{AsSignatureAffine, SignatureProjective},
-};
 #[cfg(feature = "solana-signer-derive")]
 use solana_signer::Signer;
 #[cfg(feature = "std")]
@@ -19,6 +10,19 @@ use std::{
     string::String,
     vec::Vec,
 };
+use {
+    crate::{
+        error::BlsError,
+        proof_of_possession::ProofOfPossessionProjective,
+        pubkey::{
+            PopVerified, PubkeyAffine, PubkeyProjective, VerifySignature,
+            BLS_PUBLIC_KEY_AFFINE_SIZE,
+        },
+        secret_key::{SecretKey, BLS_SECRET_KEY_SIZE},
+        signature::{AsSignatureAffine, SignatureProjective},
+    },
+    zeroize::{Zeroize, ZeroizeOnDrop},
+};
 
 /// Size of BLS keypair in bytes
 pub const BLS_KEYPAIR_SIZE: usize = BLS_SECRET_KEY_SIZE + BLS_PUBLIC_KEY_AFFINE_SIZE;
@@ -29,6 +33,16 @@ pub struct Keypair {
     pub secret: SecretKey,
     pub public: PopVerified<PubkeyAffine>,
 }
+
+impl Zeroize for Keypair {
+    fn zeroize(&mut self) {
+        // Delegate zeroization to the SecretKey.
+        // We skip `self.public` because public keys do not contain sensitive material.
+        self.secret.zeroize();
+    }
+}
+
+impl ZeroizeOnDrop for Keypair {}
 
 impl Keypair {
     /// Constructs a new, random `Keypair` using `OsRng`

--- a/bls-signatures/src/secret_key.rs
+++ b/bls-signatures/src/secret_key.rs
@@ -11,6 +11,7 @@ use {
     core::ptr,
     ff::Field,
     rand::rngs::OsRng,
+    zeroize::{Zeroize, ZeroizeOnDrop},
 };
 #[cfg(feature = "solana-signer-derive")]
 use {solana_signature::Signature, solana_signer::Signer, subtle::ConstantTimeEq};
@@ -19,8 +20,30 @@ use {solana_signature::Signature, solana_signer::Signer, subtle::ConstantTimeEq}
 pub const BLS_SECRET_KEY_SIZE: usize = 32;
 
 /// A BLS secret key
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct SecretKey(pub(crate) Scalar);
+
+impl core::fmt::Debug for SecretKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "SecretKey(<hidden>)")
+    }
+}
+
+impl Zeroize for SecretKey {
+    fn zeroize(&mut self) {
+        unsafe {
+            core::ptr::write_volatile(&mut self.0, Scalar::ZERO);
+        }
+    }
+}
+
+impl Drop for SecretKey {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl ZeroizeOnDrop for SecretKey {}
 
 impl SecretKey {
     /// Constructs a new, random `BlsSecretKey` using `OsRng`


### PR DESCRIPTION
#### Summary of Changes

- Right now, the BLS secret key implements `Debug`, which can reveal secret key information on screen or log files. I updated the code with a custom `Debug` implementation.
- I also implemented the traits `Zeroize` and `ZeroizeOnDrop` for BLS secret and BLS keypair to zeroize memory on drop as an extra safety measure.