### PR TITLE
[BLS] fix bls pop with pubkey padding

### DIFF
--- a/bls-signatures/src/hash.rs
+++ b/bls-signatures/src/hash.rs
@@ -88,7 +88,8 @@ pub(crate) fn hash_pop_to_projective(payload: &[u8]) -> G2Projective {
 }
 
 pub(crate) fn hash_bound_pop_to_projective(payload: &[u8], pubkey_bytes: &[u8]) -> G2Projective {
-    let mut bound_payload = Vec::with_capacity(payload.len() + pubkey_bytes.len());
+    let capacity = payload.len().saturating_add(pubkey_bytes.len());
+    let mut bound_payload = Vec::with_capacity(capacity);
     bound_payload.extend_from_slice(payload);
     bound_payload.extend_from_slice(pubkey_bytes);
     hash_pop_to_projective(&bound_payload)

--- a/bls-signatures/src/hash.rs
+++ b/bls-signatures/src/hash.rs
@@ -1,5 +1,6 @@
 use {
     crate::proof_of_possession::POP_DST,
+    alloc::vec::Vec,
     blstrs::{G2Affine, G2Prepared, G2Projective},
 };
 
@@ -71,9 +72,9 @@ impl PreparedHashedMessage {
 pub struct HashedPoPPayload(pub(crate) G2Affine);
 
 impl HashedPoPPayload {
-    /// Hash a message to a curve point (G2) and prepare it for verification.
-    pub fn new(payload: &[u8]) -> Self {
-        let point = G2Projective::hash_to_curve(payload, POP_DST, &[]);
+    /// Hash a payload bound to a specific public key for proof-of-possession checks.
+    pub fn new(payload: &[u8], pubkey_bytes: &[u8]) -> Self {
+        let point = hash_bound_pop_to_projective(payload, pubkey_bytes);
         Self(point.into())
     }
 }
@@ -84,4 +85,11 @@ pub(crate) fn hash_message_to_projective(message: &[u8]) -> G2Projective {
 
 pub(crate) fn hash_pop_to_projective(payload: &[u8]) -> G2Projective {
     G2Projective::hash_to_curve(payload, POP_DST, &[])
+}
+
+pub(crate) fn hash_bound_pop_to_projective(payload: &[u8], pubkey_bytes: &[u8]) -> G2Projective {
+    let mut bound_payload = Vec::with_capacity(payload.len() + pubkey_bytes.len());
+    bound_payload.extend_from_slice(payload);
+    bound_payload.extend_from_slice(pubkey_bytes);
+    hash_pop_to_projective(&bound_payload)
 }

--- a/bls-signatures/src/keypair.rs
+++ b/bls-signatures/src/keypair.rs
@@ -70,13 +70,7 @@ impl Keypair {
 
     /// Generate a proof of possession for the given keypair
     pub fn proof_of_possession(&self, payload: Option<&[u8]>) -> ProofOfPossessionProjective {
-        match payload {
-            Some(p) => self.secret.proof_of_possession(Some(p)),
-            None => {
-                let pubkey_bytes = self.public.to_bytes_compressed();
-                self.secret.proof_of_possession(Some(&pubkey_bytes))
-            }
-        }
+        self.secret.proof_of_possession(payload)
     }
 
     /// Sign a message using the provided secret key

--- a/bls-signatures/src/proof_of_possession/mod.rs
+++ b/bls-signatures/src/proof_of_possession/mod.rs
@@ -166,11 +166,11 @@ mod tests {
 
         let attacker_scalar = Scalar::from(7u64);
         let rogue_pubkey = PubkeyProjective(
-            (G1Projective::generator() * attacker_scalar) - PubkeyProjective::from(*honest.public).0,
+            (G1Projective::generator() * attacker_scalar)
+                - PubkeyProjective::from(*honest.public).0,
         );
-        let rogue_pop = ProofOfPossessionProjective(
-            (hashed_payload * attacker_scalar) - honest_pop.0,
-        );
+        let rogue_pop =
+            ProofOfPossessionProjective((hashed_payload * attacker_scalar) - honest_pop.0);
 
         assert!(rogue_pubkey
             .verify_proof_of_possession(&rogue_pop, Some(payload))

--- a/bls-signatures/src/proof_of_possession/mod.rs
+++ b/bls-signatures/src/proof_of_possession/mod.rs
@@ -23,10 +23,13 @@ mod tests {
     use {
         super::*,
         crate::{
+            hash::hash_pop_to_projective,
             keypair::Keypair,
             pubkey::{Pubkey, PubkeyAffine, PubkeyCompressed, PubkeyProjective, VerifyPop},
         },
+        blstrs::{G1Projective, Scalar},
         core::str::FromStr,
+        group::Group,
         std::string::ToString,
     };
 
@@ -150,6 +153,27 @@ mod tests {
         assert!(keypair
             .public
             .verify_proof_of_possession(&proof_standard, Some(custom_payload))
+            .is_err());
+    }
+
+    #[test]
+    #[allow(clippy::arithmetic_side_effects)]
+    fn test_custom_payload_pop_is_bound_to_pubkey() {
+        let honest = Keypair::new();
+        let payload = b"SIMD-0387-context-data";
+        let honest_pop = honest.proof_of_possession(Some(payload));
+        let hashed_payload = hash_pop_to_projective(payload);
+
+        let attacker_scalar = Scalar::from(7u64);
+        let rogue_pubkey = PubkeyProjective(
+            (G1Projective::generator() * attacker_scalar) - PubkeyProjective::from(*honest.public).0,
+        );
+        let rogue_pop = ProofOfPossessionProjective(
+            (hashed_payload * attacker_scalar) - honest_pop.0,
+        );
+
+        assert!(rogue_pubkey
+            .verify_proof_of_possession(&rogue_pop, Some(payload))
             .is_err());
     }
 

--- a/bls-signatures/src/pubkey/verify.rs
+++ b/bls-signatures/src/pubkey/verify.rs
@@ -26,12 +26,8 @@ pub trait VerifyPop: AsPubkeyAffine + Sized {
         proof: &P,
         payload: Option<&[u8]>,
     ) -> Result<(), BlsError> {
-        let hashed_pubkey = if let Some(bytes) = payload {
-            HashedPoPPayload::new(bytes)
-        } else {
-            let pubkey_bytes = self.try_as_affine()?.to_bytes_compressed();
-            HashedPoPPayload::new(&pubkey_bytes)
-        };
+        let pubkey_bytes = self.try_as_affine()?.to_bytes_compressed();
+        let hashed_pubkey = HashedPoPPayload::new(payload.unwrap_or(&[]), &pubkey_bytes);
         self.verify_proof_of_possession_pre_hashed(proof, &hashed_pubkey)
     }
 

--- a/bls-signatures/src/secret_key.rs
+++ b/bls-signatures/src/secret_key.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         error::BlsError,
-        hash::{hash_message_to_projective, hash_pop_to_projective},
+        hash::{hash_bound_pop_to_projective, hash_message_to_projective},
         proof_of_possession::ProofOfPossessionProjective,
         pubkey::PubkeyProjective,
         signature::SignatureProjective,
@@ -108,13 +108,9 @@ impl SecretKey {
     #[allow(clippy::arithmetic_side_effects)]
     #[allow(clippy::op_ref)]
     pub fn proof_of_possession(&self, payload: Option<&[u8]>) -> ProofOfPossessionProjective {
-        let hashed_point = if let Some(bytes) = payload {
-            hash_pop_to_projective(bytes)
-        } else {
-            let pubkey = PubkeyProjective::from_secret(self);
-            let pubkey_bytes = pubkey.to_bytes_compressed();
-            hash_pop_to_projective(&pubkey_bytes)
-        };
+        let pubkey = PubkeyProjective::from_secret(self);
+        let pubkey_bytes = pubkey.to_bytes_compressed();
+        let hashed_point = hash_bound_pop_to_projective(payload.unwrap_or(&[]), &pubkey_bytes);
         ProofOfPossessionProjective(hashed_point * &self.0)
     }
 


### PR DESCRIPTION
```
When payload is present, proof generation in proof_of_possession and verification in
verify_proof_of_possession hash only payload but do not necessarily bind the claimed public key
into the hash input. This weakens the proof from a proof of possession for a specific key into a signature
over a shared message and reintroduces rogue key attacks.
```

In this PR, we address this attack by always pad the payload with the public key.