### PR TITLE
[BLS] fix misleading batch verification documentation

### DIFF
--- a/bls-signatures/README.md
+++ b/bls-signatures/README.md
@@ -2,7 +2,7 @@
 
 This crate provides an implementation of BLS (Boneh-Lynn-Shacham) signatures over the BLS12-381 elliptic curve.
 
-It is primarily intended for use in the Solana Alpenglow consensus protocol, but it is general enough to be used in any Rust application requiring BLS signatures, threshold cryptography, or batch verification. Under the hood, it uses the `blst` library as its cryptographic backend.
+It is primarily intended for use in the Solana Alpenglow consensus protocol, but it is general enough to be used in any Rust application requiring BLS signatures, threshold cryptography, or aggregate screening of distinct-message signature sets. Under the hood, it uses the `blst` library as its cryptographic backend.
 
 ---
 
@@ -10,7 +10,8 @@ It is primarily intended for use in the Solana Alpenglow consensus protocol, but
 
 - **Multiple Point Representations:** Convert seamlessly between serialized Bytes (`Signature`), Compressed Bytes (`SignatureCompressed`), Projective points (`SignatureProjective` optimized for fast aggregation), and Affine points (`SignatureAffine` optimized for pairings). The same representations exist for Public Keys and Proofs of Possession.
 - **Ergonomic Verification:** Verify signatures bi-directionally (from the public key or the signature) using any representation type via the `VerifySignature` and `VerifiableSignature` traits.
-- **Aggregate & Batch Verification:** Optimized multi-miller loop algorithms for verifying aggregated signatures against shared messages (multisig) or multiple distinct messages (batch verification).
+- **Aggregate Verification & Screening:** Optimized multi-miller loop algorithms for verifying aggregated signatures against shared messages (multisig) or screening multiple distinct-message signatures via aggregate relations.
+- Supports aggregate screening of distinct-message signature sets. Note that `verify_distinct` and its variants provide screening guarantees only and do not imply individual signature validity per signer. See the API documentation for details.
 - **Parallelization:** Optional `rayon` integration to speed up multi-scalar multiplications (MSMs) and heavy verification loops.
 - **Rogue-Key Attack Prevention:** Type-safe wrappers like `PopVerified` ensure that aggregation only occurs with keys that have proven their Proof of Possession.
 

--- a/bls-signatures/src/signature/mod.rs
+++ b/bls-signatures/src/signature/mod.rs
@@ -8,8 +8,8 @@
 //! - **Points** (`SignatureProjective`, `SignatureAffine`): For cryptographic operations.
 //!
 //! The module includes highly optimized multi-miller loop logic for verifying
-//! aggregated signatures over both shared messages (multisig) and distinct
-//! messages (batch verification).
+//! aggregated signatures over shared messages (multisig) and for aggregate
+//! screening over distinct-message signature sets.
 //!
 //! # Organization
 //! - `bytes`: Raw byte definitions and base64 string conversions.
@@ -19,8 +19,8 @@
 //! - `aggregate`: Methods for combining multiple signatures into a single aggregate signature.
 //! - `verify`: Multisig verification (Verifying multiple public keys against a **single**
 //!   shared message).
-//! - `verify_distinct`: Batch verification (Verifying multiple public keys against **multiple**
-//!   distinct messages).
+//! - `verify_distinct`: Aggregate screening (Screening multiple public keys against **multiple**
+//!   distinct messages without implying per-signer validity).
 
 #[cfg(not(target_os = "solana"))]
 pub mod aggregate;

--- a/bls-signatures/src/signature/verify_distinct.rs
+++ b/bls-signatures/src/signature/verify_distinct.rs
@@ -1,10 +1,11 @@
-//! Batch verification for distinct messages.
+//! Aggregate screening for distinct-message signature sets.
 //!
 //! # Security Note: Individual Signature Validity
 //!
-//! The functions in this module verify that an **aggregated** signature is valid for a given set
-//! of public keys and their corresponding messages. However, they **do not guarantee that each
-//! individual signature was valid prior to aggregation**.
+//! The functions in this module perform aggregate screening by grouping signatures by message hash
+//! and checking the aggregate relation per bucket. They verify that an **aggregated** signature is
+//! valid for a given set of public keys and their corresponding messages, but they **do not
+//! guarantee that each individual signature was valid prior to aggregation**.
 //!
 //! Because the verification evaluates the sum of the pairings without using random linear
 //! combinations, it is mathematically possible for individually invalid signatures to cancel
@@ -109,8 +110,12 @@ impl SignatureProjective {
         (grouped_pubkeys_affine, grouped_prepared)
     }
 
-    /// Verifies an aggregated signature over a set of multiple messages and
-    /// public keys.
+    /// Performs aggregate screening of signatures over distinct messages.
+    ///
+    /// This function groups signatures by message hash and verifies the aggregate relation per
+    /// bucket. A successful result does not imply that every individual signature in the set is
+    /// valid. Callers that require per-signer validity guarantees must verify each signature
+    /// individually.
     ///
     /// Note: The term "distinct" indicates that each public key is paired with a
     /// corresponding message from the iterator. It does *not* imply that the
@@ -140,8 +145,11 @@ impl SignatureProjective {
         )
     }
 
-    /// Verifies an aggregated signature over a set of multiple pre-hashed
-    /// messages and public keys.
+    /// Performs aggregate screening of signatures over distinct pre-hashed messages.
+    ///
+    /// This function provides screening guarantees only. A successful result does not imply that
+    /// every individual signature in the set is valid. Callers that require per-signer validity
+    /// guarantees must verify each signature individually.
     ///
     /// Note: The term "distinct" indicates that each public key is paired with a
     /// corresponding message from the iterator. It does *not* imply that the
@@ -169,8 +177,11 @@ impl SignatureProjective {
         )
     }
 
-    /// Verifies an aggregated signature over a set of multiple pre-hashed and
-    /// prepared messages and public keys.
+    /// Performs aggregate screening of signatures over distinct prepared messages.
+    ///
+    /// This function provides screening guarantees only. A successful result does not imply that
+    /// every individual signature in the set is valid. Callers that require per-signer validity
+    /// guarantees must verify each signature individually.
     ///
     /// Note: The term "distinct" indicates that each public key is paired with a
     /// corresponding message from the iterator. It does *not* imply that the
@@ -200,8 +211,11 @@ impl SignatureProjective {
         )
     }
 
-    /// Verifies a pre-aggregated signature over a set of multiple messages and
-    /// public keys.
+    /// Performs aggregate screening with a pre-aggregated signature over distinct messages.
+    ///
+    /// This function provides screening guarantees only. A successful result does not imply that
+    /// every individual signature in the set is valid. Callers that require per-signer validity
+    /// guarantees must verify each signature individually.
     ///
     /// Note: The term "distinct" indicates that each public key is paired with a
     /// corresponding message from the iterator. It does *not* imply that the
@@ -229,8 +243,12 @@ impl SignatureProjective {
         )
     }
 
-    /// Verifies a pre-aggregated signature over a set of multiple pre-hashed
-    /// messages and public keys.
+    /// Performs aggregate screening with a pre-aggregated signature over distinct pre-hashed
+    /// messages.
+    ///
+    /// This function provides screening guarantees only. A successful result does not imply that
+    /// every individual signature in the set is valid. Callers that require per-signer validity
+    /// guarantees must verify each signature individually.
     ///
     /// Note: The term "distinct" indicates that each public key is paired with a
     /// corresponding message from the iterator. It does *not* imply that the
@@ -301,8 +319,12 @@ impl SignatureProjective {
             .ok_or(BlsError::VerificationFailed)
     }
 
-    /// Verifies a pre-aggregated signature over a set of multiple pre-hashed and
-    /// prepared messages and public keys.
+    /// Performs aggregate screening with a pre-aggregated signature over distinct prepared
+    /// messages.
+    ///
+    /// This function provides screening guarantees only. A successful result does not imply that
+    /// every individual signature in the set is valid. Callers that require per-signer validity
+    /// guarantees must verify each signature individually.
     ///
     /// Entries with identical message hashes are merged internally by summing
     /// their public keys, reducing pairing terms.
@@ -375,8 +397,11 @@ impl SignatureProjective {
             .ok_or(BlsError::VerificationFailed)
     }
 
-    /// Verifies a set of signatures over a set of multiple messages and
-    /// public keys in parallel.
+    /// Performs aggregate screening of signatures over distinct messages in parallel.
+    ///
+    /// This function provides screening guarantees only. A successful result does not imply that
+    /// every individual signature in the set is valid. Callers that require per-signer validity
+    /// guarantees must verify each signature individually.
     ///
     /// Note: The term "distinct" indicates that each public key is paired with a
     /// corresponding message from the slice. It does *not* imply that the messages
@@ -409,8 +434,11 @@ impl SignatureProjective {
         )
     }
 
-    /// Verifies a set of signatures over a set of distinct pre-hashed messages
-    /// and public keys in parallel.
+    /// Performs aggregate screening of signatures over distinct pre-hashed messages in parallel.
+    ///
+    /// This function provides screening guarantees only. A successful result does not imply that
+    /// every individual signature in the set is valid. Callers that require per-signer validity
+    /// guarantees must verify each signature individually.
     ///
     /// Note: The term "distinct" indicates that each public key is paired with a
     /// corresponding message from the slice. It does *not* imply that the messages
@@ -439,8 +467,11 @@ impl SignatureProjective {
         )
     }
 
-    /// Verifies a set of signatures over a set of distinct pre-hashed and
-    /// prepared messages and public keys in parallel.
+    /// Performs aggregate screening of signatures over distinct prepared messages in parallel.
+    ///
+    /// This function provides screening guarantees only. A successful result does not imply that
+    /// every individual signature in the set is valid. Callers that require per-signer validity
+    /// guarantees must verify each signature individually.
     ///
     /// Note: The term "distinct" indicates that each public key is paired with a
     /// corresponding message from the slice. It does *not* imply that the messages
@@ -475,8 +506,12 @@ impl SignatureProjective {
         )
     }
 
-    /// In parallel, verifies a pre-aggregated signature over a set of distinct
-    /// messages and public keys.
+    /// Performs aggregate screening in parallel with a pre-aggregated signature over distinct
+    /// messages.
+    ///
+    /// This function provides screening guarantees only. A successful result does not imply that
+    /// every individual signature in the set is valid. Callers that require per-signer validity
+    /// guarantees must verify each signature individually.
     ///
     /// Note: The term "distinct" indicates that each public key is paired with a
     /// corresponding message from the slice. It does *not* imply that the messages
@@ -508,8 +543,12 @@ impl SignatureProjective {
         )
     }
 
-    /// In parallel, verifies a pre-aggregated signature over a set of distinct
-    /// pre-hashed messages and public keys.
+    /// Performs aggregate screening in parallel with a pre-aggregated signature over distinct
+    /// pre-hashed messages.
+    ///
+    /// This function provides screening guarantees only. A successful result does not imply that
+    /// every individual signature in the set is valid. Callers that require per-signer validity
+    /// guarantees must verify each signature individually.
     ///
     /// Note: The term "distinct" indicates that each public key is paired with a
     /// corresponding message from the slice. It does *not* imply that the messages
@@ -582,8 +621,12 @@ impl SignatureProjective {
             .ok_or(BlsError::VerificationFailed)
     }
 
-    /// In parallel, verifies a pre-aggregated signature over a set of distinct
-    /// pre-hashed and prepared messages and public keys.
+    /// Performs aggregate screening in parallel with a pre-aggregated signature over distinct
+    /// prepared messages.
+    ///
+    /// This function provides screening guarantees only. A successful result does not imply that
+    /// every individual signature in the set is valid. Callers that require per-signer validity
+    /// guarantees must verify each signature individually.
     ///
     /// Entries with identical message hashes are merged internally by summing
     /// their public keys, reducing pairing terms.


### PR DESCRIPTION
This is part of the auditing findings D that I missed during the first screen -- the documentation is a bit abigious. Now addressed.