### PR TITLE
refactor: switch to solana-short-vec/wincode feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3987,7 +3987,7 @@ dependencies = [
  "solana-nonce",
  "solana-sanitize",
  "solana-sdk-ids",
- "solana-short-vec 3.2.1",
+ "solana-short-vec",
  "solana-system-interface",
  "solana-transaction-error",
  "static_assertions",
@@ -4179,7 +4179,7 @@ dependencies = [
  "solana-serde-varint",
  "solana-serialize-utils",
  "solana-sha256-hasher",
- "solana-short-vec 3.2.1",
+ "solana-short-vec",
  "solana-slot-hashes",
  "solana-slot-history",
  "solana-stable-layout",
@@ -4316,7 +4316,7 @@ dependencies = [
  "solana-seed-phrase",
  "solana-serde",
  "solana-serde-varint",
- "solana-short-vec 3.2.1",
+ "solana-short-vec",
  "solana-shred-version",
  "solana-signature",
  "solana-signer",
@@ -4463,7 +4463,7 @@ dependencies = [
  "rand 0.9.2",
  "serde",
  "serde_derive",
- "solana-short-vec 3.2.1",
+ "solana-short-vec",
 ]
 
 [[package]]
@@ -4501,12 +4501,6 @@ dependencies = [
 
 [[package]]
 name = "solana-short-vec"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3bd991c2cc415291c86bb0b6b4d53e93d13bb40344e4c5a2884e0e4f5fa93f"
-
-[[package]]
-name = "solana-short-vec"
 version = "3.2.1"
 dependencies = [
  "assert_matches",
@@ -4519,7 +4513,7 @@ dependencies = [
  "serde_json",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
- "solana-short-vec 3.2.1",
+ "solana-short-vec",
  "wincode",
 ]
 
@@ -4552,7 +4546,7 @@ dependencies = [
  "solana-frozen-abi-macro",
  "solana-pubkey",
  "solana-sanitize",
- "solana-short-vec 3.2.1",
+ "solana-short-vec",
  "solana-signature",
  "wincode",
 ]
@@ -4741,7 +4735,7 @@ dependencies = [
  "solana-sanitize",
  "solana-sdk-ids",
  "solana-sha256-hasher",
- "solana-short-vec 3.2.1",
+ "solana-short-vec",
  "solana-signature",
  "solana-signer",
  "solana-system-interface",
@@ -4796,7 +4790,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-serde-varint",
  "solana-serialize-utils",
- "solana-short-vec 3.2.1",
+ "solana-short-vec",
  "solana-system-interface",
  "solana-vote-interface",
  "test-case",
@@ -5493,7 +5487,6 @@ dependencies = [
  "pastey",
  "proc-macro2",
  "quote",
- "solana-short-vec 3.2.0",
  "thiserror 2.0.18",
  "wincode-derive",
 ]

--- a/message/Cargo.toml
+++ b/message/Cargo.toml
@@ -35,7 +35,12 @@ serde = [
     "solana-hash/serde",
     "solana-short-vec/serde",
 ]
-wincode = ["dep:wincode", "solana-hash/wincode", "solana-address/wincode"]
+wincode = [
+    "dep:wincode",
+    "solana-short-vec/wincode",
+    "solana-hash/wincode",
+    "solana-address/wincode",
+]
 
 [dependencies]
 blake3 = { workspace = true, features = ["traits-preview"], optional = true }
@@ -51,7 +56,7 @@ solana-sanitize = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-short-vec = { workspace = true, optional = true }
 solana-transaction-error = { workspace = true }
-wincode = { workspace = true, optional = true, features = ["std", "solana-short-vec"] }
+wincode = { workspace = true, optional = true, features = ["std"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/message/src/compiled_instruction.rs
+++ b/message/src/compiled_instruction.rs
@@ -2,9 +2,12 @@
 use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::AbiExample;
-#[cfg(feature = "wincode")]
-use wincode::{containers, len::ShortU16, SchemaRead, SchemaWrite};
 use {solana_address::Address, solana_sanitize::Sanitize};
+#[cfg(feature = "wincode")]
+use {
+    solana_short_vec::ShortU16,
+    wincode::{containers, SchemaRead, SchemaWrite},
+};
 
 /// A compact encoding of an instruction.
 ///

--- a/message/src/legacy.rs
+++ b/message/src/legacy.rs
@@ -29,9 +29,10 @@ use {
 #[cfg(feature = "wincode")]
 use {
     core::mem::MaybeUninit,
+    solana_short_vec::ShortU16,
     wincode::{
-        config::Config, containers, io::Reader, len::ShortU16, ReadResult, SchemaRead,
-        SchemaReadContext, SchemaWrite,
+        config::Config, containers, io::Reader, ReadResult, SchemaRead, SchemaReadContext,
+        SchemaWrite,
     },
 };
 

--- a/message/src/versions/v0/mod.rs
+++ b/message/src/versions/v0/mod.rs
@@ -14,8 +14,6 @@ pub use loaded::*;
 use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::AbiExample;
-#[cfg(feature = "wincode")]
-use wincode::{containers, len::ShortU16, SchemaRead, SchemaWrite};
 use {
     crate::{
         compiled_instruction::CompiledInstruction,
@@ -28,6 +26,11 @@ use {
     solana_sanitize::SanitizeError,
     solana_sdk_ids::bpf_loader_upgradeable,
     std::collections::HashSet,
+};
+#[cfg(feature = "wincode")]
+use {
+    solana_short_vec::ShortU16,
+    wincode::{containers, SchemaRead, SchemaWrite},
 };
 
 mod loaded;

--- a/transaction/Cargo.toml
+++ b/transaction/Cargo.toml
@@ -38,6 +38,7 @@ verify = ["blake3", "solana-signature/verify"]
 wincode = [
     "dep:solana-signer",
     "dep:wincode",
+    "solana-short-vec/wincode",
     "solana-message/wincode",
     "solana-signature/wincode",
 ]
@@ -58,7 +59,7 @@ solana-short-vec = { workspace = true, optional = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true, optional = true }
 solana-transaction-error = { workspace = true }
-wincode = { workspace = true, optional = true, features = ["solana-short-vec", "alloc"] }
+wincode = { workspace = true, optional = true, features = ["alloc"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/transaction/src/lib.rs
+++ b/transaction/src/lib.rs
@@ -128,8 +128,9 @@ pub use {
 #[cfg(feature = "wincode")]
 pub use {
     solana_hash::Hash,
+    solana_short_vec::ShortU16,
     solana_signer::{signers::Signers, SignerError},
-    wincode::{containers, len::ShortU16, SchemaRead, SchemaWrite},
+    wincode::{containers, SchemaRead, SchemaWrite},
 };
 use {
     solana_message::inline_nonce::is_advance_nonce_instruction_data,

--- a/transaction/src/versioned/mod.rs
+++ b/transaction/src/versioned/mod.rs
@@ -12,12 +12,12 @@ use {
 use {
     core::mem::MaybeUninit,
     solana_message::{v1::SIGNATURE_SIZE, MESSAGE_VERSION_PREFIX},
+    solana_short_vec::ShortU16,
     solana_signer::{signers::Signers, SignerError},
     wincode::{
         config::Config,
         containers, context,
         io::{Reader, Writer},
-        len::ShortU16,
         ReadError, ReadResult, SchemaRead, SchemaReadContext, SchemaWrite, UninitBuilder,
         WriteResult,
     },


### PR DESCRIPTION
https://github.com/anza-xyz/solana-sdk/pull/703 added `wincode` feature to `solana-short-vec` such that we can deprecate `solana-short-vec` feature from `wincode`.

Switch sdk crates to use that instead of relying on wincode's optional dependency (towards fixing https://github.com/anza-xyz/wincode/issues/303)