### PR TITLE
feat: add wincode feature to more crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3625,6 +3625,7 @@ dependencies = [
  "solana-sdk-macro",
  "solana-sysvar-id",
  "static_assertions",
+ "wincode",
 ]
 
 [[package]]
@@ -3776,6 +3777,7 @@ dependencies = [
  "serde_derive",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
+ "wincode",
 ]
 
 [[package]]
@@ -3805,6 +3807,7 @@ dependencies = [
  "serde_derive",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
+ "wincode",
 ]
 
 [[package]]
@@ -4260,6 +4263,7 @@ dependencies = [
  "solana-sdk-macro",
  "solana-sysvar-id",
  "static_assertions",
+ "wincode",
 ]
 
 [[package]]

--- a/epoch-schedule/Cargo.toml
+++ b/epoch-schedule/Cargo.toml
@@ -16,6 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 serde = ["dep:serde", "dep:serde_derive"]
 sysvar = ["dep:solana-sdk-ids", "dep:solana-sysvar-id"]
+wincode = ["dep:wincode"]
 
 [dependencies]
 serde = { workspace = true, optional = true }
@@ -25,6 +26,7 @@ solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-sdk-ids = { workspace = true, optional = true }
 solana-sdk-macro = { workspace = true }
 solana-sysvar-id = { workspace = true, optional = true }
+wincode = { workspace = true, optional = true }
 
 [dev-dependencies]
 solana-clock = { workspace = true }

--- a/epoch-schedule/src/lib.rs
+++ b/epoch-schedule/src/lib.rs
@@ -53,6 +53,7 @@ pub const MINIMUM_SLOTS_PER_EPOCH: u64 = 32;
     derive(Deserialize, Serialize),
     serde(rename_all = "camelCase")
 )]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Debug, CloneZeroed, PartialEq, Eq)]
 pub struct EpochSchedule {
     /// The maximum number of slots in each epoch.

--- a/hard-forks/Cargo.toml
+++ b/hard-forks/Cargo.toml
@@ -15,12 +15,14 @@ targets = ["x86_64-unknown-linux-gnu"]
 [features]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 serde = ["dep:serde", "dep:serde_derive", "serde/alloc"]
+wincode = ["dep:wincode", "wincode/alloc"]
 
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
 solana-frozen-abi-macro = { workspace = true, optional = true, features = ["frozen-abi"] }
+wincode = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/hard-forks/src/lib.rs
+++ b/hard-forks/src/lib.rs
@@ -9,6 +9,7 @@
     feature = "serde",
     derive(serde_derive::Deserialize, serde_derive::Serialize)
 )]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct HardForks {
     hard_forks: Vec<(u64, usize)>,

--- a/inflation/Cargo.toml
+++ b/inflation/Cargo.toml
@@ -15,9 +15,11 @@ targets = ["x86_64-unknown-linux-gnu"]
 [features]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 serde = ["dep:serde", "dep:serde_derive"]
+wincode = ["dep:wincode"]
 
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 solana-frozen-abi = { workspace = true, optional = true }
 solana-frozen-abi-macro = { workspace = true, optional = true }
+wincode = { workspace = true, optional = true }

--- a/inflation/src/lib.rs
+++ b/inflation/src/lib.rs
@@ -6,6 +6,7 @@ use serde_derive::{Deserialize, Serialize};
 
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(PartialEq, Clone, Debug, Copy)]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Inflation {

--- a/rent/Cargo.toml
+++ b/rent/Cargo.toml
@@ -16,6 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 serde = ["dep:serde", "dep:serde_derive"]
 sysvar = ["dep:solana-sdk-ids", "dep:solana-sysvar-id"]
+wincode = ["dep:wincode"]
 
 [dependencies]
 serde = { workspace = true, optional = true }
@@ -25,6 +26,7 @@ solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-sdk-ids = { workspace = true, optional = true }
 solana-sdk-macro = { workspace = true }
 solana-sysvar-id = { workspace = true, optional = true }
+wincode = { workspace = true, optional = true }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/rent/src/lib.rs
+++ b/rent/src/lib.rs
@@ -21,6 +21,7 @@ use solana_sdk_macro::CloneZeroed;
     feature = "serde",
     derive(serde_derive::Deserialize, serde_derive::Serialize)
 )]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(PartialEq, CloneZeroed, Debug)]
 pub struct Rent {
     /// Rental rate in lamports/byte.


### PR DESCRIPTION
Adds wincode feature and `SchemaRead` / `SchemaWrite` derives to:
* epoch-schedule
* hard-forks
* inflation
* rent

All of them expose just one type.