### PR TITLE
account: remove PROGRAM_OWNERS

### DIFF
--- a/account/src/lib.rs
+++ b/account/src/lib.rs
@@ -15,7 +15,6 @@ use {
     solana_clock::{Epoch, INITIAL_RENT_EPOCH},
     solana_instruction_error::LamportsError,
     solana_pubkey::Pubkey,
-    solana_sdk_ids::{bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, loader_v4},
     std::{cell::RefCell, fmt, mem::MaybeUninit, ops::Deref, ptr, rc::Rc, sync::Arc},
 };
 #[cfg(feature = "bincode")]
@@ -691,15 +690,6 @@ pub fn create_is_signer_account_infos<'a>(
         })
         .collect()
 }
-
-/// Replacement for the executable flag: An account being owned by one of these contains a program.
-#[deprecated(since = "4.3.0", note = "no longer available as a constant")]
-pub const PROGRAM_OWNERS: &[Pubkey] = &[
-    bpf_loader_upgradeable::id(),
-    bpf_loader::id(),
-    bpf_loader_deprecated::id(),
-    loader_v4::id(),
-];
 
 #[cfg(test)]
 pub mod tests {


### PR DESCRIPTION
#### Problem
This constant is sketchy, since it has consensus implications and one of the programs previously contained in it will be removed. It's also only used in two places in the same crate in Agave, so it can just be inlined.

#### Summary of Changes
Remove `PROGRAM_OWNERS`.