### PR TITLE
program-log: Remove explicit use of memory syscalls

### DIFF
--- a/program-log/src/logger.rs
+++ b/program-log/src/logger.rs
@@ -2,9 +2,7 @@ use core::{
     cmp::min, mem::MaybeUninit, ops::Deref, ptr::copy_nonoverlapping, slice::from_raw_parts,
 };
 #[cfg(any(target_os = "solana", target_arch = "bpf"))]
-use solana_define_syscall::definitions::{
-    sol_log_, sol_memcpy_, sol_memset_, sol_remaining_compute_units,
-};
+use solana_define_syscall::definitions::{sol_log_, sol_remaining_compute_units};
 
 /// Bytes for a truncated `str` log message.
 const TRUNCATED_SLICE: [u8; 3] = [b'.', b'.', b'.'];
@@ -271,13 +269,6 @@ macro_rules! impl_log_for_unsigned_integer {
 
                             // Copy the number to the buffer if no precision is specified.
                             if precision == 0 {
-                                #[cfg(any(target_os = "solana", target_arch = "bpf"))]
-                                sol_memcpy_(
-                                    ptr as *mut _,
-                                    source as *const _,
-                                    digits_to_write as u64,
-                                );
-                                #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
                                 copy_nonoverlapping(source, ptr, digits_to_write);
                             }
                             // If padding is needed to satisfy the precision, add leading zeros
@@ -291,9 +282,6 @@ macro_rules! impl_log_for_unsigned_integer {
                                     let padding = min(length - 2, precision - digits_to_write);
 
                                     // Precision padding.
-                                    #[cfg(any(target_os = "solana", target_arch = "bpf"))]
-                                    sol_memset_(ptr.add(2) as *mut _, b'0', padding as u64);
-                                    #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
                                     (ptr.add(2) as *mut u8).write_bytes(b'0', padding);
 
                                     let current = 2 + padding;
@@ -303,16 +291,6 @@ macro_rules! impl_log_for_unsigned_integer {
                                         let remaining = min(digits_to_write, length - current);
 
                                         // Number part.
-                                        #[cfg(any(target_os = "solana", target_arch = "bpf"))]
-                                        sol_memcpy_(
-                                            ptr.add(current) as *mut _,
-                                            source as *const _,
-                                            remaining as u64,
-                                        );
-                                        #[cfg(not(any(
-                                            target_os = "solana",
-                                            target_arch = "bpf"
-                                        )))]
                                         copy_nonoverlapping(source, ptr.add(current), remaining);
                                     }
                                 }
@@ -323,9 +301,6 @@ macro_rules! impl_log_for_unsigned_integer {
                                 let integer_part = digits_to_write - precision;
 
                                 // Integer part of the number.
-                                #[cfg(any(target_os = "solana", target_arch = "bpf"))]
-                                sol_memcpy_(ptr as *mut _, source as *const _, integer_part as u64);
-                                #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
                                 copy_nonoverlapping(source, ptr, integer_part);
 
                                 // Decimal point.
@@ -337,13 +312,6 @@ macro_rules! impl_log_for_unsigned_integer {
                                     let remaining = min(precision, length - current);
 
                                     // Fractional part of the number.
-                                    #[cfg(any(target_os = "solana", target_arch = "bpf"))]
-                                    sol_memcpy_(
-                                        ptr.add(current) as *mut _,
-                                        source.add(integer_part) as *const _,
-                                        remaining as u64,
-                                    );
-                                    #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
                                     copy_nonoverlapping(
                                         source.add(integer_part),
                                         ptr.add(current),
@@ -581,13 +549,6 @@ unsafe impl Log for &str {
         if length_to_write > 0 {
             // SAFETY: the `destination` is always within `length_to_write` bounds.
             unsafe {
-                #[cfg(any(target_os = "solana", target_arch = "bpf"))]
-                sol_memcpy_(
-                    destination as *mut _,
-                    source as *const _,
-                    length_to_write as u64,
-                );
-                #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
                 copy_nonoverlapping(source, destination as *mut _, length_to_write);
             }
 


### PR DESCRIPTION
### Problem

Currently, the `Logger` implementation is calling memory syscalls explicitly. This is less efficient than allowing the compiler to decide whether they are needed or not.

### Solution

Remove the explicit use of memory syscall. The compiler can decide to use them or not.