### PR TITLE
frozen-abi: add stable abi sample derive macro

### DIFF
--- a/frozen-abi-macro/src/lib.rs
+++ b/frozen-abi-macro/src/lib.rs
@@ -29,6 +29,12 @@ pub fn derive_stable_abi(_item: TokenStream) -> TokenStream {
     "".parse().unwrap()
 }
 
+#[cfg(not(feature = "frozen-abi"))]
+#[proc_macro_derive(StableAbiSample, attributes(stable_abi_sample))]
+pub fn derive_stable_abi_sample(_item: TokenStream) -> TokenStream {
+    "".parse().unwrap()
+}
+
 #[cfg(feature = "frozen-abi")]
 #[proc_macro_derive(StableAbi)]
 pub fn derive_stable_abi(item: TokenStream) -> TokenStream {
@@ -56,12 +62,28 @@ pub fn derive_stable_abi(item: TokenStream) -> TokenStream {
 }
 
 #[cfg(feature = "frozen-abi")]
+#[proc_macro_derive(StableAbiSample, attributes(stable_abi_sample))]
+pub fn derive_stable_abi_sample(item: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(item as Item);
+    match item {
+        Item::Struct(input) => derive_stable_abi_sample_struct_type(input),
+        Item::Enum(input) => derive_stable_abi_sample_enum_type(input),
+        _ => Error::new_spanned(
+            item,
+            "StableAbiSample can only be derived for struct or enum",
+        )
+        .to_compile_error()
+        .into(),
+    }
+}
+
+#[cfg(feature = "frozen-abi")]
 use proc_macro2::{Span, TokenStream as TokenStream2, TokenTree};
 #[cfg(feature = "frozen-abi")]
 use quote::{quote, ToTokens};
 #[cfg(feature = "frozen-abi")]
 use syn::{
-    parse_macro_input, Attribute, Error, Fields, Ident, Item, ItemEnum, ItemStruct, ItemType,
+    parse_macro_input, Attribute, Error, Expr, Fields, Ident, Item, ItemEnum, ItemStruct, ItemType,
     LitStr, Variant,
 };
 
@@ -112,6 +134,154 @@ fn filter_allow_attrs(attrs: &mut Vec<Attribute>) {
         let ss = &attr.path().segments.first().unwrap().ident.to_string();
         ss.starts_with("allow")
     });
+}
+
+#[cfg(feature = "frozen-abi")]
+fn parse_stable_abi_sample_override(field: &syn::Field) -> Result<Option<TokenStream2>, Error> {
+    let mut override_expr: Option<TokenStream2> = None;
+    for attr in &field.attrs {
+        if !attr.path().is_ident("stable_abi_sample") {
+            continue;
+        }
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("with") {
+                // reject duplicate `with` on the same field
+                if override_expr.is_some() {
+                    return Err(meta.error("duplicate `with` in `#[stable_abi_sample(...)]`"));
+                }
+                let value = meta.value()?.parse::<LitStr>()?;
+                let expr = value.parse::<Expr>().map_err(|err| {
+                    Error::new(value.span(), format!("invalid `with` expression: {err}"))
+                })?;
+                override_expr = Some(quote! { #expr });
+                Ok(())
+            } else {
+                Err(meta.error("unsupported `stable_abi_sample` option; expected `with = \"...\"`"))
+            }
+        })?;
+    }
+    Ok(override_expr)
+}
+
+#[cfg(feature = "frozen-abi")]
+fn stable_abi_sample_field_expr(field: &syn::Field) -> Result<TokenStream2, Error> {
+    Ok(match parse_stable_abi_sample_override(field)? {
+        Some(expr) => expr,
+        None => quote! { rng.random() },
+    })
+}
+
+#[cfg(feature = "frozen-abi")]
+fn derive_stable_abi_sample_struct_type(input: ItemStruct) -> TokenStream {
+    let type_name = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let turbofish = ty_generics.as_turbofish();
+    let sample_expr = match &input.fields {
+        Fields::Named(named_fields) => {
+            let mut fields = quote! {};
+            for field in &named_fields.named {
+                let field_name = &field.ident;
+                let field_expr = match stable_abi_sample_field_expr(field) {
+                    Ok(field_expr) => field_expr,
+                    Err(err) => return err.to_compile_error().into(),
+                };
+                fields.extend(quote! {#field_name: #field_expr,});
+            }
+            quote! {#type_name #turbofish { #fields }}
+        }
+        Fields::Unnamed(unnamed_fields) => {
+            let mut fields = quote! {};
+            for field in &unnamed_fields.unnamed {
+                let field_expr = match stable_abi_sample_field_expr(field) {
+                    Ok(field_expr) => field_expr,
+                    Err(err) => return err.to_compile_error().into(),
+                };
+                fields.extend(quote! {#field_expr,});
+            }
+            quote! {#type_name #turbofish ( #fields )}
+        }
+        Fields::Unit => quote! {#type_name #turbofish},
+    };
+    quote! {
+        #[automatically_derived]
+        impl #impl_generics ::solana_frozen_abi::rand::distr::Distribution<#type_name #ty_generics>
+            for ::solana_frozen_abi::rand::distr::StandardUniform
+            #where_clause
+        {
+            fn sample<R: ::solana_frozen_abi::rand::Rng + ?Sized>(
+                &self,
+                rng: &mut R,
+            ) -> #type_name #ty_generics {
+                #sample_expr
+            }
+        }
+    }
+    .into()
+}
+
+#[cfg(feature = "frozen-abi")]
+fn stable_abi_sample_enum_variant_expr(
+    type_name: &Ident,
+    ty_generics: &syn::TypeGenerics,
+    variant: &Variant,
+) -> Result<TokenStream2, Error> {
+    let variant_name = &variant.ident;
+    let turbofish = ty_generics.as_turbofish();
+    match &variant.fields {
+        Fields::Unit => Ok(quote! {#type_name #turbofish::#variant_name}),
+        Fields::Named(variant_fields) => {
+            let mut fields = quote! {};
+            for field in &variant_fields.named {
+                let field_name = &field.ident;
+                let field_expr = stable_abi_sample_field_expr(field)?;
+                fields.extend(quote! {#field_name: #field_expr,});
+            }
+            Ok(quote! {#type_name #turbofish::#variant_name { #fields }})
+        }
+        Fields::Unnamed(variant_fields) => {
+            let mut fields = quote! {};
+            for field in &variant_fields.unnamed {
+                let field_expr = stable_abi_sample_field_expr(field)?;
+                fields.extend(quote! {#field_expr,});
+            }
+            Ok(quote! {#type_name #turbofish::#variant_name( #fields )})
+        }
+    }
+}
+
+#[cfg(feature = "frozen-abi")]
+fn derive_stable_abi_sample_enum_type(input: ItemEnum) -> TokenStream {
+    let type_name = &input.ident;
+    let variants = &input.variants;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let variant_count = variants.len();
+    let mut match_arms = quote! {};
+    for (index, variant) in variants.iter().enumerate() {
+        let sample_expr =
+            match stable_abi_sample_enum_variant_expr(type_name, &ty_generics, variant) {
+                Ok(sample_expr) => sample_expr,
+                Err(err) => return err.to_compile_error().into(),
+            };
+        match_arms.extend(quote! {#index => #sample_expr,});
+    }
+    quote! {
+        #[automatically_derived]
+        impl #impl_generics ::solana_frozen_abi::rand::distr::Distribution<#type_name #ty_generics>
+            for ::solana_frozen_abi::rand::distr::StandardUniform
+            #where_clause
+        {
+            fn sample<R: ::solana_frozen_abi::rand::Rng + ?Sized>(
+                &self,
+                rng: &mut R,
+            ) -> #type_name #ty_generics {
+                match rng.random_range(0..#variant_count) {
+                    #match_arms
+                    _ => unreachable!(),
+                }
+            }
+        }
+    }
+    .into()
 }
 
 #[cfg(feature = "frozen-abi")]

--- a/frozen-abi-macro/src/lib.rs
+++ b/frozen-abi-macro/src/lib.rs
@@ -55,13 +55,34 @@ pub fn derive_stable_abi(item: TokenStream) -> TokenStream {
     expanded.into()
 }
 
+#[cfg(not(feature = "frozen-abi"))]
+#[proc_macro_derive(StableAbiSample, attributes(stable_abi_sample))]
+pub fn derive_stable_abi_sample(_item: TokenStream) -> TokenStream {
+    "".parse().unwrap()
+}
+
+#[cfg(feature = "frozen-abi")]
+#[proc_macro_derive(StableAbiSample, attributes(stable_abi_sample))]
+pub fn derive_stable_abi_sample(item: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(item as Item);
+    let expanded = match item {
+        Item::Struct(input) => derive_stable_abi_sample_struct_type(input),
+        Item::Enum(input) => derive_stable_abi_sample_enum_type(input),
+        _ => Err(Error::new_spanned(
+            item,
+            "StableAbiSample can only be derived for struct or enum",
+        )),
+    };
+    expanded.unwrap_or_else(|err| err.to_compile_error()).into()
+}
+
 #[cfg(feature = "frozen-abi")]
 use proc_macro2::{Span, TokenStream as TokenStream2, TokenTree};
 #[cfg(feature = "frozen-abi")]
 use quote::{quote, ToTokens};
 #[cfg(feature = "frozen-abi")]
 use syn::{
-    parse_macro_input, Attribute, Error, Fields, Ident, Item, ItemEnum, ItemStruct, ItemType,
+    parse_macro_input, Attribute, Error, Expr, Fields, Ident, Item, ItemEnum, ItemStruct, ItemType,
     LitStr, Variant,
 };
 
@@ -112,6 +133,153 @@ fn filter_allow_attrs(attrs: &mut Vec<Attribute>) {
         let ss = &attr.path().segments.first().unwrap().ident.to_string();
         ss.starts_with("allow")
     });
+}
+
+#[cfg(feature = "frozen-abi")]
+fn parse_stable_abi_sample_override(field: &syn::Field) -> Result<Option<TokenStream2>, Error> {
+    let mut override_expr: Option<TokenStream2> = None;
+    for attr in &field.attrs {
+        if !attr.path().is_ident("stable_abi_sample") {
+            continue;
+        }
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("with") {
+                // reject duplicate `with` on the same field
+                if override_expr.is_some() {
+                    return Err(meta.error("duplicate `with` in `#[stable_abi_sample(...)]`"));
+                }
+                let value = meta.value()?.parse::<LitStr>()?;
+                let expr = value.parse::<Expr>().map_err(|err| {
+                    Error::new(value.span(), format!("invalid `with` expression: {err}"))
+                })?;
+                override_expr = Some(quote! { #expr });
+                Ok(())
+            } else {
+                Err(meta.error("unsupported `stable_abi_sample` option; expected `with = \"...\"`"))
+            }
+        })?;
+    }
+    Ok(override_expr)
+}
+
+#[cfg(feature = "frozen-abi")]
+fn stable_abi_sample_field_expr(field: &syn::Field) -> Result<TokenStream2, Error> {
+    Ok(match parse_stable_abi_sample_override(field)? {
+        Some(expr) => expr,
+        None => quote! { rng.random() },
+    })
+}
+
+#[cfg(feature = "frozen-abi")]
+fn derive_stable_abi_sample_struct_type(input: ItemStruct) -> Result<TokenStream2, Error> {
+    let type_name = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let turbofish = ty_generics.as_turbofish();
+    let sample_expr = match &input.fields {
+        Fields::Named(named_fields) => {
+            let fields = named_fields
+                .named
+                .iter()
+                .map(|field| -> Result<_, Error> {
+                    let field_name = &field.ident;
+                    let field_expr = stable_abi_sample_field_expr(field)?;
+                    Ok(quote! {#field_name: #field_expr,})
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            quote! {#type_name #turbofish { #(#fields)* }}
+        }
+        Fields::Unnamed(unnamed_fields) => {
+            let fields = unnamed_fields
+                .unnamed
+                .iter()
+                .map(stable_abi_sample_field_expr)
+                .collect::<Result<Vec<_>, _>>()?;
+            quote! {#type_name #turbofish ( #(#fields),* )}
+        }
+        Fields::Unit => quote! {#type_name #turbofish},
+    };
+    Ok(quote! {
+        #[automatically_derived]
+        impl #impl_generics ::solana_frozen_abi::rand::distr::Distribution<#type_name #ty_generics>
+            for ::solana_frozen_abi::rand::distr::StandardUniform
+            #where_clause
+        {
+            fn sample<R: ::solana_frozen_abi::rand::Rng + ?Sized>(
+                &self,
+                rng: &mut R,
+            ) -> #type_name #ty_generics {
+                #sample_expr
+            }
+        }
+    })
+}
+
+#[cfg(feature = "frozen-abi")]
+fn stable_abi_sample_enum_variant_expr(
+    type_name: &Ident,
+    ty_generics: &syn::TypeGenerics,
+    variant: &Variant,
+) -> Result<TokenStream2, Error> {
+    let variant_name = &variant.ident;
+    let turbofish = ty_generics.as_turbofish();
+    match &variant.fields {
+        Fields::Unit => Ok(quote! {#type_name #turbofish::#variant_name}),
+        Fields::Named(variant_fields) => {
+            let fields = variant_fields
+                .named
+                .iter()
+                .map(|field| -> Result<_, Error> {
+                    let field_name = &field.ident;
+                    let field_expr = stable_abi_sample_field_expr(field)?;
+                    Ok(quote! {#field_name: #field_expr,})
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(quote! {#type_name #turbofish::#variant_name { #(#fields)* }})
+        }
+        Fields::Unnamed(variant_fields) => {
+            let fields = variant_fields
+                .unnamed
+                .iter()
+                .map(stable_abi_sample_field_expr)
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(quote! {#type_name #turbofish::#variant_name( #(#fields),* )})
+        }
+    }
+}
+
+#[cfg(feature = "frozen-abi")]
+fn derive_stable_abi_sample_enum_type(input: ItemEnum) -> Result<TokenStream2, Error> {
+    let type_name = &input.ident;
+    let variants = &input.variants;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let variant_count = variants.len();
+    let match_arms = variants
+        .iter()
+        .enumerate()
+        .map(|(index, variant)| -> Result<_, Error> {
+            let sample_expr =
+                stable_abi_sample_enum_variant_expr(type_name, &ty_generics, variant)?;
+            Ok(quote! {#index => #sample_expr})
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(quote! {
+        #[automatically_derived]
+        impl #impl_generics ::solana_frozen_abi::rand::distr::Distribution<#type_name #ty_generics>
+            for ::solana_frozen_abi::rand::distr::StandardUniform
+            #where_clause
+        {
+            fn sample<R: ::solana_frozen_abi::rand::Rng + ?Sized>(
+                &self,
+                rng: &mut R,
+            ) -> #type_name #ty_generics {
+                match rng.random_range(0..#variant_count) {
+                    #(#match_arms,)*
+                    _ => unreachable!(),
+                }
+            }
+        }
+    })
 }
 
 #[cfg(feature = "frozen-abi")]
@@ -311,8 +479,8 @@ pub fn derive_abi_enum_visitor(item: TokenStream) -> TokenStream {
 fn quote_for_test(
     test_mod_ident: &Ident,
     type_name: &Ident,
-    expected_api_digest: Option<&str>,
-    expected_abi_digest: Option<&str>,
+    expected_api_digest: Option<&Expr>,
+    expected_abi_digest: Option<&Expr>,
     abi_serializer: AbiSerializer,
 ) -> TokenStream2 {
     let test_api = if let Some(expected_api_digest) = expected_api_digest {
@@ -397,8 +565,8 @@ fn test_mod_name(type_name: &Ident) -> Ident {
 #[cfg(feature = "frozen-abi")]
 fn frozen_abi_type_alias(
     input: ItemType,
-    expected_api_digest: Option<&str>,
-    expected_abi_digest: Option<&str>,
+    expected_api_digest: Option<&Expr>,
+    expected_abi_digest: Option<&Expr>,
     abi_serializer: AbiSerializer,
 ) -> TokenStream {
     let type_name = &input.ident;
@@ -419,8 +587,8 @@ fn frozen_abi_type_alias(
 #[cfg(feature = "frozen-abi")]
 fn frozen_abi_struct_type(
     input: ItemStruct,
-    expected_api_digest: Option<&str>,
-    expected_abi_digest: Option<&str>,
+    expected_api_digest: Option<&Expr>,
+    expected_abi_digest: Option<&Expr>,
     abi_serializer: AbiSerializer,
 ) -> TokenStream {
     let type_name = &input.ident;
@@ -487,8 +655,8 @@ fn quote_sample_variant(
 #[cfg(feature = "frozen-abi")]
 fn frozen_abi_enum_type(
     input: ItemEnum,
-    expected_api_digest: Option<&str>,
-    expected_abi_digest: Option<&str>,
+    expected_api_digest: Option<&Expr>,
+    expected_abi_digest: Option<&Expr>,
     abi_serializer: AbiSerializer,
 ) -> TokenStream {
     let type_name = &input.ident;
@@ -509,16 +677,16 @@ fn frozen_abi_enum_type(
 #[cfg(feature = "frozen-abi")]
 #[proc_macro_attribute]
 pub fn frozen_abi(attrs: TokenStream, item: TokenStream) -> TokenStream {
-    let mut api_expected_digest: Option<String> = None;
-    let mut abi_expected_digest: Option<String> = None;
+    let mut api_expected_digest: Option<Expr> = None;
+    let mut abi_expected_digest: Option<Expr> = None;
     let mut abi_serializer = AbiSerializer::Bincode;
 
     let attrs_parser = syn::meta::parser(|meta| {
         if meta.path.is_ident("digest") || meta.path.is_ident("api_digest") {
-            api_expected_digest = Some(meta.value()?.parse::<LitStr>()?.value());
+            api_expected_digest = Some(meta.value()?.parse::<Expr>()?);
             Ok(())
         } else if meta.path.is_ident("abi_digest") {
-            abi_expected_digest = Some(meta.value()?.parse::<LitStr>()?.value());
+            abi_expected_digest = Some(meta.value()?.parse::<Expr>()?);
             Ok(())
         } else if meta.path.is_ident("abi_serializer") {
             abi_serializer = match meta.value()?.parse::<LitStr>()?.value().as_str() {
@@ -550,20 +718,20 @@ pub fn frozen_abi(attrs: TokenStream, item: TokenStream) -> TokenStream {
     match item {
         Item::Struct(input) => frozen_abi_struct_type(
             input,
-            api_expected_digest.as_deref(),
-            abi_expected_digest.as_deref(),
+            api_expected_digest.as_ref(),
+            abi_expected_digest.as_ref(),
             abi_serializer,
         ),
         Item::Enum(input) => frozen_abi_enum_type(
             input,
-            api_expected_digest.as_deref(),
-            abi_expected_digest.as_deref(),
+            api_expected_digest.as_ref(),
+            abi_expected_digest.as_ref(),
             abi_serializer,
         ),
         Item::Type(input) => frozen_abi_type_alias(
             input,
-            api_expected_digest.as_deref(),
-            abi_expected_digest.as_deref(),
+            api_expected_digest.as_ref(),
+            abi_expected_digest.as_ref(),
             abi_serializer,
         ),
         _ => Error::new_spanned(

--- a/frozen-abi/Cargo.toml
+++ b/frozen-abi/Cargo.toml
@@ -45,7 +45,7 @@ memmap2 = { workspace = true }
 # to avoid version skew and keep digest computation stable regardless of consumer dependencies.
 rand = { workspace = true }
 rand_chacha = { workspace = true }
-wincode = { workspace = true, features = ["alloc", "derive"], optional = true }
+wincode = { workspace = true, features = ["std", "alloc", "derive"], optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dev-dependencies]
 bitflags = { workspace = true, features = ["serde"] }

--- a/frozen-abi/Cargo.toml
+++ b/frozen-abi/Cargo.toml
@@ -51,6 +51,7 @@ wincode = { workspace = true, features = ["alloc", "derive"], optional = true }
 bitflags = { workspace = true, features = ["serde"] }
 serde_bytes = { workspace = true }
 serde_with = { workspace = true, features = ["macros"] }
+wincode = { workspace = true, features = ["std", "alloc", "derive"] }
 
 [lints]
 workspace = true

--- a/frozen-abi/src/lib.rs
+++ b/frozen-abi/src/lib.rs
@@ -15,9 +15,7 @@
 //! The macro would generate the `test_abi_digest` test that verifies binary layout stability:
 //! - Initializes a deterministic random number generator with fixed seed
 //! - Generates 10_000 instances of the type via `StableAbi::random()`
-//! - Serializes each instance with `bincode` by default
-//! - Types using `wincode` can switch the ABI test to `wincode` with
-//!   `#[frozen_abi(abi_serializer = "wincode", ...)]`
+//! - Serializes each instance
 //! - Hashes all serialized bytes together
 //! - Compares the resulting hash against the provided in `abi_digest` attribute
 //!
@@ -28,15 +26,51 @@
 //!
 //! ## Adding StableAbi to a New Type
 //!
-//! For types which implement `Distribution<T>` for `StandardUniform`:
+//! Deriving `StableAbi` adds:
 //!
 //! ```rust,ignore
-//! #[derive(StableAbi)]
-//! #[frozen_abi(abi_digest = "...")]
-//!    struct MyType { ... }
+//! impl ::solana_frozen_abi::stable_abi::StableAbi for MyType {}
 //! ```
 //!
-//! For types which don't, you must provide as well a custom implementation:
+//! The `StableAbi::random()` default implementation calls `rng.random::<MyType>()`, so your type
+//! also needs `Distribution<MyType> for StandardUniform`.
+//!
+//! There are two ways to provide it:
+//!
+//! 1. Derive `StableAbiSample`
+//!
+//! `StableAbiSample` auto-generates `Distribution<MyType> for StandardUniform` and, by default,
+//! tries to sample each field via `rng.random()`.
+//!
+//! ```rust,ignore
+//! #[derive(StableAbi, StableAbiSample)]
+//! #[frozen_abi(abi_digest = "...")]
+//! struct MyType {
+//!     a: u64,
+//!     b: bool,
+//!     c: [u8; 32],
+//!     d: (u8, u8),
+//! }
+//! ```
+//!
+//! Field override is optional and only needed for fields that cannot be sampled with plain
+//! `rng.random()` (for example `Vec<_>` or `HashMap<_, _>`), or when you want a specific shape.
+//!
+//! ```rust,ignore
+//! #[derive(StableAbi, StableAbiSample)]
+//! #[frozen_abi(abi_digest = "...", abi_serializer = "wincode")]
+//! struct MyTypeWithOverride {
+//!     #[stable_abi_sample(with = "rng.random::<[bool; 4]>().to_vec()")]
+//!     a: Vec<bool>,
+//!     #[stable_abi_sample(
+//!         with = "{ let mut m = std::collections::HashMap::new(); m.insert(rng.random(), rng.random()); m }"
+//!     )]
+//!     b: std::collections::HashMap<u64, bool>,
+//!     c: [u8; 32],
+//! }
+//! ```
+//!
+//! 2. Write a manual `Distribution` implementation
 //!
 //! ```rust,ignore
 //! #[cfg(feature = "frozen-abi")]
@@ -52,21 +86,27 @@
 //!    }
 //! ```
 //!
-//! Deriving the `StableAbi` adds the following impl, which comes with the default `random()`
-//! implementation:
+//! For `wincode`-based types, add `abi_serializer = "wincode"` to `#[frozen_abi(...)]`.
 //!
 //! ```rust,ignore
-//! impl ::solana_frozen_abi::stable_abi::StableAbi for MyType {}
+//! #[derive(StableAbi, StableAbiSample, wincode::SchemaWrite)]
+//! #[frozen_abi(
+//!     api_digest = "...",
+//!     abi_digest = "...",
+//!     abi_serializer = "wincode",
+//! )]
+//! struct MyWincodeType {
+//!     a: u64,
+//!     b: bool,
+//! }
 //! ```
-//!
-//! For `wincode`-based types, add `abi_serializer = "wincode"` to `#[frozen_abi(...)]`.
 //!
 //! ## Edge Cases
 //!
 //! 1. It will not detect field name or order changes, nor same size type swaps (e.g., `i64`
 //!    and `u64`). These cases are still covered by `AbiExample`
-//! 2. The implementor must ensure a consistent order of `rng.random()` calls, as any change
-//!    will result in different hash
+//! 2. The implementor must ensure a consistent order of `rng.random()` calls in case of manual implementation
+//!    or with overrides, as any change to these will result in different hash
 //! 3. For collection types with non deterministic ordering (e.g., `HashMap`), it is recommended
 //!    to insert only one item to avoid false positives caused by iteration order differences
 

--- a/frozen-abi/src/lib.rs
+++ b/frozen-abi/src/lib.rs
@@ -15,9 +15,7 @@
 //! The macro would generate the `test_abi_digest` test that verifies binary layout stability:
 //! - Initializes a deterministic random number generator with fixed seed
 //! - Generates 10_000 instances of the type via `StableAbi::random()`
-//! - Serializes each instance with `bincode` by default
-//! - Types using `wincode` can switch the ABI test to `wincode` with
-//!   `#[frozen_abi(abi_serializer = "wincode", ...)]`
+//! - Serializes each instance
 //! - Hashes all serialized bytes together
 //! - Compares the resulting hash against the provided in `abi_digest` attribute
 //!
@@ -28,15 +26,52 @@
 //!
 //! ## Adding StableAbi to a New Type
 //!
-//! For types which implement `Distribution<T>` for `StandardUniform`:
+//! Deriving `StableAbi` adds:
 //!
 //! ```rust,ignore
-//! #[derive(StableAbi)]
-//! #[frozen_abi(abi_digest = "...")]
-//!    struct MyType { ... }
+//! impl ::solana_frozen_abi::stable_abi::StableAbi for MyType {}
 //! ```
 //!
-//! For types which don't, you must provide as well a custom implementation:
+//! The `StableAbi::random()` default implementation calls `rng.random::<MyType>()`, so your type
+//! also needs `Distribution<MyType> for StandardUniform`.
+//!
+//! There are two ways to provide it:
+//!
+//! 1. Derive `StableAbiSample`
+//!
+//! `StableAbiSample` auto-generates `Distribution<MyType> for StandardUniform` and, by default,
+//! tries to sample each field via `rng.random()`.
+//!
+//! ```rust,ignore
+//! #[derive(StableAbi, StableAbiSample)]
+//! #[frozen_abi(abi_digest = "...")]
+//! struct MyType {
+//!     a: u64,
+//!     b: bool,
+//!     c: [u8; 32],
+//!     d: (u8, u8),
+//! }
+//! ```
+//!
+//! Field override is optional and only needed for fields that cannot be sampled with plain
+//! `rng.random()` (for example `Vec<_>` or `HashMap<_, _>`), or when you want a specific shape.
+//!
+//! ```rust,ignore
+//! #[derive(StableAbi, StableAbiSample)]
+//! #[frozen_abi(abi_digest = "...", abi_serializer = "wincode")]
+//! struct MyTypeWithOverride {
+//!     #[stable_abi_sample(
+//!         with = "(0..rng.random::<u8>() % 4).map(|_| rng.random::<bool>()).collect()")]
+//!     a: Vec<bool>,
+//!     #[stable_abi_sample(
+//!         with = "std::collections::HashMap::from_iter([(rng.random(), rng.random())])"
+//!     )]
+//!     b: std::collections::HashMap<u64, bool>,
+//!     c: [u8; 32],
+//! }
+//! ```
+//!
+//! 2. Write a manual `Distribution` implementation
 //!
 //! ```rust,ignore
 //! #[cfg(feature = "frozen-abi")]
@@ -52,21 +87,27 @@
 //!    }
 //! ```
 //!
-//! Deriving the `StableAbi` adds the following impl, which comes with the default `random()`
-//! implementation:
+//! For `wincode`-based types, add `abi_serializer = "wincode"` to `#[frozen_abi(...)]`.
 //!
 //! ```rust,ignore
-//! impl ::solana_frozen_abi::stable_abi::StableAbi for MyType {}
+//! #[derive(StableAbi, StableAbiSample, wincode::SchemaWrite)]
+//! #[frozen_abi(
+//!     api_digest = "...",
+//!     abi_digest = "...",
+//!     abi_serializer = "wincode",
+//! )]
+//! struct MyWincodeType {
+//!     a: u64,
+//!     b: bool,
+//! }
 //! ```
-//!
-//! For `wincode`-based types, add `abi_serializer = "wincode"` to `#[frozen_abi(...)]`.
 //!
 //! ## Edge Cases
 //!
 //! 1. It will not detect field name or order changes, nor same size type swaps (e.g., `i64`
 //!    and `u64`). These cases are still covered by `AbiExample`
-//! 2. The implementor must ensure a consistent order of `rng.random()` calls, as any change
-//!    will result in different hash
+//! 2. The implementor must ensure a consistent order of `rng.random()` calls in case of manual implementation
+//!    or with overrides, as any change to these will result in different hash
 //! 3. For collection types with non deterministic ordering (e.g., `HashMap`), it is recommended
 //!    to insert only one item to avoid false positives caused by iteration order differences
 

--- a/frozen-abi/src/stable_abi.rs
+++ b/frozen-abi/src/stable_abi.rs
@@ -85,7 +85,7 @@ mod tests {
                     }
                 }
             }
-        };
+        }
     }
 
     linked_stable_abi_pair!(
@@ -123,5 +123,129 @@ mod tests {
                 d: rng.random(),
             }
         }
+    }
+
+    // Verify stable abi sample derive (all fields with rand distribution)
+    #[derive(wincode::SchemaWrite)]
+    #[cfg_attr(
+        feature = "frozen-abi",
+        derive(
+            solana_frozen_abi_macro::StableAbi,
+            solana_frozen_abi_macro::StableAbiSample
+        ),
+        solana_frozen_abi_macro::frozen_abi(
+            abi_digest = "AgNkEpErnFBuy7iTAEUUAC1fbvokEkhbsfFnx4DtXAvY",
+            abi_serializer = "wincode",
+        )
+    )]
+    struct TestStableAbiSampleSimple {
+        a: u64,
+        b: bool,
+        c: [u8; 32],
+        d: (u8, u8),
+    }
+
+    #[derive(wincode::SchemaWrite)]
+    #[cfg_attr(
+        feature = "frozen-abi",
+        derive(
+            solana_frozen_abi_macro::StableAbi,
+            solana_frozen_abi_macro::StableAbiSample
+        ),
+        solana_frozen_abi_macro::frozen_abi(
+            abi_digest = "CuEDjcfdYbKAoxSV9QeQDv9K71mKgitE28CwvB4PAM3S",
+            abi_serializer = "wincode",
+        )
+    )]
+    enum TestStableAbiSampleEnumSimple {
+        A,
+        B(u64),
+        C(u8, u16, u32, u64),
+        D(f64),
+    }
+
+    #[derive(wincode::SchemaWrite)]
+    #[cfg_attr(
+        feature = "frozen-abi",
+        derive(
+            solana_frozen_abi_macro::StableAbi,
+            solana_frozen_abi_macro::StableAbiSample
+        ),
+        solana_frozen_abi_macro::frozen_abi(
+            abi_digest = "2XwyJT2T6oDWtStC8n9EfDMk8wHBExsX4AoBS5uRf74u",
+            abi_serializer = "wincode",
+        )
+    )]
+    enum TestStableAbiSampleEnumNamed {
+        A,
+        B { a: u64, b: bool },
+    }
+
+    // Verify stable abi sample derive (fields mixed, mostly without implementation of rand distribution)
+    #[derive(wincode::SchemaWrite)]
+    #[cfg_attr(
+        feature = "frozen-abi",
+        derive(
+            solana_frozen_abi_macro::StableAbi,
+            solana_frozen_abi_macro::StableAbiSample
+        ),
+        solana_frozen_abi_macro::frozen_abi(
+            abi_digest = "EVb5Tgy4rZzifSr6cE8HX3K8Zy6w9PD9hamvo3G9Ue7D",
+            abi_serializer = "wincode",
+        )
+    )]
+    struct TestStableAbiSampleOverride {
+        #[stable_abi_sample(with = "rng.random::<[bool; 4]>().to_vec()")]
+        a: Vec<bool>,
+        #[stable_abi_sample(
+            with = "{ let mut m = std::collections::HashMap::new(); m.insert(rng.random(), rng.random()); m }"
+        )]
+        b: std::collections::HashMap<u64, bool>,
+        #[stable_abi_sample(with = "rng.random::<u64>()")]
+        c: u64,
+        d: u16,
+    }
+
+    #[derive(wincode::SchemaWrite)]
+    #[cfg_attr(
+        feature = "frozen-abi",
+        derive(
+            solana_frozen_abi_macro::StableAbi,
+            solana_frozen_abi_macro::StableAbiSample
+        ),
+        solana_frozen_abi_macro::frozen_abi(
+            abi_digest = "DTzLXmgVsieme1R1gFBF3NBckeeXfqR7hrkiMyWXUK7M",
+            abi_serializer = "wincode",
+        )
+    )]
+    enum TestStableAbiSampleEnumOverride {
+        A,
+        B(u64),
+        C(#[stable_abi_sample(with = "rng.random::<[bool; 4]>().to_vec()")] Vec<bool>),
+    }
+
+    #[derive(wincode::SchemaWrite)]
+    #[cfg_attr(
+        feature = "frozen-abi",
+        derive(
+            solana_frozen_abi_macro::StableAbi,
+            solana_frozen_abi_macro::StableAbiSample
+        ),
+        solana_frozen_abi_macro::frozen_abi(
+            abi_digest = "NDiMpkrAEM4QN3GkELuBzxdCwCtVz6gp3pjFuiGtTWD",
+            abi_serializer = "wincode",
+        )
+    )]
+    enum TestStableAbiSampleEnumNamedOverride {
+        A,
+        B {
+            a: u64,
+            b: bool,
+        },
+        C {
+            #[stable_abi_sample(with = "rng.random::<[bool; 4]>().to_vec()")]
+            a: Vec<bool>,
+            b: u16,
+        },
     }
 }

--- a/frozen-abi/src/stable_abi.rs
+++ b/frozen-abi/src/stable_abi.rs
@@ -11,6 +11,8 @@ pub trait StableAbi: Sized {
 
 #[cfg(all(test, feature = "frozen-abi"))]
 mod tests {
+    use std::collections::{BTreeMap, VecDeque};
+
     // Keep the bincode and wincode test fixtures structurally identical so their
     // derived `test_abi_digest` checks enforce one shared ABI digest across serializers.
     #[rustfmt::skip]
@@ -85,7 +87,7 @@ mod tests {
                     }
                 }
             }
-        };
+        }
     }
 
     linked_stable_abi_pair!(
@@ -123,5 +125,232 @@ mod tests {
                 d: rng.random(),
             }
         }
+    }
+
+    // Verify stable abi sample derive (all fields with rand distribution)
+    #[derive(wincode::SchemaWrite)]
+    #[cfg_attr(
+        feature = "frozen-abi",
+        derive(
+            solana_frozen_abi_macro::StableAbi,
+            solana_frozen_abi_macro::StableAbiSample
+        ),
+        solana_frozen_abi_macro::frozen_abi(
+            abi_digest = "AgNkEpErnFBuy7iTAEUUAC1fbvokEkhbsfFnx4DtXAvY",
+            abi_serializer = "wincode",
+        )
+    )]
+    struct TestStableAbiSampleSimple {
+        a: u64,
+        b: bool,
+        c: [u8; 32],
+        d: (u8, u8),
+    }
+
+    #[derive(wincode::SchemaWrite)]
+    #[cfg_attr(
+        feature = "frozen-abi",
+        derive(
+            solana_frozen_abi_macro::StableAbi,
+            solana_frozen_abi_macro::StableAbiSample
+        ),
+        solana_frozen_abi_macro::frozen_abi(
+            abi_digest = "CuEDjcfdYbKAoxSV9QeQDv9K71mKgitE28CwvB4PAM3S",
+            abi_serializer = "wincode",
+        )
+    )]
+    enum TestStableAbiSampleEnumSimple {
+        A,
+        B(u64),
+        C(u8, u16, u32, u64),
+        D(f64),
+    }
+
+    #[derive(wincode::SchemaWrite)]
+    #[cfg_attr(
+        feature = "frozen-abi",
+        derive(
+            solana_frozen_abi_macro::StableAbi,
+            solana_frozen_abi_macro::StableAbiSample
+        ),
+        solana_frozen_abi_macro::frozen_abi(
+            abi_digest = "2XwyJT2T6oDWtStC8n9EfDMk8wHBExsX4AoBS5uRf74u",
+            abi_serializer = "wincode",
+        )
+    )]
+    enum TestStableAbiSampleEnumNamed {
+        A,
+        B { a: u64, b: bool },
+    }
+
+    // Verify stable abi sample derive (fields mixed, mostly without implementation of rand distribution)
+    #[derive(wincode::SchemaWrite)]
+    #[cfg_attr(
+        feature = "frozen-abi",
+        derive(
+            solana_frozen_abi_macro::StableAbi,
+            solana_frozen_abi_macro::StableAbiSample
+        ),
+        solana_frozen_abi_macro::frozen_abi(
+            abi_digest = "Da7uAdhapexEgWf4xxKLrYXhnYU9g6CKpRSbrzFWDg6a",
+            abi_serializer = "wincode",
+        )
+    )]
+    struct TestStableAbiSampleOverride {
+        #[stable_abi_sample(
+            with = "(0..rng.random::<u8>() % 4).map(|_| rng.random::<bool>()).collect()"
+        )]
+        a: Vec<bool>,
+        // Keep a single entry so HashMap iteration order cannot affect the digest.
+        #[stable_abi_sample(
+            with = "std::collections::HashMap::from_iter([(rng.random(), rng.random())])"
+        )]
+        b: std::collections::HashMap<u64, bool>,
+        #[stable_abi_sample(with = "rng.random::<u64>()")]
+        c: u64,
+        d: u16,
+    }
+
+    #[derive(wincode::SchemaWrite)]
+    #[cfg_attr(
+        feature = "frozen-abi",
+        derive(
+            solana_frozen_abi_macro::StableAbi,
+            solana_frozen_abi_macro::StableAbiSample
+        ),
+        solana_frozen_abi_macro::frozen_abi(
+            abi_digest = "DTzLXmgVsieme1R1gFBF3NBckeeXfqR7hrkiMyWXUK7M",
+            abi_serializer = "wincode",
+        )
+    )]
+    enum TestStableAbiSampleEnumOverride {
+        A,
+        B(u64),
+        C(#[stable_abi_sample(with = "rng.random::<[bool; 4]>().to_vec()")] Vec<bool>),
+    }
+
+    #[derive(wincode::SchemaWrite)]
+    #[cfg_attr(
+        feature = "frozen-abi",
+        derive(
+            solana_frozen_abi_macro::StableAbi,
+            solana_frozen_abi_macro::StableAbiSample
+        ),
+        solana_frozen_abi_macro::frozen_abi(
+            abi_digest = "NDiMpkrAEM4QN3GkELuBzxdCwCtVz6gp3pjFuiGtTWD",
+            abi_serializer = "wincode",
+        )
+    )]
+    enum TestStableAbiSampleEnumNamedOverride {
+        A,
+        B {
+            a: u64,
+            b: bool,
+        },
+        C {
+            #[stable_abi_sample(with = "rng.random::<[bool; 4]>().to_vec()")]
+            a: Vec<bool>,
+            b: u16,
+        },
+    }
+
+    const ABI_DIGEST_EQUIVALENT_FIELD_STRUCTURES: &str =
+        "G7kuFGzwY6HwSytv6UsjWVEAbhrfv2n2gmchE27mSRiM";
+    #[derive(Debug, wincode::SchemaWrite)]
+    #[cfg_attr(
+                feature = "frozen-abi",
+                derive(solana_frozen_abi_macro::StableAbi, solana_frozen_abi_macro::StableAbiSample),
+                solana_frozen_abi_macro::frozen_abi(
+                    abi_digest = ABI_DIGEST_EQUIVALENT_FIELD_STRUCTURES,
+                    abi_serializer = "wincode",
+                )
+            )]
+    struct TestEquivalentWincodeStruct {
+        a: u8,
+        b: u64,
+        c: (u8, [u8; 3]),
+    }
+
+    #[derive(Debug, serde_derive::Serialize)]
+    #[cfg_attr(
+                feature = "frozen-abi",
+                derive(solana_frozen_abi_macro::StableAbi, solana_frozen_abi_macro::StableAbiSample),
+                solana_frozen_abi_macro::frozen_abi(
+                    abi_digest = ABI_DIGEST_EQUIVALENT_FIELD_STRUCTURES,
+                    abi_serializer = "bincode",
+                )
+            )]
+    struct TestEquivalentBincodeTuple(u8, u64, u8, [u8; 3]);
+
+    const ABI_DIGEST_EQUIVALENT_BYTE_SEQUENCES: &str =
+        "14qLvWX4UebbLBaKi6v31A8xDfXU8ifX8DqCGbpAwjtD";
+    #[derive(Debug, wincode::SchemaWrite)]
+    #[cfg_attr(
+                feature = "frozen-abi",
+                derive(solana_frozen_abi_macro::StableAbi, solana_frozen_abi_macro::StableAbiSample),
+                solana_frozen_abi_macro::frozen_abi(
+                    abi_digest = ABI_DIGEST_EQUIVALENT_BYTE_SEQUENCES,
+                    abi_serializer = "wincode",
+                )
+            )]
+    struct TestEquivalentCollectionsWincode {
+        #[stable_abi_sample(
+            with = "(0..rng.random::<u8>() % 4).map(|_| rng.random::<u8>()).collect()"
+        )]
+        a: Vec<u8>,
+        b: bool,
+    }
+
+    #[derive(Debug, serde_derive::Serialize)]
+    #[cfg_attr(
+                feature = "frozen-abi",
+                derive(solana_frozen_abi_macro::StableAbi, solana_frozen_abi_macro::StableAbiSample),
+                solana_frozen_abi_macro::frozen_abi(
+                    abi_digest = ABI_DIGEST_EQUIVALENT_BYTE_SEQUENCES,
+                    abi_serializer = "bincode",
+                )
+            )]
+    struct TestEquivalentCollectionsBincode(
+        #[stable_abi_sample(
+            with = "(0..rng.random::<u8>() % 4).map(|_| rng.random::<u8>()).collect()"
+        )]
+        VecDeque<u8>,
+        bool,
+    );
+
+    const ABI_DIGEST_EQUIVALENT_KEY_VALUE_SEQUENCES: &str =
+        "9pGP5GGD2HxDRCQeDv3rPGTfVH9SzkZCXMSGHpZnzz4G";
+    #[derive(Debug, wincode::SchemaWrite)]
+    #[cfg_attr(
+                feature = "frozen-abi",
+                derive(solana_frozen_abi_macro::StableAbi, solana_frozen_abi_macro::StableAbiSample),
+                solana_frozen_abi_macro::frozen_abi(
+                    abi_digest = ABI_DIGEST_EQUIVALENT_KEY_VALUE_SEQUENCES,
+                    abi_serializer = "wincode",
+                )
+            )]
+    struct TestEquivalentBTreeMapVsVecWincode {
+        #[stable_abi_sample(
+            with = "(0..rng.random::<u16>() % 4).map(|i| (((i << 8) + rng.random::<u8>() as u16), rng.random())).collect()"
+        )]
+        a: BTreeMap<u16, u8>,
+        b: bool,
+    }
+
+    #[derive(Debug, serde_derive::Serialize)]
+    #[cfg_attr(
+                feature = "frozen-abi",
+                derive(solana_frozen_abi_macro::StableAbi, solana_frozen_abi_macro::StableAbiSample),
+                solana_frozen_abi_macro::frozen_abi(
+                    abi_digest = ABI_DIGEST_EQUIVALENT_KEY_VALUE_SEQUENCES,
+                    abi_serializer = "bincode",
+                )
+            )]
+    struct TestEquivalentBTreeMapVsVecBincode {
+        #[stable_abi_sample(
+            with = "(0..rng.random::<u16>() % 4).map(|i| (((i << 8) + rng.random::<u8>() as u16), rng.random())).collect()"
+        )]
+        a: Vec<(u16, u8)>,
+        b: bool,
     }
 }


### PR DESCRIPTION
### Description

There was no way to derive rand distribution implementation, which is required by `StableAbi` tests.

### Summary of changes
- extended docs and tests
- added stable abi sample derive macro, which allow for providing `with=` parameter with override as needed
- changed literal to expression in digests