### PR TITLE
Serialize `Address` as base58 string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -67,9 +67,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
@@ -335,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "array-bytes"
-version = "1.4.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad284aeb45c13f2fb4f084de4a420ebf447423bdf9386c0540ce33cb3ef4b8c"
+checksum = "c5b210fcebfebcdd3ac59145390e5a4c16a980f4a18d4b676cd96dee09926854"
 
 [[package]]
 name = "arrayref"
@@ -747,18 +747,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.39"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.39"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -766,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
@@ -954,9 +954,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -1543,12 +1543,13 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "zerocopy 0.8.47",
 ]
 
 [[package]]
@@ -1589,9 +1590,9 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1950,13 +1951,13 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
- "hermit-abi 0.5.1",
+ "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2476,7 +2477,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -3323,6 +3324,7 @@ dependencies = [
  "rand 0.9.2",
  "serde",
  "serde_derive",
+ "serde_json",
  "sha2-const-stable",
  "solana-account-info",
  "solana-address",
@@ -5219,9 +5221,9 @@ checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
@@ -5771,7 +5773,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+dependencies = [
+ "zerocopy-derive 0.8.47",
 ]
 
 [[package]]
@@ -5779,6 +5790,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/address/Cargo.toml
+++ b/address/Cargo.toml
@@ -33,7 +33,7 @@ frozen-abi = [
 nullable = ["dep:solana-nullable"]
 rand = ["dep:rand", "atomic", "std"]
 sanitize = ["dep:solana-sanitize"]
-serde = ["dep:serde", "dep:serde_derive"]
+serde = ["dep:serde", "dep:serde_derive", "decode"]
 sha2 = ["dep:sha2-const-stable", "dep:solana-sha256-hasher", "syscalls"]
 std = ["decode", "borsh?/std", "serde?/std", "wincode?/std", "alloc"]
 alloc = ["wincode?/alloc"]
@@ -69,6 +69,7 @@ solana-sha256-hasher = { workspace = true, features = ["sha2"], optional = true 
 
 [dev-dependencies]
 anyhow = { workspace = true }
+serde_json = { workspace = true }
 solana-account-info = { path = "../account-info" }
 solana-address = { path = ".", features = ["atomic", "borsh", "curve25519", "decode", "dev-context-only-utils", "error", "nullable", "sanitize", "sha2", "std", "syscalls"] }
 solana-cpi = { path = "../cpi" }

--- a/address/src/lib.rs
+++ b/address/src/lib.rs
@@ -43,7 +43,7 @@ use core::{
     ptr::read_unaligned,
 };
 #[cfg(feature = "serde")]
-use serde_derive::{Deserialize, Serialize};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "wincode")]
 use wincode::{SchemaRead, SchemaWrite};
 #[cfg(feature = "borsh")]
@@ -91,7 +91,6 @@ pub const PDA_MARKER: &[u8; 21] = b"ProgramDerivedAddress";
     borsh(crate = "borsh")
 )]
 #[cfg_attr(feature = "borsh", derive(BorshSchema))]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "bytemuck", derive(Pod, Zeroable))]
 #[cfg_attr(feature = "wincode", derive(SchemaWrite, SchemaRead))]
 #[cfg_attr(feature = "dev-context-only-utils", derive(Arbitrary))]
@@ -172,6 +171,22 @@ impl TryFrom<&str> for Address {
     type Error = ParseAddressError;
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         Address::from_str(s)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for Address {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for Address {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        <&str as Deserialize>::deserialize(deserializer)?
+            .parse()
+            .map_err(de::Error::custom)
     }
 }
 
@@ -509,6 +524,8 @@ macro_rules! declare_deprecated_id {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "serde")]
+    use serde_json::{from_str, to_string};
     use {super::*, core::str::from_utf8, std::string::String};
 
     fn encode_address(address: &[u8; 32]) -> String {
@@ -808,5 +825,39 @@ mod tests {
             assert_eq!(!p1.eq(&p3), p1.0 != p3.0);
             assert!(!address_eq(&p1, &p3));
         }
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_json_serializes_zero_address_as_base58_string() {
+        let address = Address::from([0u8; ADDRESS_BYTES]);
+        let serialized = to_string(&address).unwrap();
+        assert_eq!(serialized, "\"11111111111111111111111111111111\"");
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_json_serializes_known_bytes_as_base58_string() {
+        let address = Address::from([1u8; ADDRESS_BYTES]);
+        let serialized = to_string(&address).unwrap();
+        assert_eq!(
+            serialized,
+            "\"4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi\""
+        );
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_json_deserializes_known_base58_string() {
+        let expected = Address::from([1u8; ADDRESS_BYTES]);
+        let serialized = "\"4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi\"";
+        let deserialized = from_str::<Address>(serialized).unwrap();
+        assert_eq!(deserialized, expected);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_json_rejects_invalid_base58_string() {
+        assert!(from_str::<Address>("xyz_hello").is_err());
     }
 }


### PR DESCRIPTION
Reference: https://github.com/solana-program/token-metadata/pull/57#discussion_r2974368421

Currently, serde serializes Address as a 32 integer array. This is not idiomatic as addresses have always historically been serialized as base58 strings. This PR adds custom serde impl's that replace the default derives.

Change considered a bug fix and will go out as a patch release.