### PR TITLE
message: Add heap size bounds check for message v1

### DIFF
--- a/message/src/versions/mod.rs
+++ b/message/src/versions/mod.rs
@@ -579,7 +579,9 @@ mod tests {
                 priority_fee in of(any::<u64>()),
                 compute_unit_limit in of(0..=1_400_000u32),
                 loaded_accounts_data_size_limit in of(0..=20_480u32),
-                heap_size in of(MIN_HEAP_SIZE..=MAX_HEAP_SIZE),
+                // heap size must be a multiple of 1024 and between MIN_HEAP_SIZE
+                // and MAX_HEAP_SIZE if specified.
+                heap_size in of(MIN_HEAP_SIZE.saturating_div(1024)..=MAX_HEAP_SIZE.saturating_div(1024)),
                 required_signatures in 1..=12u8,
             )
             (
@@ -598,7 +600,7 @@ mod tests {
                 priority_fee in Just(priority_fee),
                 compute_unit_limit in Just(compute_unit_limit),
                 loaded_accounts_data_size_limit in Just(loaded_accounts_data_size_limit),
-                heap_size in Just(heap_size),
+                heap_size in Just(heap_size.map(|size| size.saturating_mul(1024))),
                 required_signatures in Just(required_signatures),
             ) -> TestMessageData
         {

--- a/message/src/versions/mod.rs
+++ b/message/src/versions/mod.rs
@@ -456,13 +456,15 @@ unsafe impl<'de, C: Config> SchemaRead<'de, C> for VersionedMessage {
 mod tests {
     use {
         super::*,
-        crate::{v0::MessageAddressTableLookup, v1::V1_PREFIX},
+        crate::{
+            v0::MessageAddressTableLookup,
+            v1::{MAX_HEAP_SIZE, MIN_HEAP_SIZE, V1_PREFIX},
+        },
         proptest::{
             collection::vec,
             option::of,
             prelude::{any, Just},
             prop_compose, proptest,
-            strategy::Strategy,
         },
         solana_instruction::{AccountMeta, Instruction},
     };
@@ -577,7 +579,7 @@ mod tests {
                 priority_fee in of(any::<u64>()),
                 compute_unit_limit in of(0..=1_400_000u32),
                 loaded_accounts_data_size_limit in of(0..=20_480u32),
-                heap_size in of((0..=32u32).prop_map(|n| n.saturating_mul(1024))),
+                heap_size in of(MIN_HEAP_SIZE..=MAX_HEAP_SIZE),
                 required_signatures in 1..=12u8,
             )
             (

--- a/message/src/versions/v1/message.rs
+++ b/message/src/versions/v1/message.rs
@@ -56,8 +56,8 @@ use {
         compiled_instruction::CompiledInstruction,
         compiled_keys::CompiledKeys,
         v1::{
-            MessageError, TransactionConfig, TransactionConfigMask, DEFAULT_HEAP_SIZE,
-            MAX_ADDRESSES, MAX_HEAP_SIZE, MAX_INSTRUCTIONS, MAX_SIGNATURES,
+            MessageError, TransactionConfig, TransactionConfigMask, MAX_ADDRESSES, MAX_HEAP_SIZE,
+            MAX_INSTRUCTIONS, MAX_SIGNATURES, MIN_HEAP_SIZE,
         },
         AccountKeys, CompileError, MessageHeader,
     },
@@ -468,7 +468,7 @@ impl Message {
                 return Err(MessageError::InvalidHeapSize);
             }
 
-            if !(DEFAULT_HEAP_SIZE..=MAX_HEAP_SIZE).contains(&heap_size) {
+            if !(MIN_HEAP_SIZE..=MAX_HEAP_SIZE).contains(&heap_size) {
                 return Err(MessageError::InvalidHeapSize);
             }
         }
@@ -1083,6 +1083,34 @@ mod tests {
         let mut message = create_test_message();
         message.config.heap_size = Some(1025); // Not a multiple of 1024
         assert_eq!(message.sanitize(), Err(SanitizeError::InvalidValue));
+    }
+
+    #[test]
+    fn sanitize_rejects_heap_size_below_minimum() {
+        let mut message = create_test_message();
+        message.config.heap_size = Some(MIN_HEAP_SIZE - 1);
+        assert_eq!(message.sanitize(), Err(SanitizeError::InvalidValue));
+    }
+
+    #[test]
+    fn sanitize_rejects_heap_size_above_maximum() {
+        let mut message = create_test_message();
+        message.config.heap_size = Some(MAX_HEAP_SIZE + 1);
+        assert_eq!(message.sanitize(), Err(SanitizeError::InvalidValue));
+    }
+
+    #[test]
+    fn sanitize_accepts_minimum_heap_size() {
+        let mut message = create_test_message();
+        message.config.heap_size = Some(MIN_HEAP_SIZE);
+        assert!(message.sanitize().is_ok());
+    }
+
+    #[test]
+    fn sanitize_accepts_maximum_heap_size() {
+        let mut message = create_test_message();
+        message.config.heap_size = Some(MAX_HEAP_SIZE);
+        assert!(message.sanitize().is_ok());
     }
 
     #[test]

--- a/message/src/versions/v1/message.rs
+++ b/message/src/versions/v1/message.rs
@@ -56,8 +56,8 @@ use {
         compiled_instruction::CompiledInstruction,
         compiled_keys::CompiledKeys,
         v1::{
-            MessageError, TransactionConfig, TransactionConfigMask, MAX_ADDRESSES,
-            MAX_INSTRUCTIONS, MAX_SIGNATURES,
+            MessageError, TransactionConfig, TransactionConfigMask, DEFAULT_HEAP_SIZE,
+            MAX_ADDRESSES, MAX_HEAP_SIZE, MAX_INSTRUCTIONS, MAX_SIGNATURES,
         },
         AccountKeys, CompileError, MessageHeader,
     },
@@ -462,9 +462,13 @@ impl Message {
             return Err(MessageError::InvalidConfigMask);
         }
 
-        // heap size must be a multiple of 1024
+        // if specified, heap size must be a multiple of 1024 and within valid bounds
         if let Some(heap_size) = self.config.heap_size {
             if heap_size % 1024 != 0 {
+                return Err(MessageError::InvalidHeapSize);
+            }
+
+            if !(DEFAULT_HEAP_SIZE..=MAX_HEAP_SIZE).contains(&heap_size) {
                 return Err(MessageError::InvalidHeapSize);
             }
         }

--- a/message/src/versions/v1/mod.rs
+++ b/message/src/versions/v1/mod.rs
@@ -31,10 +31,13 @@ pub const MAX_INSTRUCTIONS: u8 = 64;
 /// Maximum number of signatures in a V1 transaction.
 pub const MAX_SIGNATURES: u8 = 12;
 
-/// Default heap size in bytes when not specified (32KB).
+/// Default heap size in bytes when not specified.
 ///
-/// This also represents the minimum heap size.
-pub const DEFAULT_HEAP_SIZE: u32 = 32 * 1024;
+/// This is the same as the minimum heap size.
+pub const DEFAULT_HEAP_SIZE: u32 = MIN_HEAP_SIZE;
+
+/// Minimum heap size in bytes (32KB).
+pub const MIN_HEAP_SIZE: u32 = 32 * 1024;
 
 /// Maximum heap size in bytes (256KB).
 pub const MAX_HEAP_SIZE: u32 = 256 * 1024;

--- a/message/src/versions/v1/mod.rs
+++ b/message/src/versions/v1/mod.rs
@@ -32,7 +32,12 @@ pub const MAX_INSTRUCTIONS: u8 = 64;
 pub const MAX_SIGNATURES: u8 = 12;
 
 /// Default heap size in bytes when not specified (32KB).
-pub const DEFAULT_HEAP_SIZE: u32 = 32_768;
+///
+/// This also represents the minimum heap size.
+pub const DEFAULT_HEAP_SIZE: u32 = 32 * 1024;
+
+/// Maximum heap size in bytes (256KB).
+pub const MAX_HEAP_SIZE: u32 = 256 * 1024;
 
 /// Size of the fixed header portion of a serialized V1 message.
 pub const FIXED_HEADER_SIZE: usize = size_of::<MessageHeader>() // legacy header


### PR DESCRIPTION
### Problem

Message v1 accepts a configurable heap size parameter, but currently the value is not being validated.

### Solution

Add bounds validation for the heap size parameter.