### PR TITLE
account: deprecate PROGRAM_OWNERS

### DIFF
--- a/account/src/lib.rs
+++ b/account/src/lib.rs
@@ -693,7 +693,7 @@ pub fn create_is_signer_account_infos<'a>(
 }
 
 /// Replacement for the executable flag: An account being owned by one of these contains a program.
-#[deprecated(since = "5.0.0", note = "no longer available as a constant")]
+#[deprecated(since = "4.3.0", note = "no longer available as a constant")]
 pub const PROGRAM_OWNERS: &[Pubkey] = &[
     bpf_loader_upgradeable::id(),
     bpf_loader::id(),

--- a/account/src/lib.rs
+++ b/account/src/lib.rs
@@ -693,6 +693,7 @@ pub fn create_is_signer_account_infos<'a>(
 }
 
 /// Replacement for the executable flag: An account being owned by one of these contains a program.
+#[deprecated(since = "5.0.0", note = "no longer available as a constant")]
 pub const PROGRAM_OWNERS: &[Pubkey] = &[
     bpf_loader_upgradeable::id(),
     bpf_loader::id(),


### PR DESCRIPTION
#### Problem
This constant is sketchy, since it has consensus implications and one of the programs previously contained in it will be removed. It's also only used in two places in the same crate in Agave, so it can just be inlined.

#### Summary of Changes
Deprecate `PROGRAM_OWNERS`.