### PR TITLE
loader-v3-interface: convert to wincode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3944,6 +3944,7 @@ dependencies = [
 name = "solana-loader-v3-interface"
 version = "7.0.0"
 dependencies = [
+ "bincode",
  "serde",
  "serde_bytes",
  "serde_derive",
@@ -3954,6 +3955,7 @@ dependencies = [
  "solana-pubkey",
  "solana-sdk-ids",
  "solana-system-interface",
+ "test-case",
  "wincode",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3944,7 +3944,6 @@ dependencies = [
 name = "solana-loader-v3-interface"
 version = "7.0.0"
 dependencies = [
- "bincode",
  "serde",
  "serde_bytes",
  "serde_derive",
@@ -3955,6 +3954,7 @@ dependencies = [
  "solana-pubkey",
  "solana-sdk-ids",
  "solana-system-interface",
+ "wincode",
 ]
 
 [[package]]

--- a/loader-v3-interface/Cargo.toml
+++ b/loader-v3-interface/Cargo.toml
@@ -40,7 +40,9 @@ solana-system-interface = { workspace = true, optional = true }
 wincode = { workspace = true, optional = true }
 
 [dev-dependencies]
-solana-loader-v3-interface = { path = ".", features = ["dev-context-only-utils"] }
+bincode = { workspace = true }
+solana-loader-v3-interface = { path = ".", features = ["dev-context-only-utils", "serde"] }
+test-case = { workspace = true }
 
 [lints]
 workspace = true

--- a/loader-v3-interface/Cargo.toml
+++ b/loader-v3-interface/Cargo.toml
@@ -15,10 +15,17 @@ all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
 [features]
-bincode = ["dep:solana-system-interface", "serde", "solana-instruction/bincode"]
-dev-context-only-utils = ["bincode"]
+dev-context-only-utils = ["wincode"]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "serde"]
 serde = ["dep:serde", "dep:serde_bytes", "dep:serde_derive", "solana-pubkey/serde"]
+wincode = [
+    "dep:solana-system-interface",
+    "dep:wincode",
+    "solana-instruction/wincode",
+    "solana-pubkey/wincode",
+    "solana-system-interface/wincode",
+    "wincode/alloc",
+]
 
 [dependencies]
 serde = { workspace = true, optional = true }
@@ -29,10 +36,10 @@ solana-frozen-abi-macro = { workspace = true, features = ["frozen-abi"], optiona
 solana-instruction = { workspace = true, features = ["std"] }
 solana-pubkey = { workspace = true, features = ["curve25519"] }
 solana-sdk-ids = { workspace = true }
-solana-system-interface = { workspace = true, features = ["bincode"], optional = true }
+solana-system-interface = { workspace = true, optional = true }
+wincode = { workspace = true, optional = true }
 
 [dev-dependencies]
-bincode = { workspace = true }
 solana-loader-v3-interface = { path = ".", features = ["dev-context-only-utils"] }
 
 [lints]

--- a/loader-v3-interface/src/instruction.rs
+++ b/loader-v3-interface/src/instruction.rs
@@ -1,12 +1,13 @@
 //! Instructions for the upgradable BPF loader.
 
-#[cfg(feature = "bincode")]
+#[cfg(feature = "wincode")]
 use {
     crate::{get_program_data_address, state::UpgradeableLoaderState},
     solana_instruction::{error::InstructionError, AccountMeta, Instruction},
     solana_pubkey::Pubkey,
     solana_sdk_ids::{bpf_loader_upgradeable::id, sysvar},
     solana_system_interface::instruction as system_instruction,
+    wincode::{SchemaRead, SchemaWrite},
 };
 
 /// Minimum number of bytes for an `ExtendProgram` instruction.
@@ -22,6 +23,7 @@ pub const MINIMUM_EXTEND_PROGRAM_BYTES: u32 = 10_240;
     feature = "serde",
     derive(serde_derive::Deserialize, serde_derive::Serialize)
 )]
+#[cfg_attr(feature = "wincode", derive(SchemaRead, SchemaWrite))]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum UpgradeableLoaderInstruction {
     /// Initialize a Buffer account.
@@ -187,7 +189,7 @@ pub enum UpgradeableLoaderInstruction {
     SetAuthorityChecked,
 }
 
-#[cfg(feature = "bincode")]
+#[cfg(feature = "wincode")]
 /// Returns the instructions required to initialize a Buffer account.
 pub fn create_buffer(
     payer_address: &Pubkey,
@@ -204,7 +206,7 @@ pub fn create_buffer(
             UpgradeableLoaderState::size_of_buffer(program_len) as u64,
             &id(),
         ),
-        Instruction::new_with_bincode(
+        Instruction::new_with_wincode(
             id(),
             &UpgradeableLoaderInstruction::InitializeBuffer,
             vec![
@@ -215,7 +217,7 @@ pub fn create_buffer(
     ])
 }
 
-#[cfg(feature = "bincode")]
+#[cfg(feature = "wincode")]
 /// Returns the instructions required to write a chunk of program data to a
 /// buffer account.
 pub fn write(
@@ -224,7 +226,7 @@ pub fn write(
     offset: u32,
     bytes: Vec<u8>,
 ) -> Instruction {
-    Instruction::new_with_bincode(
+    Instruction::new_with_wincode(
         id(),
         &UpgradeableLoaderInstruction::Write { offset, bytes },
         vec![
@@ -234,7 +236,7 @@ pub fn write(
     )
 }
 
-#[cfg(feature = "bincode")]
+#[cfg(feature = "wincode")]
 /// Returns the instructions required to deploy a program with a specified
 /// maximum program length.  The maximum length must be large enough to
 /// accommodate any future upgrades.
@@ -255,7 +257,7 @@ pub fn deploy_with_max_program_len(
             UpgradeableLoaderState::size_of_program() as u64,
             &id(),
         ),
-        Instruction::new_with_bincode(
+        Instruction::new_with_wincode(
             id(),
             &UpgradeableLoaderInstruction::DeployWithMaxDataLen { max_data_len },
             vec![
@@ -272,7 +274,7 @@ pub fn deploy_with_max_program_len(
     ])
 }
 
-#[cfg(feature = "bincode")]
+#[cfg(feature = "wincode")]
 /// Returns the instructions required to upgrade a program.
 pub fn upgrade(
     program_address: &Pubkey,
@@ -281,7 +283,7 @@ pub fn upgrade(
     spill_address: &Pubkey,
 ) -> Instruction {
     let programdata_address = get_program_data_address(program_address);
-    Instruction::new_with_bincode(
+    Instruction::new_with_wincode(
         id(),
         &UpgradeableLoaderInstruction::Upgrade,
         vec![
@@ -312,14 +314,14 @@ pub fn is_set_authority_checked_instruction(instruction_data: &[u8]) -> bool {
     !instruction_data.is_empty() && 7 == instruction_data[0]
 }
 
-#[cfg(feature = "bincode")]
+#[cfg(feature = "wincode")]
 /// Returns the instructions required to set a buffers's authority.
 pub fn set_buffer_authority(
     buffer_address: &Pubkey,
     current_authority_address: &Pubkey,
     new_authority_address: &Pubkey,
 ) -> Instruction {
-    Instruction::new_with_bincode(
+    Instruction::new_with_wincode(
         id(),
         &UpgradeableLoaderInstruction::SetAuthority,
         vec![
@@ -330,7 +332,7 @@ pub fn set_buffer_authority(
     )
 }
 
-#[cfg(feature = "bincode")]
+#[cfg(feature = "wincode")]
 /// Returns the instructions required to set a buffers's authority. If using this instruction, the new authority
 /// must sign.
 pub fn set_buffer_authority_checked(
@@ -338,7 +340,7 @@ pub fn set_buffer_authority_checked(
     current_authority_address: &Pubkey,
     new_authority_address: &Pubkey,
 ) -> Instruction {
-    Instruction::new_with_bincode(
+    Instruction::new_with_wincode(
         id(),
         &UpgradeableLoaderInstruction::SetAuthorityChecked,
         vec![
@@ -349,7 +351,7 @@ pub fn set_buffer_authority_checked(
     )
 }
 
-#[cfg(feature = "bincode")]
+#[cfg(feature = "wincode")]
 /// Returns the instructions required to set a program's authority.
 pub fn set_upgrade_authority(
     program_address: &Pubkey,
@@ -365,10 +367,10 @@ pub fn set_upgrade_authority(
     if let Some(address) = new_authority_address {
         metas.push(AccountMeta::new_readonly(*address, false));
     }
-    Instruction::new_with_bincode(id(), &UpgradeableLoaderInstruction::SetAuthority, metas)
+    Instruction::new_with_wincode(id(), &UpgradeableLoaderInstruction::SetAuthority, metas)
 }
 
-#[cfg(feature = "bincode")]
+#[cfg(feature = "wincode")]
 /// Returns the instructions required to set a program's authority. If using this instruction, the new authority
 /// must sign.
 pub fn set_upgrade_authority_checked(
@@ -383,14 +385,14 @@ pub fn set_upgrade_authority_checked(
         AccountMeta::new_readonly(*current_authority_address, true),
         AccountMeta::new_readonly(*new_authority_address, true),
     ];
-    Instruction::new_with_bincode(
+    Instruction::new_with_wincode(
         id(),
         &UpgradeableLoaderInstruction::SetAuthorityChecked,
         metas,
     )
 }
 
-#[cfg(feature = "bincode")]
+#[cfg(feature = "wincode")]
 /// Returns the instructions required to close a buffer account
 pub fn close(
     close_address: &Pubkey,
@@ -405,7 +407,7 @@ pub fn close(
     )
 }
 
-#[cfg(feature = "bincode")]
+#[cfg(feature = "wincode")]
 /// Returns the instructions required to close program, buffer, or uninitialized account
 pub fn close_any(
     close_address: &Pubkey,
@@ -423,10 +425,10 @@ pub fn close_any(
     if let Some(program_address) = program_address {
         metas.push(AccountMeta::new(*program_address, false));
     }
-    Instruction::new_with_bincode(id(), &UpgradeableLoaderInstruction::Close, metas)
+    Instruction::new_with_wincode(id(), &UpgradeableLoaderInstruction::Close, metas)
 }
 
-#[cfg(feature = "bincode")]
+#[cfg(feature = "wincode")]
 /// Returns the instruction required to extend the size of a program's
 /// executable data account.
 ///
@@ -450,14 +452,14 @@ pub fn extend_program(
         ));
         metas.push(AccountMeta::new(*payer_address, true));
     }
-    Instruction::new_with_bincode(
+    Instruction::new_with_wincode(
         id(),
         &UpgradeableLoaderInstruction::ExtendProgram { additional_bytes },
         metas,
     )
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "wincode"))]
 mod tests {
     use super::*;
 
@@ -468,7 +470,7 @@ mod tests {
         F: Fn(&[u8]) -> bool,
     {
         let result = is_instruction_fn(
-            &bincode::serialize(&UpgradeableLoaderInstruction::InitializeBuffer).unwrap(),
+            &wincode::serialize(&UpgradeableLoaderInstruction::InitializeBuffer).unwrap(),
         );
         let expected_result = matches!(
             expected_instruction,
@@ -477,7 +479,7 @@ mod tests {
         assert_eq!(expected_result, result);
 
         let result = is_instruction_fn(
-            &bincode::serialize(&UpgradeableLoaderInstruction::Write {
+            &wincode::serialize(&UpgradeableLoaderInstruction::Write {
                 offset: 0,
                 bytes: vec![],
             })
@@ -493,7 +495,7 @@ mod tests {
         assert_eq!(expected_result, result);
 
         let result = is_instruction_fn(
-            &bincode::serialize(&UpgradeableLoaderInstruction::DeployWithMaxDataLen {
+            &wincode::serialize(&UpgradeableLoaderInstruction::DeployWithMaxDataLen {
                 max_data_len: 0,
             })
             .unwrap(),
@@ -505,12 +507,12 @@ mod tests {
         assert_eq!(expected_result, result);
 
         let result =
-            is_instruction_fn(&bincode::serialize(&UpgradeableLoaderInstruction::Upgrade).unwrap());
+            is_instruction_fn(&wincode::serialize(&UpgradeableLoaderInstruction::Upgrade).unwrap());
         let expected_result = matches!(expected_instruction, UpgradeableLoaderInstruction::Upgrade);
         assert_eq!(expected_result, result);
 
         let result = is_instruction_fn(
-            &bincode::serialize(&UpgradeableLoaderInstruction::SetAuthority).unwrap(),
+            &wincode::serialize(&UpgradeableLoaderInstruction::SetAuthority).unwrap(),
         );
         let expected_result = matches!(
             expected_instruction,
@@ -519,7 +521,7 @@ mod tests {
         assert_eq!(expected_result, result);
 
         let result =
-            is_instruction_fn(&bincode::serialize(&UpgradeableLoaderInstruction::Close).unwrap());
+            is_instruction_fn(&wincode::serialize(&UpgradeableLoaderInstruction::Close).unwrap());
         let expected_result = matches!(expected_instruction, UpgradeableLoaderInstruction::Close);
         assert_eq!(expected_result, result);
     }

--- a/loader-v3-interface/src/instruction.rs
+++ b/loader-v3-interface/src/instruction.rs
@@ -461,7 +461,7 @@ pub fn extend_program(
 
 #[cfg(all(test, feature = "wincode"))]
 mod tests {
-    use super::*;
+    use {super::*, test_case::test_case};
 
     fn assert_is_instruction<F>(
         is_instruction_fn: F,
@@ -551,5 +551,31 @@ mod tests {
             is_upgrade_instruction,
             UpgradeableLoaderInstruction::Upgrade {},
         );
+    }
+
+    /// Verify that wincode produces the exact same bytes as bincode for
+    /// every instruction variant, and that both round-trip correctly.
+    #[test_case(UpgradeableLoaderInstruction::InitializeBuffer)]
+    #[test_case(UpgradeableLoaderInstruction::Write { offset: 42, bytes: vec![1, 2, 3, 4, 5] })]
+    #[test_case(UpgradeableLoaderInstruction::Write { offset: 0, bytes: vec![] })]
+    #[test_case(UpgradeableLoaderInstruction::DeployWithMaxDataLen { max_data_len: 1_000_000 })]
+    #[test_case(UpgradeableLoaderInstruction::DeployWithMaxDataLen { max_data_len: 0 })]
+    #[test_case(UpgradeableLoaderInstruction::Upgrade)]
+    #[test_case(UpgradeableLoaderInstruction::SetAuthority)]
+    #[test_case(UpgradeableLoaderInstruction::Close)]
+    #[test_case(UpgradeableLoaderInstruction::ExtendProgram { additional_bytes: 10_240 })]
+    #[test_case(UpgradeableLoaderInstruction::ExtendProgram { additional_bytes: 0 })]
+    #[test_case(UpgradeableLoaderInstruction::SetAuthorityChecked)]
+    fn wire_compat_bincode_vs_wincode(instr: UpgradeableLoaderInstruction) {
+        let bincode_bytes = bincode::serialize(&instr).unwrap();
+        let wincode_bytes = wincode::serialize(&instr).unwrap();
+        assert_eq!(bincode_bytes, wincode_bytes);
+
+        let from_bincode: UpgradeableLoaderInstruction =
+            bincode::deserialize(&bincode_bytes).unwrap();
+        let from_wincode: UpgradeableLoaderInstruction =
+            wincode::deserialize(&wincode_bytes).unwrap();
+        assert_eq!(from_bincode, instr);
+        assert_eq!(from_wincode, instr);
     }
 }

--- a/loader-v3-interface/src/state.rs
+++ b/loader-v3-interface/src/state.rs
@@ -69,7 +69,7 @@ impl UpgradeableLoaderState {
 
 #[cfg(all(test, feature = "wincode"))]
 mod tests {
-    use super::*;
+    use {super::*, test_case::test_case};
 
     #[test]
     fn test_state_size_of_uninitialized() {
@@ -110,5 +110,24 @@ mod tests {
         };
         let size = wincode::serialized_size(&state).unwrap();
         assert_eq!(UpgradeableLoaderState::size_of_program() as u64, size);
+    }
+
+    /// Verify that wincode produces the exact same bytes as bincode for
+    /// every state variant, and that both round-trip correctly.
+    #[test_case(UpgradeableLoaderState::Uninitialized)]
+    #[test_case(UpgradeableLoaderState::Buffer { authority_address: Some(Pubkey::default()) })]
+    #[test_case(UpgradeableLoaderState::Buffer { authority_address: None })]
+    #[test_case(UpgradeableLoaderState::Program { programdata_address: Pubkey::default() })]
+    #[test_case(UpgradeableLoaderState::ProgramData { slot: 123_456_789, upgrade_authority_address: Some(Pubkey::default()) })]
+    #[test_case(UpgradeableLoaderState::ProgramData { slot: 0, upgrade_authority_address: None })]
+    fn wire_compat_bincode_vs_wincode(state: UpgradeableLoaderState) {
+        let bincode_bytes = bincode::serialize(&state).unwrap();
+        let wincode_bytes = wincode::serialize(&state).unwrap();
+        assert_eq!(bincode_bytes, wincode_bytes);
+
+        let from_bincode: UpgradeableLoaderState = bincode::deserialize(&bincode_bytes).unwrap();
+        let from_wincode: UpgradeableLoaderState = wincode::deserialize(&wincode_bytes).unwrap();
+        assert_eq!(from_bincode, state);
+        assert_eq!(from_wincode, state);
     }
 }

--- a/loader-v3-interface/src/state.rs
+++ b/loader-v3-interface/src/state.rs
@@ -1,4 +1,6 @@
 use solana_pubkey::Pubkey;
+#[cfg(feature = "wincode")]
+use wincode::{SchemaRead, SchemaWrite};
 
 /// Upgradeable loader account states
 #[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
@@ -6,6 +8,7 @@ use solana_pubkey::Pubkey;
     feature = "serde",
     derive(serde_derive::Deserialize, serde_derive::Serialize)
 )]
+#[cfg_attr(feature = "wincode", derive(SchemaRead, SchemaWrite))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum UpgradeableLoaderState {
     /// Account is not initialized.
@@ -64,23 +67,23 @@ impl UpgradeableLoaderState {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "wincode"))]
 mod tests {
-    use {super::*, bincode::serialized_size};
+    use super::*;
 
     #[test]
     fn test_state_size_of_uninitialized() {
-        let buffer_state = UpgradeableLoaderState::Uninitialized;
-        let size = serialized_size(&buffer_state).unwrap();
+        let state = UpgradeableLoaderState::Uninitialized;
+        let size = wincode::serialized_size(&state).unwrap();
         assert_eq!(UpgradeableLoaderState::size_of_uninitialized() as u64, size);
     }
 
     #[test]
     fn test_state_size_of_buffer_metadata() {
-        let buffer_state = UpgradeableLoaderState::Buffer {
+        let state = UpgradeableLoaderState::Buffer {
             authority_address: Some(Pubkey::default()),
         };
-        let size = serialized_size(&buffer_state).unwrap();
+        let size = wincode::serialized_size(&state).unwrap();
         assert_eq!(
             UpgradeableLoaderState::size_of_buffer_metadata() as u64,
             size
@@ -89,11 +92,11 @@ mod tests {
 
     #[test]
     fn test_state_size_of_programdata_metadata() {
-        let programdata_state = UpgradeableLoaderState::ProgramData {
+        let state = UpgradeableLoaderState::ProgramData {
             upgrade_authority_address: Some(Pubkey::default()),
             slot: 0,
         };
-        let size = serialized_size(&programdata_state).unwrap();
+        let size = wincode::serialized_size(&state).unwrap();
         assert_eq!(
             UpgradeableLoaderState::size_of_programdata_metadata() as u64,
             size
@@ -102,10 +105,10 @@ mod tests {
 
     #[test]
     fn test_state_size_of_program() {
-        let program_state = UpgradeableLoaderState::Program {
+        let state = UpgradeableLoaderState::Program {
             programdata_address: Pubkey::default(),
         };
-        let size = serialized_size(&program_state).unwrap();
+        let size = wincode::serialized_size(&state).unwrap();
         assert_eq!(UpgradeableLoaderState::size_of_program() as u64, size);
     }
 }


### PR DESCRIPTION
Convert the Loader V3 interface to use wincode instead of bincode.