### PR TITLE
fix: Add sha2 feature where needed

### DIFF
--- a/genesis-config/Cargo.toml
+++ b/genesis-config/Cargo.toml
@@ -49,7 +49,7 @@ solana-poh-config = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
-solana-sha256-hasher = { workspace = true }
+solana-sha256-hasher = { workspace = true, features = ["sha2"] }
 solana-shred-version = { workspace = true }
 solana-signer = { workspace = true }
 solana-time-utils = { workspace = true }

--- a/nonce/Cargo.toml
+++ b/nonce/Cargo.toml
@@ -42,5 +42,6 @@ wincode = { workspace = true, optional = true, features = ["alloc"] }
 
 [dev-dependencies]
 bincode = { workspace = true }
+solana-sha256-hasher = { workspace = true, features = ["sha2"] }
 solana-nonce = { path = ".", features = ["dev-context-only-utils", "wincode"] }
 solana-pubkey = { workspace = true, features = ["std"], default-features = false }

--- a/nonce/Cargo.toml
+++ b/nonce/Cargo.toml
@@ -42,6 +42,6 @@ wincode = { workspace = true, optional = true, features = ["alloc"] }
 
 [dev-dependencies]
 bincode = { workspace = true }
-solana-sha256-hasher = { workspace = true, features = ["sha2"] }
 solana-nonce = { path = ".", features = ["dev-context-only-utils", "wincode"] }
 solana-pubkey = { workspace = true, features = ["std"], default-features = false }
+solana-sha256-hasher = { workspace = true, features = ["sha2"] }

--- a/shred-version/Cargo.toml
+++ b/shred-version/Cargo.toml
@@ -15,9 +15,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 solana-hard-forks = { workspace = true }
 solana-hash = { workspace = true }
-solana-sha256-hasher = { workspace = true }
-
-[dev-dependencies]
 solana-sha256-hasher = { workspace = true, features = ["sha2"] }
 
 [lints]

--- a/slot-hashes/Cargo.toml
+++ b/slot-hashes/Cargo.toml
@@ -24,4 +24,4 @@ solana-sdk-ids = { workspace = true, optional = true }
 solana-sysvar-id = { workspace = true, optional = true }
 
 [dev-dependencies]
-solana-sha256-hasher = { workspace = true }
+solana-sha256-hasher = { workspace = true, features = ["sha2"] }

--- a/sysvar/Cargo.toml
+++ b/sysvar/Cargo.toml
@@ -73,7 +73,7 @@ serial_test = { workspace = true }
 solana-example-mocks = { path = "../example-mocks" }
 solana-hash = { workspace = true, features = ["atomic", "bytemuck"] }
 solana-msg = { workspace = true, features = ["std"] }
-solana-sha256-hasher = { workspace = true }
+solana-sha256-hasher = { workspace = true, features = ["sha2"] }
 solana-sysvar = { path = ".", features = ["dev-context-only-utils"] }
 test-case = { workspace = true }
 


### PR DESCRIPTION
This PR adds the sha2 feature to some crates for which it was not previously enabled.