### PR TITLE
define-syscall: allow trailing commas in macros

### DIFF
--- a/define-syscall/src/lib.rs
+++ b/define-syscall/src/lib.rs
@@ -9,7 +9,7 @@ pub mod definitions;
 ))]
 #[macro_export]
 macro_rules! define_syscall {
-    ($(#[$attr:meta])* fn $name:ident($($arg:ident: $typ:ty),*) -> $ret:ty) => {
+    ($(#[$attr:meta])* fn $name:ident($($arg:ident: $typ:ty),* $(,)?) -> $ret:ty) => {
         $(#[$attr])*
         #[inline]
         pub unsafe fn $name($($arg: $typ),*) -> $ret {
@@ -24,7 +24,7 @@ macro_rules! define_syscall {
         }
 
     };
-    ($(#[$attr:meta])* fn $name:ident($($arg:ident: $typ:ty),*)) => {
+    ($(#[$attr:meta])* fn $name:ident($($arg:ident: $typ:ty),* $(,)?)) => {
         define_syscall!($(#[$attr])* fn $name($($arg: $typ),*) -> ());
     }
 }
@@ -35,13 +35,13 @@ macro_rules! define_syscall {
 )))]
 #[macro_export]
 macro_rules! define_syscall {
-    ($(#[$attr:meta])* fn $name:ident($($arg:ident: $typ:ty),*) -> $ret:ty) => {
+    ($(#[$attr:meta])* fn $name:ident($($arg:ident: $typ:ty),* $(,)?) -> $ret:ty) => {
         extern "C" {
             $(#[$attr])*
             pub fn $name($($arg: $typ),*) -> $ret;
         }
     };
-    ($(#[$attr:meta])* fn $name:ident($($arg:ident: $typ:ty),*)) => {
+    ($(#[$attr:meta])* fn $name:ident($($arg:ident: $typ:ty),* $(,)?)) => {
         define_syscall!($(#[$attr])* fn $name($($arg: $typ),*) -> ());
     }
 }


### PR DESCRIPTION
This pull request updates the `define_syscall!` macro to allow for an optional trailing comma in the argument list. 

This change improves flexibility and consistency with Rust's macro conventions.

Closes: #705 Fixes #701

cc: @joncinque 