### PR TITLE
loader-v3-interface: remove ExtendProgramChecked instruction

### DIFF
--- a/loader-v3-interface/src/instruction.rs
+++ b/loader-v3-interface/src/instruction.rs
@@ -179,25 +179,6 @@ pub enum UpgradeableLoaderInstruction {
     ///   1. `[writable]` The Program account.
     ///   2. `[signer]` The current authority.
     Migrate,
-
-    /// Extend a program's ProgramData account by the specified number of bytes.
-    /// Only upgradeable programs can be extended.
-    ///
-    /// This instruction differs from ExtendProgram in that the authority is a
-    /// required signer.
-    ///
-    /// # Account references
-    ///   0. `[writable]` The ProgramData account.
-    ///   1. `[writable]` The ProgramData account's associated Program account.
-    ///   2. `[signer]` The authority.
-    ///   3. `[]` System program (`solana_sdk::system_program::id()`), optional, used to transfer
-    ///      lamports from the payer to the ProgramData account.
-    ///   4. `[signer]` The payer account, optional, that will pay necessary rent exemption costs
-    ///      for the increased storage size.
-    ExtendProgramChecked {
-        /// Number of bytes to extend the program data.
-        additional_bytes: u32,
-    },
 }
 
 #[cfg(feature = "bincode")]
@@ -328,10 +309,6 @@ pub fn is_set_authority_checked_instruction(instruction_data: &[u8]) -> bool {
 
 pub fn is_migrate_instruction(instruction_data: &[u8]) -> bool {
     !instruction_data.is_empty() && 8 == instruction_data[0]
-}
-
-pub fn is_extend_program_checked_instruction(instruction_data: &[u8]) -> bool {
-    !instruction_data.is_empty() && 9 == instruction_data[0]
 }
 
 #[cfg(feature = "bincode")]
@@ -492,35 +469,6 @@ pub fn migrate_program(
     Instruction::new_with_bincode(id(), &UpgradeableLoaderInstruction::Migrate, accounts)
 }
 
-/// Returns the instruction required to extend the size of a program's
-/// executable data account
-#[cfg(feature = "bincode")]
-pub fn extend_program_checked(
-    program_address: &Pubkey,
-    authority_address: &Pubkey,
-    payer_address: Option<&Pubkey>,
-    additional_bytes: u32,
-) -> Instruction {
-    let program_data_address = get_program_data_address(program_address);
-    let mut metas = vec![
-        AccountMeta::new(program_data_address, false),
-        AccountMeta::new(*program_address, false),
-        AccountMeta::new(*authority_address, true),
-    ];
-    if let Some(payer_address) = payer_address {
-        metas.push(AccountMeta::new_readonly(
-            solana_sdk_ids::system_program::id(),
-            false,
-        ));
-        metas.push(AccountMeta::new(*payer_address, true));
-    }
-    Instruction::new_with_bincode(
-        id(),
-        &UpgradeableLoaderInstruction::ExtendProgramChecked { additional_bytes },
-        metas,
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -621,17 +569,6 @@ mod tests {
         assert_is_instruction(
             is_migrate_instruction,
             UpgradeableLoaderInstruction::Migrate {},
-        );
-    }
-
-    #[test]
-    fn test_is_extend_program_checked_instruction() {
-        assert!(!is_extend_program_checked_instruction(&[]));
-        assert_is_instruction(
-            is_extend_program_checked_instruction,
-            UpgradeableLoaderInstruction::ExtendProgramChecked {
-                additional_bytes: 0,
-            },
         );
     }
 }


### PR DESCRIPTION
#### Problem
[SIMD-0164](https://github.com/solana-foundation/solana-improvement-documents/pull/164) was never approved and subsequently closed. This instruction should not exist.

#### Summary of Changes
Remove the enum variant, instruction builder, discriminant checker, and associated test.