### PR TITLE
sha512 syscall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3800,6 +3800,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-hash-512"
+version = "0.0.0"
+dependencies = [
+ "borsh",
+ "bs58",
+ "bytemuck",
+ "bytemuck_derive",
+ "five8",
+ "serde",
+ "serde-big-array",
+ "serde_derive",
+ "solana-atomic-u64",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-hash",
+ "solana-hash-512",
+ "wincode",
+]
+
+[[package]]
 name = "solana-inflation"
 version = "3.1.0"
 dependencies = [
@@ -4463,6 +4483,16 @@ dependencies = [
  "solana-define-syscall",
  "solana-hash",
  "solana-sha256-hasher",
+]
+
+[[package]]
+name = "solana-sha512-hasher"
+version = "0.0.0"
+dependencies = [
+ "sha2",
+ "solana-define-syscall",
+ "solana-hash-512",
+ "solana-sha512-hasher",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "genesis-config",
     "hard-forks",
     "hash",
+    "hash-512",
     "inflation",
     "instruction",
     "instruction-error",
@@ -86,6 +87,7 @@ members = [
     "serde-varint",
     "serialize-utils",
     "sha256-hasher",
+    "sha512-hasher",
     "short-vec",
     "shred-version",
     "signature",
@@ -261,6 +263,7 @@ solana-frozen-abi-macro = { path = "frozen-abi-macro", version = "3.0.1" }
 solana-genesis-config = { path = "genesis-config", version = "4.0.0" }
 solana-hard-forks = { path = "hard-forks", version = "3.1.0", default-features = false }
 solana-hash = { path = "hash", version = "4.3.0", default-features = false }
+solana-hash-512 = { path = "hash-512", version = "0.0.0", default-features = false }
 solana-inflation = { path = "inflation", version = "3.1.0" }
 solana-instruction = { path = "instruction", version = "3.4.0", default-features = false }
 solana-instruction-error = { path = "instruction-error", version = "2.3.0" }
@@ -310,6 +313,7 @@ solana-serde = { path = "serde", version = "3.0.0" }
 solana-serde-varint = { path = "serde-varint", version = "3.0.1" }
 solana-serialize-utils = { path = "serialize-utils", version = "3.1.0" }
 solana-sha256-hasher = { path = "sha256-hasher", version = "3.0.0" }
+solana-sha512-hasher = { path = "sha512-hasher", version = "0.0.0" }
 solana-short-vec = { path = "short-vec", version = "3.2.0", default-features = false }
 solana-shred-version = { path = "shred-version", version = "3.0.0" }
 solana-signature = { path = "signature", version = "3.4.0", default-features = false }

--- a/define-syscall/src/definitions.rs
+++ b/define-syscall/src/definitions.rs
@@ -21,6 +21,7 @@ define_syscall!(fn sol_try_find_program_address(seeds_addr: *const u8, seeds_len
 define_syscall!(fn sol_sha256(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
 define_syscall!(fn sol_keccak256(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
 define_syscall!(fn sol_blake3(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
+define_syscall!(fn sol_sha512(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
 define_syscall!(fn sol_curve_validate_point(curve_id: u64, point_addr: *const u8, result: *mut u8) -> u64);
 define_syscall!(fn sol_curve_group_op(curve_id: u64, group_op: u64, left_input_addr: *const u8, right_input_addr: *const u8, result_point_addr: *mut u8) -> u64);
 define_syscall!(fn sol_curve_multiscalar_mul(curve_id: u64, scalars_addr: *const u8, points_addr: *const u8, points_len: u64, result_point_addr: *mut u8) -> u64);

--- a/hash-512/Cargo.toml
+++ b/hash-512/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+name = "solana-hash-512"
+description = "Solana wrapper for the 64-byte output of the SHA-512 hashing algorithm."
+documentation = "https://docs.rs/solana-hash-512"
+version = "0.0.0"
+rust-version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+atomic = ["dep:solana-atomic-u64"]
+borsh = ["dep:borsh"]
+bytemuck = ["copy", "dep:bytemuck", "dep:bytemuck_derive"]
+copy = []
+decode = ["dep:five8", "solana-hash/decode"]
+default = []
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "std"]
+serde = ["dep:serde", "dep:serde_derive", "dep:serde-big-array"]
+std = ["borsh?/std", "serde?/std", "wincode?/std"]
+wincode = ["dep:wincode"]
+
+[dependencies]
+borsh = { workspace = true, optional = true }
+bytemuck = { workspace = true, optional = true }
+bytemuck_derive = { workspace = true, optional = true }
+five8 = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+serde-big-array = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
+solana-atomic-u64 = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
+solana-frozen-abi-macro = { workspace = true, optional = true, features = ["frozen-abi"] }
+solana-hash = { workspace = true, optional = true }
+wincode = { workspace = true, optional = true }
+
+[dev-dependencies]
+bs58 = { workspace = true, default-features = false, features = ["alloc"] }
+solana-hash-512 = { path = ".", features = ["atomic", "copy", "decode"] }
+
+[lints]
+workspace = true

--- a/hash-512/src/lib.rs
+++ b/hash-512/src/lib.rs
@@ -1,0 +1,190 @@
+#![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
+#[cfg(feature = "borsh")]
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+#[cfg(feature = "std")]
+extern crate std;
+#[cfg(feature = "bytemuck")]
+use bytemuck_derive::{Pod, Zeroable};
+#[cfg(feature = "decode")]
+use core::{
+    fmt,
+    str::{from_utf8_unchecked, FromStr},
+};
+#[cfg(feature = "serde")]
+use {
+    serde_big_array::BigArray,
+    serde_derive::{Deserialize, Serialize},
+};
+#[cfg(feature = "borsh")]
+extern crate alloc;
+#[cfg(feature = "borsh")]
+use alloc::string::ToString;
+#[cfg(feature = "decode")]
+pub use solana_hash::ParseHashError;
+#[cfg(feature = "wincode")]
+use wincode::{SchemaRead, SchemaWrite};
+
+/// Size of a hash in bytes.
+pub const HASH_BYTES: usize = 64;
+/// Maximum string length of a base58 encoded 64-byte hash.
+pub const MAX_BASE58_LEN: usize = 88;
+
+/// A hash; the 64-byte output of the SHA-512 hashing algorithm.
+#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
+#[cfg_attr(
+    feature = "borsh",
+    derive(BorshSerialize, BorshDeserialize),
+    borsh(crate = "borsh")
+)]
+#[cfg_attr(feature = "borsh", derive(BorshSchema))]
+#[cfg_attr(feature = "bytemuck", derive(Pod, Zeroable))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "wincode", derive(SchemaWrite, SchemaRead))]
+#[cfg_attr(feature = "copy", derive(Copy))]
+#[cfg_attr(not(feature = "decode"), derive(Debug))]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[repr(transparent)]
+pub struct Hash512(
+    #[cfg_attr(feature = "serde", serde(with = "BigArray"))] pub(crate) [u8; HASH_BYTES],
+);
+
+impl Default for Hash512 {
+    fn default() -> Self {
+        Self([0u8; HASH_BYTES])
+    }
+}
+
+impl From<[u8; HASH_BYTES]> for Hash512 {
+    fn from(from: [u8; HASH_BYTES]) -> Self {
+        Self(from)
+    }
+}
+
+impl AsRef<[u8]> for Hash512 {
+    fn as_ref(&self) -> &[u8] {
+        &self.0[..]
+    }
+}
+
+#[cfg(feature = "decode")]
+fn write_as_base58(f: &mut fmt::Formatter, h: &Hash512) -> fmt::Result {
+    let mut out = [0u8; MAX_BASE58_LEN];
+    let len = five8::encode_64(&h.0, &mut out) as usize;
+    // any sequence of base58 chars is valid utf8
+    let as_str = unsafe { from_utf8_unchecked(&out[..len]) };
+    f.write_str(as_str)
+}
+
+#[cfg(feature = "decode")]
+impl fmt::Debug for Hash512 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write_as_base58(f, self)
+    }
+}
+
+#[cfg(feature = "decode")]
+impl fmt::Display for Hash512 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write_as_base58(f, self)
+    }
+}
+
+#[cfg(feature = "decode")]
+impl FromStr for Hash512 {
+    type Err = ParseHashError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        use five8::DecodeError;
+        if s.len() > MAX_BASE58_LEN {
+            return Err(ParseHashError::WrongSize);
+        }
+        let mut bytes = [0; HASH_BYTES];
+        five8::decode_64(s, &mut bytes).map_err(|e| match e {
+            DecodeError::InvalidChar(_) => ParseHashError::Invalid,
+            DecodeError::TooLong
+            | DecodeError::TooShort
+            | DecodeError::LargestTermTooHigh
+            | DecodeError::OutputTooLong => ParseHashError::WrongSize,
+        })?;
+        Ok(Self::from(bytes))
+    }
+}
+
+impl Hash512 {
+    pub const fn new_from_array(hash_array: [u8; HASH_BYTES]) -> Self {
+        Self(hash_array)
+    }
+
+    /// unique Hash512 for tests and benchmarks.
+    #[cfg(feature = "atomic")]
+    pub fn new_unique() -> Self {
+        use solana_atomic_u64::AtomicU64;
+        static I: AtomicU64 = AtomicU64::new(1);
+
+        let mut b = [0u8; HASH_BYTES];
+        let i = I.fetch_add(1);
+        b[0..8].copy_from_slice(&i.to_le_bytes());
+        Self::new_from_array(b)
+    }
+
+    pub const fn to_bytes(&self) -> [u8; HASH_BYTES] {
+        self.0
+    }
+
+    pub const fn as_bytes(&self) -> &[u8; HASH_BYTES] {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_unique() {
+        assert_ne!(Hash512::new_unique(), Hash512::new_unique());
+    }
+
+    #[test]
+    fn test_hash512_fromstr() {
+        let hash = Hash512::new_from_array([1; HASH_BYTES]);
+
+        let mut hash_base58_str = bs58::encode(hash).into_string();
+
+        assert_eq!(hash_base58_str.parse::<Hash512>(), Ok(hash));
+
+        hash_base58_str.push_str(&bs58::encode(hash.as_ref()).into_string());
+        assert_eq!(
+            hash_base58_str.parse::<Hash512>(),
+            Err(ParseHashError::WrongSize)
+        );
+
+        hash_base58_str.truncate(hash_base58_str.len() / 2);
+        assert_eq!(hash_base58_str.parse::<Hash512>(), Ok(hash));
+
+        hash_base58_str.truncate(hash_base58_str.len() / 2);
+        assert_eq!(
+            hash_base58_str.parse::<Hash512>(),
+            Err(ParseHashError::WrongSize)
+        );
+
+        let input_too_big = bs58::encode(&[0xffu8; HASH_BYTES + 1]).into_string();
+        assert!(input_too_big.len() > MAX_BASE58_LEN);
+        assert_eq!(
+            input_too_big.parse::<Hash512>(),
+            Err(ParseHashError::WrongSize)
+        );
+
+        let mut hash_base58_str = bs58::encode(hash.as_ref()).into_string();
+        assert_eq!(hash_base58_str.parse::<Hash512>(), Ok(hash));
+
+        // throw some non-base58 stuff in there
+        hash_base58_str.replace_range(..1, "I");
+        assert_eq!(
+            hash_base58_str.parse::<Hash512>(),
+            Err(ParseHashError::Invalid)
+        );
+    }
+}

--- a/scripts/patch-crates-functions.sh
+++ b/scripts/patch-crates-functions.sh
@@ -41,6 +41,7 @@ all_crate_dirs=(
   genesis-config
   hard-forks
   hash
+  hash-512
   inflation
   instruction
   instructions-sysvar
@@ -85,6 +86,7 @@ all_crate_dirs=(
   serde-varint
   serialize-utils
   sha256-hasher
+  sha512-hasher
   short-vec
   shred-version
   signature

--- a/sha512-hasher/Cargo.toml
+++ b/sha512-hasher/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "solana-sha512-hasher"
+description = "Solana SHA512 hashing"
+documentation = "https://docs.rs/solana-sha512-hasher"
+version = "0.0.0"
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[features]
+sha2 = ["dep:sha2"]
+
+[dependencies]
+solana-hash-512 = { workspace = true }
+
+[target.'cfg(any(target_os = "solana", target_arch = "bpf"))'.dependencies]
+solana-define-syscall = { workspace = true }
+
+[target.'cfg(not(any(target_os = "solana", target_arch = "bpf")))'.dependencies]
+sha2 = { workspace = true, optional = true }
+
+[dev-dependencies]
+solana-sha512-hasher = { path = ".", features = ["sha2"] }
+
+[lints]
+workspace = true

--- a/sha512-hasher/src/lib.rs
+++ b/sha512-hasher/src/lib.rs
@@ -1,0 +1,81 @@
+#![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+#[cfg(any(target_os = "solana", target_arch = "bpf"))]
+pub use solana_define_syscall::definitions::sol_sha512;
+use solana_hash_512::Hash512;
+#[cfg(any(target_os = "solana", target_arch = "bpf"))]
+use {core::mem::MaybeUninit, solana_hash_512::HASH_BYTES};
+#[cfg(all(feature = "sha2", not(any(target_os = "solana", target_arch = "bpf"))))]
+use {
+    sha2::{Digest, Sha512},
+    solana_hash_512::HASH_BYTES,
+};
+
+#[cfg(all(feature = "sha2", not(any(target_os = "solana", target_arch = "bpf"))))]
+#[derive(Clone, Default)]
+pub struct Hasher {
+    hasher: Sha512,
+}
+
+#[cfg(all(feature = "sha2", not(any(target_os = "solana", target_arch = "bpf"))))]
+impl Hasher {
+    #[inline(always)]
+    pub fn hash(&mut self, val: &[u8]) {
+        self.hasher.update(val);
+    }
+
+    #[inline(always)]
+    pub fn hashv(&mut self, vals: &[&[u8]]) {
+        for val in vals {
+            self.hash(val);
+        }
+    }
+
+    #[inline(always)]
+    pub fn result(self) -> Hash512 {
+        let bytes: [u8; HASH_BYTES] = self.hasher.finalize().into();
+        bytes.into()
+    }
+}
+
+/// Return a Sha512 hash for the given data.
+#[cfg_attr(target_os = "solana", inline(always))]
+pub fn hashv(vals: &[&[u8]]) -> Hash512 {
+    // Perform the calculation inline, calling this from within a program is
+    // not supported
+    #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
+    {
+        #[cfg(feature = "sha2")]
+        {
+            let mut hasher = Hasher::default();
+            hasher.hashv(vals);
+            hasher.result()
+        }
+        #[cfg(not(feature = "sha2"))]
+        {
+            core::hint::black_box(vals);
+            panic!("hashv is only available on target `solana` or with the `sha2` feature enabled on this crate")
+        }
+    }
+    // Call via a system call to perform the calculation
+    #[cfg(any(target_os = "solana", target_arch = "bpf"))]
+    {
+        let mut hash_result = MaybeUninit::<[u8; HASH_BYTES]>::uninit();
+        // SAFETY: This is sound as sol_sha512 always fills all 64 bytes of our hash
+        unsafe {
+            sol_sha512(
+                vals as *const _ as *const u8,
+                vals.len() as u64,
+                hash_result.as_mut_ptr() as *mut u8,
+            );
+            Hash512::new_from_array(hash_result.assume_init())
+        }
+    }
+}
+
+/// Return a Sha512 hash for the given data.
+#[cfg_attr(target_os = "solana", inline(always))]
+pub fn hash(val: &[u8]) -> Hash512 {
+    hashv(&[val])
+}


### PR DESCRIPTION
This PR lays the groundwork for the implementation of the upcoming [SHA512 syscall](https://github.com/solana-foundation/solana-improvement-documents/pull/512). It introduces two new crates to the solana-sdk repo:

1. `solana-hash-512` - a 64-byte variant of `solana-hash` that duplicates all existing functionality, but references 64-byte specific functions in serialization methods such as `five8`, and with a max base58 string length of 88 instead of 44. It shares the existing `HashError` enum type with `solana-hash` so as to not create a new error enum just for this use case, as the enum variants and corresponding error messages are identical.
2. `solana-sha512-hasher` - a duplicate of the existing `solana-sha256-hasher` API, but for SHA512. Returns a `Hash512` instead of a `Hash`.

Along with these changes, we also introduce the `sol_sha512` syscall in `define-syscalls`, as well as handling the hasher reexport and all necessary APIs for use with `register_feature_gated_function` in Agave.