### PR TITLE
[BLS] update screening doc; improve security boundary

### DIFF
--- a/bls-signatures/README.md
+++ b/bls-signatures/README.md
@@ -13,7 +13,7 @@ It is primarily intended for use in the Solana Alpenglow consensus protocol, but
 - **Aggregate Verification & Screening:** Optimized multi-miller loop algorithms for verifying aggregated signatures against shared messages (multisig) or screening multiple distinct-message signatures via aggregate relations.
 - Supports aggregate screening of distinct-message signature sets. Note that `verify_distinct` and its variants provide screening guarantees only and do not imply individual signature validity per signer. See the API documentation for details.
 - **Parallelization:** Optional `rayon` integration to speed up multi-scalar multiplications (MSMs) and heavy verification loops.
-- **Rogue-Key Attack Prevention:** Type-safe wrappers like `PopVerified` ensure that aggregation only occurs with keys that have proven their Proof of Possession.
+- **Rogue-Key Attack Prevention:** Crate-provided aggregation APIs require `PopVerified` keys, and crate-provided `VerifySignature` implementations are limited to PoP-verified wrappers.
 
 ---
 
@@ -118,7 +118,9 @@ A well-known vulnerability in BLS signature aggregation is the Rogue Key Attack.
 
 One mitigation is to require a Proof of Possession (PoP) from every participant. A PoP is a cryptographic proof that the creator of a public key actually controls the corresponding private key.
 
-To prevent accidental vulnerabilities and the aggregation of unverified keys, the aggregation and verification APIs strictly require the `PopVerified<T>` wrapper type. You cannot mathematically aggregate public keys in this crate without first proving you've verified their PoP.
+To prevent accidental vulnerabilities and the aggregation of unverified keys, the aggregation APIs require the `PopVerified<T>` wrapper type. You cannot mathematically aggregate public keys through this crate's aggregation APIs without first proving you've verified their PoP.
+
+For single-signature verification, `VerifySignature` remains a public extension trait. This crate only implements it for `PopVerified<T>` and aggregate public-key wrappers, not for its raw public key types. Downstream crates can still implement the trait for their own key wrappers; doing so is an explicit convention boundary, not a hard type-system guarantee from this crate. Avoid implementing `VerifySignature` for unverified key wrappers in code paths that rely on PoP validation, aggregation safety, signer attribution, rewards, or penalties.
 
 ```rust
 use solana_bls_signatures::{
@@ -137,8 +139,8 @@ let pop = keypair.proof_of_possession(None);
 // Assume we receive the raw public key bytes, signature, and PoP over the network
 let raw_pubkey: Pubkey = (*keypair.public).into();
 
-// ❌ THIS WILL FAIL TO COMPILE!
-// The type system prevents using unverified keys for signature verification.
+// ❌ THIS WILL FAIL TO COMPILE with this crate's raw public key types.
+// The crate does not implement `VerifySignature` for unverified raw public keys.
 // raw_pubkey.verify_signature(&signature, message).unwrap();
 
 // 3. Verify the PoP. Upon success, it returns a `PopVerified` wrapper,

--- a/bls-signatures/benches/bls_signatures.rs
+++ b/bls-signatures/benches/bls_signatures.rs
@@ -168,9 +168,9 @@ fn bench_proof_of_possession(c: &mut Criterion) {
     });
 }
 
-// Benchmark for batch verification functions
-fn bench_batch_verification(c: &mut Criterion) {
-    let mut group = c.benchmark_group("batch_verify");
+// Benchmark for `verify_distinct` aggregate screening functions.
+fn bench_aggregate_screening(c: &mut Criterion) {
+    let mut group = c.benchmark_group("aggregate_screening");
 
     for num_validators in [64, 128, 256, 512, 1024, 2048].iter() {
         let keypairs: Vec<Keypair> = (0..*num_validators).map(|_| Keypair::new()).collect();
@@ -199,7 +199,7 @@ fn bench_batch_verification(c: &mut Criterion) {
             .collect();
 
         group.bench_function(
-            format!("{num_validators} sequential batch verification"),
+            format!("{num_validators} sequential aggregate screening"),
             |b| {
                 b.iter(|| {
                     SignatureProjective::verify_distinct(
@@ -213,7 +213,7 @@ fn bench_batch_verification(c: &mut Criterion) {
         );
 
         group.bench_function(
-            format!("{num_validators} sequential batch verification (pre-hashed)"),
+            format!("{num_validators} sequential aggregate screening (pre-hashed)"),
             |b| {
                 b.iter(|| {
                     SignatureProjective::verify_distinct_pre_hashed(
@@ -227,7 +227,7 @@ fn bench_batch_verification(c: &mut Criterion) {
         );
 
         group.bench_function(
-            format!("{num_validators} sequential batch verification (prepared)"),
+            format!("{num_validators} sequential aggregate screening (prepared)"),
             |b| {
                 b.iter(|| {
                     SignatureProjective::verify_distinct_prepared(
@@ -245,7 +245,7 @@ fn bench_batch_verification(c: &mut Criterion) {
             let message_refs: Vec<&[u8]> = messages.iter().map(|v| v.as_slice()).collect();
 
             group.bench_function(
-                format!("{num_validators} parallel batch verification"),
+                format!("{num_validators} parallel aggregate screening"),
                 |b| {
                     b.iter(|| {
                         SignatureProjective::par_verify_distinct(
@@ -268,6 +268,6 @@ criterion_group!(
     bench_aggregate,
     bench_key_generation,
     bench_proof_of_possession,
-    bench_batch_verification
+    bench_aggregate_screening
 );
 criterion_main!(benches);

--- a/bls-signatures/src/macros.rs
+++ b/bls-signatures/src/macros.rs
@@ -559,6 +559,8 @@ macro_rules! impl_unchecked_conversions {
 macro_rules! impl_pubkey_wrapper_delegations {
     ($wrapper:ident) => {
         #[cfg(not(target_os = "solana"))]
+        // `VerifySignature` remains public, but this crate only implements it for
+        // wrappers whose construction represents the PoP-verified safety boundary.
         impl<T: AsPubkeyAffine + ?Sized> VerifySignature for $wrapper<T> {}
 
         #[cfg(not(target_os = "solana"))]

--- a/bls-signatures/src/pubkey/verify.rs
+++ b/bls-signatures/src/pubkey/verify.rs
@@ -60,9 +60,16 @@ pub trait VerifyPop: AsPubkeyAffine + Sized {
 // Blanket implementation so any raw key can attempt to prove itself
 impl<T: AsPubkeyAffine> VerifyPop for T {}
 
-/// A trait that provides signature verification methods exclusively to safe public key types.
+/// A trait that provides signature verification methods to public-key-like types.
+///
+/// The crate-provided implementations are intentionally limited to `PopVerified<T>` and
+/// aggregate public-key wrappers, so raw public key types from this crate do not gain
+/// direct signature-verification methods before PoP verification. This trait remains public
+/// as an extension point for downstream key wrappers. Implementing it for an unverified key
+/// type opts out of the crate's PoP-verified usage convention and can reintroduce rogue-key
+/// risks in aggregation or signer-attribution flows.
 pub trait VerifySignature: AsPubkeyAffine {
-    /// Uses this safe public key to verify any convertible signature type.
+    /// Uses this public key to verify any convertible signature type.
     fn verify_signature<S: AsSignatureAffine>(
         &self,
         signature: &S,
@@ -72,7 +79,7 @@ pub trait VerifySignature: AsPubkeyAffine {
         self.verify_signature_pre_hashed(signature, &hashed_message)
     }
 
-    /// Uses this safe public key to verify any convertible signature type using a pre-hashed message.
+    /// Uses this public key to verify any convertible signature type using a pre-hashed message.
     fn verify_signature_pre_hashed<S: AsSignatureAffine>(
         &self,
         signature: &S,
@@ -82,7 +89,7 @@ pub trait VerifySignature: AsPubkeyAffine {
         self.verify_signature_prepared(signature, &prepared_hashed_message)
     }
 
-    /// Uses this safe public key to verify any convertible signature type using a prepared message.
+    /// Uses this public key to verify any convertible signature type using a prepared message.
     fn verify_signature_prepared<S: AsSignatureAffine>(
         &self,
         signature: &S,

--- a/bls-signatures/src/signature/mod.rs
+++ b/bls-signatures/src/signature/mod.rs
@@ -791,7 +791,7 @@ mod tests {
             .verify_signature(&id_sig_proj, test_message)
             .is_err());
 
-        // Batch verification with an identity public key must fail
+        // Aggregate screening with an identity public key must fail
         let pubkey_affine: PubkeyAffine = *keypair.public;
         let id_pubkey_affine: PubkeyAffine = id_pubkey_proj.try_as_affine().unwrap();
 
@@ -829,7 +829,7 @@ mod tests {
                 messages.into_iter()
             )
             .is_err(),
-            "Batch distinct verification containing an identity public key must fail"
+            "Aggregate screening containing an identity public key must fail"
         );
     }
 

--- a/bls-signatures/src/signature/verify.rs
+++ b/bls-signatures/src/signature/verify.rs
@@ -9,7 +9,11 @@ use rayon::prelude::*;
 
 /// A trait that provides verification methods to any convertible signature type.
 pub trait VerifiableSignature: AsSignatureAffine + Sized {
-    /// Verify the signature against any convertible public key type and a message.
+    /// Verify the signature against a public key type that implements `VerifySignature`.
+    ///
+    /// This follows the same convention as `VerifySignature`: crate-provided public key
+    /// verification is exposed through PoP-verified wrappers, while downstream
+    /// implementations are an explicit extension point.
     fn verify<P: VerifySignature>(&self, pubkey: &P, message: &[u8]) -> Result<(), BlsError> {
         pubkey.verify_signature(self, message)
     }
@@ -61,7 +65,7 @@ impl SignatureProjective {
         let aggregate_pubkey = PubkeyProjective::aggregate(public_keys)?;
         let aggregate_signature = SignatureProjective::aggregate(signatures)?;
 
-        // This is safe because AggregatePubkey implements VerifySignature!
+        // AggregatePubkey is the crate-provided aggregate wrapper implementing VerifySignature.
         aggregate_pubkey.verify_signature_prepared(&aggregate_signature, prepared_hashed_message)
     }
 

--- a/bls-signatures/tests/ethereum_vectors.rs
+++ b/bls-signatures/tests/ethereum_vectors.rs
@@ -235,18 +235,19 @@ fn ethereum_fast_aggregate_verify_vectors() {
 }
 
 #[test]
-fn ethereum_batch_verify_vectors() {
+fn ethereum_aggregate_screening_compatibility_vectors() {
+    // Ethereum calls this fixture suite `batch_verify`. In this crate, the matching
+    // `verify_distinct` APIs are aggregate screening checks: they verify the aggregate
+    // relation for the supplied key/message/signature set and do not provide RLC-style
+    // weighted batch verification or per-signer validity guarantees.
     for path in json_files("batch_verify") {
         let case = load_case(&path);
         let input = &case["input"];
         let expected = case["output"].as_bool().unwrap();
         let case_id = path.file_stem().unwrap().to_str().unwrap();
 
-        // Our current batch API intentionally omits RLC-style weighting and relies on
-        // upstream PoP guarantees instead. Ethereum's negative `batch_verify` vectors
-        // include stricter semantics that target weighted batch verification, so this
-        // compatibility test only asserts the positive cases that `verify_distinct`
-        // is expected to support.
+        // Ethereum's negative vectors include stricter semantics than aggregate
+        // screening supports, so this compatibility test only asserts positive cases.
         if !expected {
             continue;
         }

--- a/bls-signatures/tests/fetch_ethereum_vectors.py
+++ b/bls-signatures/tests/fetch_ethereum_vectors.py
@@ -15,6 +15,9 @@ ARCHIVE_URL = (
     f"https://github.com/ethereum/bls12-381-tests/releases/download/{VERSION}/"
     "bls_tests_json.tar.gz"
 )
+# These are upstream Ethereum fixture directory names. The `batch_verify` suite
+# name is retained for compatibility; it does not describe this crate's
+# `verify_distinct` aggregate-screening API.
 REQUIRED_DIRS = (
     "aggregate",
     "aggregate_verify",


### PR DESCRIPTION
This PR addresses audit documentation findings around BLS verification semantics.

- It clarifies that `verify_distinct` and related APIs provide aggregate screening guarantees, not CHP12-style weighted batch verification or per-signer validity guarantees. 
- It also clarifies the `VerifySignature` safety boundary while keeping `VerifySignature` public: crate-provided implementations are limited to `PopVerified<T>` and aggregate public-key wrappers, but downstream implementations remain an explicit extension point.