### PR TITLE
[BLS] add compiler_fence to zeroize

### DIFF
--- a/bls-signatures/src/keypair.rs
+++ b/bls-signatures/src/keypair.rs
@@ -131,6 +131,16 @@ impl From<&Keypair> for [u8; BLS_KEYPAIR_SIZE] {
     }
 }
 
+impl From<&Keypair> for Zeroizing<[u8; BLS_KEYPAIR_SIZE]> {
+    fn from(keypair: &Keypair) -> Self {
+        let mut bytes = Zeroizing::new([0u8; BLS_KEYPAIR_SIZE]);
+        let secret_bytes: Zeroizing<[u8; BLS_SECRET_KEY_SIZE]> = (&keypair.secret).into();
+        bytes[..BLS_SECRET_KEY_SIZE].copy_from_slice(secret_bytes.as_slice());
+        bytes[BLS_SECRET_KEY_SIZE..].copy_from_slice(&keypair.public.to_bytes_uncompressed());
+        bytes
+    }
+}
+
 #[cfg(feature = "std")]
 impl Keypair {
     pub fn read_json<R: Read>(reader: &mut R) -> Result<Self, Box<dyn error::Error>> {
@@ -145,11 +155,12 @@ impl Keypair {
         Self::read_json(&mut file)
     }
 
-    /// WARNING: The returned JSON string contains secret-key material. Callers should clear it as
-    /// soon as they are done using it.
-    pub fn write_json<W: Write>(&self, writer: &mut W) -> Result<String, Box<dyn error::Error>> {
-        let bytes = Zeroizing::new(Into::<[u8; BLS_KEYPAIR_SIZE]>::into(self));
-        let json = serde_json::to_string(bytes.as_slice())?;
+    pub fn write_json<W: Write>(
+        &self,
+        writer: &mut W,
+    ) -> Result<Zeroizing<String>, Box<dyn error::Error>> {
+        let bytes: Zeroizing<[u8; BLS_KEYPAIR_SIZE]> = self.into();
+        let json = Zeroizing::new(serde_json::to_string(bytes.as_slice())?);
         writer.write_all(json.as_bytes())?;
         Ok(json)
     }
@@ -157,7 +168,7 @@ impl Keypair {
     pub fn write_json_file<F: AsRef<Path>>(
         &self,
         outfile: F,
-    ) -> Result<String, Box<dyn core::error::Error>> {
+    ) -> Result<Zeroizing<String>, Box<dyn core::error::Error>> {
         let outfile = outfile.as_ref();
 
         if let Some(outdir) = outfile.parent() {

--- a/bls-signatures/src/keypair.rs
+++ b/bls-signatures/src/keypair.rs
@@ -124,7 +124,7 @@ impl From<&Keypair> for [u8; BLS_KEYPAIR_SIZE] {
         // WARNING: `bytes` contains raw secret-key material. Callers should zeroize the returned
         // buffer as soon as they are done using it.
         let mut bytes = [0u8; BLS_KEYPAIR_SIZE];
-        let secret_bytes = Zeroizing::new(Into::<[u8; BLS_SECRET_KEY_SIZE]>::into(&keypair.secret));
+        let secret_bytes: Zeroizing<[u8; BLS_SECRET_KEY_SIZE]> = (&keypair.secret).into();
         bytes[..BLS_SECRET_KEY_SIZE].copy_from_slice(secret_bytes.as_slice());
         bytes[BLS_SECRET_KEY_SIZE..].copy_from_slice(&keypair.public.to_bytes_uncompressed());
         bytes

--- a/bls-signatures/src/secret_key.rs
+++ b/bls-signatures/src/secret_key.rs
@@ -131,23 +131,30 @@ impl SecretKey {
 
 impl TryFrom<&[u8]> for SecretKey {
     type Error = BlsError;
-    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        if bytes.len() != BLS_SECRET_KEY_SIZE {
+    fn try_from(src: &[u8]) -> Result<Self, Self::Error> {
+        if src.len() != BLS_SECRET_KEY_SIZE {
             return Err(BlsError::ParseFromBytes);
         }
-        let bytes = Zeroizing::new(<[u8; BLS_SECRET_KEY_SIZE]>::try_from(bytes).unwrap());
+        let mut bytes = Zeroizing::new([0u8; BLS_SECRET_KEY_SIZE]);
+        bytes.copy_from_slice(src);
         Self::parse_scalar(&bytes).map(Self)
     }
 }
 
-impl From<&SecretKey> for [u8; BLS_SECRET_KEY_SIZE] {
-    fn from(secret_key: &SecretKey) -> Self {
-        // WARNING: The returned buffer contains raw secret-key bytes. Callers should zeroize it
-        // as soon as they are done using it.
-        secret_key.0.to_bytes_le()
-    }
-}
-
+/// Converts a secret key into a zeroizing little-endian byte buffer.
+///
+/// If a caller explicitly needs a plain `[u8; BLS_SECRET_KEY_SIZE]`, they can
+/// copy it out of the zeroizing wrapper:
+///
+/// ```
+/// use zeroize::Zeroizing;
+/// use solana_bls_signatures::secret_key::{SecretKey, BLS_SECRET_KEY_SIZE};
+///
+/// let secret_key = SecretKey::new();
+/// let zeroizing_bytes: Zeroizing<[u8; BLS_SECRET_KEY_SIZE]> = (&secret_key).into();
+/// let mut raw_bytes = [0u8; BLS_SECRET_KEY_SIZE];
+/// raw_bytes.copy_from_slice(zeroizing_bytes.as_slice());
+/// ```
 impl From<&SecretKey> for Zeroizing<[u8; BLS_SECRET_KEY_SIZE]> {
     fn from(secret_key: &SecretKey) -> Self {
         Zeroizing::new(secret_key.0.to_bytes_le())

--- a/bls-signatures/src/secret_key.rs
+++ b/bls-signatures/src/secret_key.rs
@@ -8,7 +8,7 @@ use {
     },
     blst::{blst_keygen, blst_scalar},
     blstrs::Scalar,
-    core::ptr,
+    core::{ptr, sync::atomic},
     ff::Field,
     rand::rngs::OsRng,
     zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing},
@@ -36,8 +36,9 @@ impl core::fmt::Debug for SecretKey {
 impl Zeroize for SecretKey {
     fn zeroize(&mut self) {
         unsafe {
-            core::ptr::write_volatile(&mut self.0, Scalar::ZERO);
+            ptr::write_volatile(&mut self.0, Scalar::ZERO);
         }
+        atomic::compiler_fence(atomic::Ordering::SeqCst);
     }
 }
 
@@ -51,7 +52,7 @@ impl ZeroizeOnDrop for SecretKey {}
 
 impl SecretKey {
     /// Parses a canonical, non-zero secret scalar from little-endian bytes.
-    fn parse_scalar(bytes: &[u8; BLS_SECRET_KEY_SIZE]) -> Result<Scalar, BlsError> {
+    fn parse_scalar(bytes: &Zeroizing<[u8; BLS_SECRET_KEY_SIZE]>) -> Result<Scalar, BlsError> {
         let scalar: Option<Scalar> = Scalar::from_bytes_le(bytes).into();
         let scalar = scalar.ok_or(BlsError::FieldDecode)?;
         if bool::from(scalar.is_zero()) {
@@ -82,7 +83,8 @@ impl SecretKey {
                 0,
             );
         }
-        Self::parse_scalar(&scalar.b).map(Self)
+        let bytes = Zeroizing::new(scalar.b);
+        Self::parse_scalar(&bytes).map(Self)
     }
 
     /// Derive a `BlsSecretKey` from a Solana signer
@@ -133,8 +135,8 @@ impl TryFrom<&[u8]> for SecretKey {
         if bytes.len() != BLS_SECRET_KEY_SIZE {
             return Err(BlsError::ParseFromBytes);
         }
-        // unwrap safe due to the length check above
-        Self::parse_scalar(bytes.try_into().unwrap()).map(Self)
+        let bytes = Zeroizing::new(<[u8; BLS_SECRET_KEY_SIZE]>::try_from(bytes).unwrap());
+        Self::parse_scalar(&bytes).map(Self)
     }
 }
 
@@ -143,5 +145,11 @@ impl From<&SecretKey> for [u8; BLS_SECRET_KEY_SIZE] {
         // WARNING: The returned buffer contains raw secret-key bytes. Callers should zeroize it
         // as soon as they are done using it.
         secret_key.0.to_bytes_le()
+    }
+}
+
+impl From<&SecretKey> for Zeroizing<[u8; BLS_SECRET_KEY_SIZE]> {
+    fn from(secret_key: &SecretKey) -> Self {
+        Zeroizing::new(secret_key.0.to_bytes_le())
     }
 }


### PR DESCRIPTION
This PR enhances zeroization as follows

- add `compiler_fence` for zeroization
- add zeroization via type protection for sk related json