### PR TITLE
program-log-macro: Use block expression

### DIFF
--- a/program-log-macro/src/lib.rs
+++ b/program-log-macro/src/lib.rs
@@ -231,9 +231,11 @@ pub fn log(input: TokenStream) -> TokenStream {
             }
         })
     } else {
-        TokenStream::from(
-            quote! {::solana_program_log::logger::log_message(#format_string.as_bytes());},
-        )
+        TokenStream::from(quote! {
+            {
+                ::solana_program_log::logger::log_message(#format_string.as_bytes());
+            }
+        })
     }
 }
 


### PR DESCRIPTION
### Problem

Currently the `log!` macro expansion behaves differently depending on whether there are placeholders in the message or not. This is problematic since it might lead to an invalid expansion when the macro is used in a `match` arm expression, for example.

### Solution

Update the macro expansion to always return a block.