### PR TITLE
transaction: prepend v1 message byte in SanitizedTransaction::message_data

### DIFF
--- a/message/src/versions/mod.rs
+++ b/message/src/versions/mod.rs
@@ -652,8 +652,8 @@ mod tests {
 
             let message = builder.build().unwrap();
 
-            // Serialize V1 to raw bytes.
-            let bytes = v1::serialize(&message);
+            // Serialize V1 to raw bytes (without the version prefix).
+            let bytes = wincode::serialize(&message).unwrap();
             // Deserialize from raw bytes.
             let parsed = v1::deserialize(&bytes).unwrap();
 

--- a/message/src/versions/v1/message.rs
+++ b/message/src/versions/v1/message.rs
@@ -391,6 +391,12 @@ impl Message {
         crate::is_program_id_write_demoted(i, &self.account_keys, &self.instructions)
     }
 
+    /// Serialize this message with the V1 version prefix byte.
+    #[cfg(feature = "wincode")]
+    pub fn serialize(&self) -> Vec<u8> {
+        wincode::serialize(&(crate::v1::V1_PREFIX, self)).unwrap()
+    }
+
     /// Calculate the serialized size of the message in bytes.
     #[allow(clippy::arithmetic_side_effects)]
     #[inline(always)]

--- a/message/src/versions/v1/message.rs
+++ b/message/src/versions/v1/message.rs
@@ -588,6 +588,7 @@ unsafe impl<C: ConfigCore> SchemaWrite<C> for Message {
 /// Serialize the message.
 #[cfg(feature = "wincode")]
 #[inline]
+#[deprecated(since = "4.1.2", note = "use `Message::serialize` instead")]
 pub fn serialize(message: &Message) -> Vec<u8> {
     wincode::serialize(message).unwrap()
 }
@@ -1233,7 +1234,7 @@ mod tests {
         ];
 
         for message in &test_cases {
-            assert_eq!(message.size(), serialize(message).len());
+            assert_eq!(message.size(), wincode::serialize(message).unwrap().len());
         }
     }
 
@@ -1255,7 +1256,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let bytes = serialize(&message);
+        let bytes = wincode::serialize(&message).unwrap();
 
         // Build expected bytes manually per SIMD-0385
         //
@@ -1298,7 +1299,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let bytes = serialize(&message);
+        let bytes = wincode::serialize(&message).unwrap();
 
         let mut expected = vec![1, 0, 0];
         // ConfigMask: priority fee (bits 0,1) + CU limit (bit 2) = 0b111 = 7
@@ -1337,7 +1338,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let serialized = serialize(&message);
+        let serialized = wincode::serialize(&message).unwrap();
         let deserialized = deserialize(&serialized).unwrap();
         assert_eq!(message.config, deserialized.config);
     }

--- a/transaction/src/sanitized.rs
+++ b/transaction/src/sanitized.rs
@@ -272,7 +272,7 @@ impl SanitizedTransaction {
         match &self.message {
             SanitizedMessage::Legacy(legacy_message) => legacy_message.message.serialize(),
             SanitizedMessage::V0(loaded_msg) => loaded_msg.message.serialize(),
-            SanitizedMessage::V1(cached_msg) => v1::serialize(&cached_msg.message),
+            SanitizedMessage::V1(cached_msg) => cached_msg.message.serialize(),
         }
     }
 
@@ -327,6 +327,7 @@ impl SanitizedTransaction {
 mod tests {
     use {
         super::*,
+        solana_instruction::{AccountMeta, Instruction},
         solana_keypair::Keypair,
         solana_message::{MessageHeader, SimpleAddressLoader},
         solana_signer::Signer,
@@ -452,5 +453,35 @@ mod tests {
             )
             .is_ok());
         }
+    }
+
+    #[test]
+    fn test_verify_v1_message_data_includes_prefix() {
+        let payer = Keypair::new();
+        let program_id = Address::new_unique();
+        let instruction = Instruction::new_with_bytes(
+            program_id,
+            &[1, 2, 3],
+            vec![AccountMeta::new(payer.pubkey(), true)],
+        );
+        let message =
+            v1::Message::try_compile(&payer.pubkey(), &[instruction], Hash::new_unique()).unwrap();
+        let versioned_tx =
+            VersionedTransaction::try_new(VersionedMessage::V1(message), &[&payer]).unwrap();
+
+        let sanitized = SanitizedTransaction::try_create(
+            versioned_tx,
+            MessageHash::Compute,
+            None,
+            SimpleAddressLoader::Disabled,
+            &HashSet::default(),
+        )
+        .unwrap();
+
+        // The signed bytes must begin with the V1 version prefix.
+        let signed_bytes = sanitized.message_data();
+        assert_eq!(signed_bytes[0], solana_message::v1::V1_PREFIX);
+
+        sanitized.verify().unwrap();
     }
 }


### PR DESCRIPTION
While testing v1 transactions I found that the preflight sigverify would fail. Transactions would land and confirm, but only with `skipPreflight: true` in the RPC request. This is because the bytes being signed at the RPC sigverify were just `v1::serialize`, which excludes the version byte.

This PR adds `serialize` for the v1 versioned message, which prepends the v1 message byte to `v1::serialize`. We then update `SanitizedTransaction::message_data` to use `cached_msg.message.serialize()`, matching the v0 branch, instead of calling `v1::serialize` directly.

Testing locally, this enables sending v1 transactions without `skipPreflight`.