### PR TITLE
feat(reward-info): support wincode feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4268,6 +4268,7 @@ dependencies = [
  "serde_derive",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
+ "wincode",
 ]
 
 [[package]]

--- a/reward-info/Cargo.toml
+++ b/reward-info/Cargo.toml
@@ -15,9 +15,11 @@ targets = ["x86_64-unknown-linux-gnu"]
 [features]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "serde"]
 serde = ["dep:serde", "dep:serde_derive"]
+wincode = ["dep:wincode"]
 
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
+wincode = { workspace = true, optional = true }

--- a/reward-info/src/lib.rs
+++ b/reward-info/src/lib.rs
@@ -5,9 +5,12 @@ use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::{AbiEnumVisitor, AbiExample};
 use std::fmt;
+#[cfg(feature = "wincode")]
+use wincode::{SchemaRead, SchemaWrite};
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "wincode", derive(SchemaRead, SchemaWrite))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum RewardType {
     Fee,


### PR DESCRIPTION
Support wincode schemas for `RewardType` gated by `wincode` feature