### PR TITLE
loader-v3-interface: un-deprecate deploy_with_max_program_len

### DIFF
--- a/loader-v3-interface/src/instruction.rs
+++ b/loader-v3-interface/src/instruction.rs
@@ -247,7 +247,6 @@ pub fn write(
     )
 }
 
-#[deprecated(since = "2.2.0", note = "Use loader-v4 instead")]
 #[cfg(feature = "bincode")]
 /// Returns the instructions required to deploy a program with a specified
 /// maximum program length.  The maximum length must be large enough to


### PR DESCRIPTION
#### Problem
As per [RFC-0423](https://github.com/solana-foundation/solana-improvement-documents/discussions/423), Loader V4 will be redesigned and reintroduced as an on-chain program. The builtin implementation should be removed.

#### Summary of Changes
Un-deprecate `deploy_with_max_program_len` in the Loader V3 interface.