### PR TITLE
define-syscall: accept trailing comma in macro argument list

### DIFF
--- a/define-syscall/src/lib.rs
+++ b/define-syscall/src/lib.rs
@@ -9,7 +9,7 @@ pub mod definitions;
 ))]
 #[macro_export]
 macro_rules! define_syscall {
-    ($(#[$attr:meta])* fn $name:ident($($arg:ident: $typ:ty),*) -> $ret:ty) => {
+    ($(#[$attr:meta])* fn $name:ident($($arg:ident: $typ:ty),* $(,)?) -> $ret:ty) => {
         $(#[$attr])*
         #[inline]
         pub unsafe fn $name($($arg: $typ),*) -> $ret {
@@ -24,7 +24,7 @@ macro_rules! define_syscall {
         }
 
     };
-    ($(#[$attr:meta])* fn $name:ident($($arg:ident: $typ:ty),*)) => {
+    ($(#[$attr:meta])* fn $name:ident($($arg:ident: $typ:ty),* $(,)?)) => {
         define_syscall!($(#[$attr])* fn $name($($arg: $typ),*) -> ());
     }
 }
@@ -35,13 +35,13 @@ macro_rules! define_syscall {
 )))]
 #[macro_export]
 macro_rules! define_syscall {
-    ($(#[$attr:meta])* fn $name:ident($($arg:ident: $typ:ty),*) -> $ret:ty) => {
+    ($(#[$attr:meta])* fn $name:ident($($arg:ident: $typ:ty),* $(,)?) -> $ret:ty) => {
         extern "C" {
             $(#[$attr])*
             pub fn $name($($arg: $typ),*) -> $ret;
         }
     };
-    ($(#[$attr:meta])* fn $name:ident($($arg:ident: $typ:ty),*)) => {
+    ($(#[$attr:meta])* fn $name:ident($($arg:ident: $typ:ty),* $(,)?)) => {
         define_syscall!($(#[$attr])* fn $name($($arg: $typ),*) -> ());
     }
 }

--- a/define-syscall/tests/trailing_comma.rs
+++ b/define-syscall/tests/trailing_comma.rs
@@ -1,0 +1,8 @@
+use solana_define_syscall::define_syscall;
+
+// Regression test for #701: argument lists should accept an optional trailing comma.
+define_syscall!(fn syscall_with_ret(a: u64, b: *const u8,) -> u64);
+define_syscall!(fn syscall_without_ret(a: u64,));
+
+#[test]
+fn define_syscall_accepts_trailing_comma() {}


### PR DESCRIPTION
## Summary
Fixes #701 by allowing `define_syscall!` to accept an optional trailing comma in argument lists.

## Changes
- Updated macro patterns in `define-syscall/src/lib.rs` from:
  - `($($arg:ident: $typ:ty),*)`
  to:
  - `($($arg:ident: $typ:ty),* $(,)?)`
- Applied this to all relevant macro arms (with return type and without, in both cfg branches).
- Added regression test: `define-syscall/tests/trailing_comma.rs`.

## Why
Rust function-style argument lists support trailing commas, and `rustfmt` commonly inserts them for multi-line formatting. The macro should match that syntax.

## Testing
- `cargo test -p solana-define-syscall`
