### PR TITLE
feat(address-lookup-table-interface): support wincode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3362,6 +3362,7 @@ dependencies = [
  "solana-pubkey",
  "solana-sdk-ids",
  "solana-slot-hashes",
+ "wincode",
 ]
 
 [[package]]

--- a/address-lookup-table-interface/Cargo.toml
+++ b/address-lookup-table-interface/Cargo.toml
@@ -24,9 +24,17 @@ bincode = [
     "solana-instruction/bincode",
 ]
 bytemuck = ["dep:bytemuck", "solana-pubkey/bytemuck"]
-dev-context-only-utils = ["bincode", "bytemuck"]
+dev-context-only-utils = ["wincode", "bytemuck"]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "serde"]
 serde = ["dep:serde", "dep:serde_derive", "serde/alloc", "solana-pubkey/serde"]
+wincode = [
+    "dep:wincode",
+    "dep:solana-instruction",
+    "dep:solana-instruction-error",
+    "wincode/alloc",
+    "solana-pubkey/wincode",
+    "solana-instruction/wincode",
+]
 
 [dependencies]
 bincode = { workspace = true, optional = true }
@@ -41,6 +49,7 @@ solana-instruction-error = { workspace = true, optional = true }
 solana-pubkey = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-slot-hashes = { workspace = true }
+wincode = { workspace = true, optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 solana-pubkey = { workspace = true, features = ["curve25519"] }

--- a/address-lookup-table-interface/src/instruction.rs
+++ b/address-lookup-table-interface/src/instruction.rs
@@ -1,13 +1,20 @@
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
 use {solana_clock::Slot, solana_pubkey::Pubkey, solana_sdk_ids::address_lookup_table::id};
-#[cfg(feature = "bincode")]
+#[cfg(all(not(feature = "wincode"), feature = "bincode"))]
 use {
     solana_instruction::{AccountMeta, Instruction},
     solana_sdk_ids::system_program,
 };
+#[cfg(feature = "wincode")]
+use {
+    solana_instruction::{AccountMeta, Instruction},
+    solana_sdk_ids::system_program,
+    wincode::{SchemaRead, SchemaWrite},
+};
 
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "wincode", derive(SchemaRead, SchemaWrite))]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum ProgramInstruction {
     /// Create an address lookup table
@@ -77,9 +84,9 @@ pub fn derive_lookup_table_address(
     )
 }
 
-#[cfg(feature = "bincode")]
 /// Constructs an instruction to create a table account and returns
 /// the instruction and the table account's derived address.
+#[cfg(any(feature = "wincode", feature = "bincode"))]
 fn create_lookup_table_common(
     authority_address: Pubkey,
     payer_address: Pubkey,
@@ -88,7 +95,22 @@ fn create_lookup_table_common(
 ) -> (Instruction, Pubkey) {
     let (lookup_table_address, bump_seed) =
         derive_lookup_table_address(&authority_address, recent_slot);
+    #[cfg(all(not(feature = "wincode"), feature = "bincode"))]
     let instruction = Instruction::new_with_bincode(
+        id(),
+        &ProgramInstruction::CreateLookupTable {
+            recent_slot,
+            bump_seed,
+        },
+        vec![
+            AccountMeta::new(lookup_table_address, false),
+            AccountMeta::new_readonly(authority_address, authority_is_signer),
+            AccountMeta::new(payer_address, true),
+            AccountMeta::new_readonly(system_program::id(), false),
+        ],
+    );
+    #[cfg(feature = "wincode")]
+    let instruction = Instruction::new_with_wincode(
         id(),
         &ProgramInstruction::CreateLookupTable {
             recent_slot,
@@ -113,7 +135,7 @@ fn create_lookup_table_common(
 /// This instruction doesn't require the authority to be a signer but
 /// until v1.12 the address lookup table program still requires the
 /// authority to sign the transaction.
-#[cfg(feature = "bincode")]
+#[cfg(any(feature = "wincode", feature = "bincode"))]
 pub fn create_lookup_table(
     authority_address: Pubkey,
     payer_address: Pubkey,
@@ -125,21 +147,33 @@ pub fn create_lookup_table(
 /// Constructs an instruction that freezes an address lookup
 /// table so that it can never be closed or extended again. Empty
 /// lookup tables cannot be frozen.
-#[cfg(feature = "bincode")]
+#[cfg(any(feature = "wincode", feature = "bincode"))]
 pub fn freeze_lookup_table(lookup_table_address: Pubkey, authority_address: Pubkey) -> Instruction {
-    Instruction::new_with_bincode(
+    #[cfg(all(not(feature = "wincode"), feature = "bincode"))]
+    let instruction = Instruction::new_with_bincode(
         id(),
         &ProgramInstruction::FreezeLookupTable,
         vec![
             AccountMeta::new(lookup_table_address, false),
             AccountMeta::new_readonly(authority_address, true),
         ],
-    )
+    );
+
+    #[cfg(feature = "wincode")]
+    let instruction = Instruction::new_with_wincode(
+        id(),
+        &ProgramInstruction::FreezeLookupTable,
+        vec![
+            AccountMeta::new(lookup_table_address, false),
+            AccountMeta::new_readonly(authority_address, true),
+        ],
+    );
+    instruction
 }
 
 /// Constructs an instruction which extends an address lookup
 /// table account with new addresses.
-#[cfg(feature = "bincode")]
+#[cfg(any(feature = "wincode", feature = "bincode"))]
 pub fn extend_lookup_table(
     lookup_table_address: Pubkey,
     authority_address: Pubkey,
@@ -158,41 +192,61 @@ pub fn extend_lookup_table(
         ]);
     }
 
-    Instruction::new_with_bincode(
+    #[cfg(all(not(feature = "wincode"), feature = "bincode"))]
+    let instruction = Instruction::new_with_bincode(
         id(),
         &ProgramInstruction::ExtendLookupTable { new_addresses },
         accounts,
-    )
+    );
+    #[cfg(feature = "wincode")]
+    let instruction = Instruction::new_with_wincode(
+        id(),
+        &ProgramInstruction::ExtendLookupTable { new_addresses },
+        accounts,
+    );
+    instruction
 }
 
 /// Constructs an instruction that deactivates an address lookup
 /// table so that it cannot be extended again and will be unusable
 /// and eligible for closure after a short amount of time.
-#[cfg(feature = "bincode")]
+#[cfg(any(feature = "wincode", feature = "bincode"))]
 pub fn deactivate_lookup_table(
     lookup_table_address: Pubkey,
     authority_address: Pubkey,
 ) -> Instruction {
-    Instruction::new_with_bincode(
+    #[cfg(all(not(feature = "wincode"), feature = "bincode"))]
+    let instruction = Instruction::new_with_bincode(
         id(),
         &ProgramInstruction::DeactivateLookupTable,
         vec![
             AccountMeta::new(lookup_table_address, false),
             AccountMeta::new_readonly(authority_address, true),
         ],
-    )
+    );
+    #[cfg(feature = "wincode")]
+    let instruction = Instruction::new_with_wincode(
+        id(),
+        &ProgramInstruction::DeactivateLookupTable,
+        vec![
+            AccountMeta::new(lookup_table_address, false),
+            AccountMeta::new_readonly(authority_address, true),
+        ],
+    );
+    instruction
 }
 
 /// Returns an instruction that closes an address lookup table
 /// account. The account will be deallocated and the lamports
 /// will be drained to the recipient address.
-#[cfg(feature = "bincode")]
+#[cfg(any(feature = "wincode", feature = "bincode"))]
 pub fn close_lookup_table(
     lookup_table_address: Pubkey,
     authority_address: Pubkey,
     recipient_address: Pubkey,
 ) -> Instruction {
-    Instruction::new_with_bincode(
+    #[cfg(all(not(feature = "wincode"), feature = "bincode"))]
+    let instruction = Instruction::new_with_bincode(
         id(),
         &ProgramInstruction::CloseLookupTable,
         vec![
@@ -200,5 +254,16 @@ pub fn close_lookup_table(
             AccountMeta::new_readonly(authority_address, true),
             AccountMeta::new(recipient_address, false),
         ],
-    )
+    );
+    #[cfg(feature = "wincode")]
+    let instruction = Instruction::new_with_wincode(
+        id(),
+        &ProgramInstruction::CloseLookupTable,
+        vec![
+            AccountMeta::new(lookup_table_address, false),
+            AccountMeta::new_readonly(authority_address, true),
+            AccountMeta::new(recipient_address, false),
+        ],
+    );
+    instruction
 }

--- a/address-lookup-table-interface/src/state.rs
+++ b/address-lookup-table-interface/src/state.rs
@@ -2,7 +2,7 @@
 use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::{AbiEnumVisitor, AbiExample};
-#[cfg(feature = "bincode")]
+#[cfg(all(not(feature = "wincode"), feature = "bincode"))]
 use solana_instruction_error::InstructionError;
 use {
     crate::error::AddressLookupError,
@@ -10,6 +10,11 @@ use {
     solana_pubkey::Pubkey,
     solana_slot_hashes::{get_entries, SlotHashes, MAX_ENTRIES},
     std::borrow::Cow,
+};
+#[cfg(feature = "wincode")]
+use {
+    solana_instruction_error::InstructionError,
+    wincode::{SchemaRead, SchemaWrite},
 };
 
 /// The lookup table may be in a deactivating state until
@@ -42,6 +47,7 @@ pub enum LookupTableStatus {
 /// Address lookup table metadata
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "wincode", derive(SchemaRead, SchemaWrite))]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct LookupTableMeta {
     /// Lookup tables cannot be closed until the deactivation slot is
@@ -121,6 +127,7 @@ impl LookupTableMeta {
 /// Program account states
 #[cfg_attr(feature = "frozen-abi", derive(AbiEnumVisitor, AbiExample))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "wincode", derive(SchemaRead, SchemaWrite))]
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum ProgramState {
@@ -140,7 +147,7 @@ pub struct AddressLookupTable<'a> {
 impl<'a> AddressLookupTable<'a> {
     /// Serialize an address table's updated meta data and zero
     /// any leftover bytes.
-    #[cfg(feature = "bincode")]
+    #[cfg(any(feature = "wincode", feature = "bincode"))]
     pub fn overwrite_meta_data(
         data: &mut [u8],
         lookup_table_meta: LookupTableMeta,
@@ -149,6 +156,10 @@ impl<'a> AddressLookupTable<'a> {
             .get_mut(0..LOOKUP_TABLE_META_SIZE)
             .ok_or(InstructionError::InvalidAccountData)?;
         meta_data.fill(0);
+        #[cfg(feature = "wincode")]
+        wincode::serialize_into(meta_data, &ProgramState::LookupTable(lookup_table_meta))
+            .map_err(|_| InstructionError::GenericError)?;
+        #[cfg(all(not(feature = "wincode"), feature = "bincode"))]
         bincode::serialize_into(meta_data, &ProgramState::LookupTable(lookup_table_meta))
             .map_err(|_| InstructionError::GenericError)?;
         Ok(())
@@ -215,7 +226,7 @@ impl<'a> AddressLookupTable<'a> {
     }
 
     /// Serialize an address table including its addresses
-    #[cfg(feature = "bincode")]
+    #[cfg(any(feature = "wincode", feature = "bincode"))]
     pub fn serialize_for_tests(self) -> Result<Vec<u8>, InstructionError> {
         let mut data = vec![0; LOOKUP_TABLE_META_SIZE];
         Self::overwrite_meta_data(&mut data, self.meta)?;
@@ -227,10 +238,14 @@ impl<'a> AddressLookupTable<'a> {
 
     /// Efficiently deserialize an address table without allocating
     /// for stored addresses.
-    #[cfg(all(feature = "bincode", feature = "bytemuck"))]
+    #[cfg(all(any(feature = "wincode", feature = "bincode"), feature = "bytemuck"))]
     pub fn deserialize(data: &'a [u8]) -> Result<AddressLookupTable<'a>, InstructionError> {
+        #[cfg(all(not(feature = "wincode"), feature = "bincode"))]
         let program_state: ProgramState =
             bincode::deserialize(data).map_err(|_| InstructionError::InvalidAccountData)?;
+        #[cfg(feature = "wincode")]
+        let program_state: ProgramState =
+            wincode::deserialize(data).map_err(|_| InstructionError::InvalidAccountData)?;
 
         let meta = match program_state {
             ProgramState::LookupTable(meta) => Ok(meta),
@@ -282,12 +297,18 @@ mod tests {
     #[test]
     fn test_lookup_table_meta_size() {
         let lookup_table = ProgramState::LookupTable(LookupTableMeta::new_for_tests());
+        #[cfg(all(not(feature = "wincode"), feature = "bincode"))]
         let meta_size = bincode::serialized_size(&lookup_table).unwrap();
+        #[cfg(feature = "wincode")]
+        let meta_size = wincode::serialized_size(&lookup_table).unwrap();
         assert!(meta_size as usize <= LOOKUP_TABLE_META_SIZE);
         assert_eq!(meta_size as usize, 56);
 
         let lookup_table = ProgramState::LookupTable(LookupTableMeta::default());
+        #[cfg(all(not(feature = "wincode"), feature = "bincode"))]
         let meta_size = bincode::serialized_size(&lookup_table).unwrap();
+        #[cfg(feature = "wincode")]
+        let meta_size = wincode::serialized_size(&lookup_table).unwrap();
         assert!(meta_size as usize <= LOOKUP_TABLE_META_SIZE);
         assert_eq!(meta_size as usize, 24);
     }
@@ -364,7 +385,10 @@ mod tests {
     fn test_overwrite_meta_data() {
         let meta = LookupTableMeta::new_for_tests();
         let empty_table = ProgramState::LookupTable(meta.clone());
+        #[cfg(all(not(feature = "wincode"), feature = "bincode"))]
         let mut serialized_table_1 = bincode::serialize(&empty_table).unwrap();
+        #[cfg(feature = "wincode")]
+        let mut serialized_table_1 = wincode::serialize(&empty_table).unwrap();
         serialized_table_1.resize(LOOKUP_TABLE_META_SIZE, 0);
 
         let address_table = AddressLookupTable::new_for_tests(meta, 0);

--- a/message/Cargo.toml
+++ b/message/Cargo.toml
@@ -61,7 +61,7 @@ borsh = { workspace = true }
 itertools = { workspace = true }
 proptest = { workspace = true }
 serde_json = { workspace = true }
-solana-address-lookup-table-interface = { workspace = true, features = ["bincode", "bytemuck"] }
+solana-address-lookup-table-interface = { workspace = true, features = ["wincode", "bytemuck"] }
 solana-example-mocks = { path = "../example-mocks" }
 solana-hash = { workspace = true, features = ["atomic"] }
 solana-instruction = { workspace = true, features = ["borsh"] }


### PR DESCRIPTION
Add `wincode` feature.

Note: when both `bincode` and `wincode` features are enabled, the `wincode` based code is used