### PR TITLE
account: remove loader v4 from PROGRAM_OWNERS

### DIFF
--- a/account/src/lib.rs
+++ b/account/src/lib.rs
@@ -15,7 +15,7 @@ use {
     solana_clock::{Epoch, INITIAL_RENT_EPOCH},
     solana_instruction_error::LamportsError,
     solana_pubkey::Pubkey,
-    solana_sdk_ids::{bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, loader_v4},
+    solana_sdk_ids::{bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable},
     std::{cell::RefCell, fmt, mem::MaybeUninit, ops::Deref, ptr, rc::Rc, sync::Arc},
 };
 #[cfg(feature = "bincode")]
@@ -697,7 +697,6 @@ pub const PROGRAM_OWNERS: &[Pubkey] = &[
     bpf_loader_upgradeable::id(),
     bpf_loader::id(),
     bpf_loader_deprecated::id(),
-    loader_v4::id(),
 ];
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem
As per [RFC-0423](https://github.com/solana-foundation/solana-improvement-documents/discussions/423), Loader V4 will be redesigned and reintroduced as an on-chain program. The builtin implementation should be removed.

#### Summary of Changes
Remove Loader V4's ID from `PROGRAM_OWNERS`, which is used in Agave to key on program account ownership.