### PR TITLE
feat(sysvar): support wincode schemas for serializable types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4715,6 +4715,7 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "test-case",
+ "wincode",
 ]
 
 [[package]]

--- a/sysvar/Cargo.toml
+++ b/sysvar/Cargo.toml
@@ -32,6 +32,20 @@ serde = [
     "solana-slot-hashes/serde",
     "solana-slot-history/serde",
 ]
+wincode = [
+    "dep:wincode",
+    "wincode/alloc",
+    "solana-clock/wincode",
+    "solana-epoch-rewards/wincode",
+    "solana-epoch-schedule/wincode",
+    "solana-fee-calculator/wincode",
+    "solana-hash/wincode",
+    "solana-last-restart-slot/wincode",
+    "solana-pubkey/wincode",
+    "solana-rent/wincode",
+    "solana-slot-hashes/wincode",
+    "solana-slot-history/wincode",
+]
 
 [dependencies]
 bincode = { workspace = true, optional = true }
@@ -58,6 +72,7 @@ solana-sdk-macro = { workspace = true }
 solana-slot-hashes = { workspace = true, features = ["sysvar"] }
 solana-slot-history = { workspace = true, features = ["sysvar"] }
 solana-sysvar-id = { workspace = true }
+wincode = { workspace = true, optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 base64 = { workspace = true }

--- a/sysvar/src/fees.rs
+++ b/sysvar/src/fees.rs
@@ -41,6 +41,7 @@ impl_deprecated_sysvar_id!(Fees);
 )]
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Debug, CloneZeroed, Default, PartialEq, Eq)]
 pub struct Fees {
     pub fee_calculator: FeeCalculator,

--- a/sysvar/src/recent_blockhashes.rs
+++ b/sysvar/src/recent_blockhashes.rs
@@ -45,6 +45,7 @@ impl_sysvar_id!(RecentBlockhashes);
 )]
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Entry {
     pub blockhash: Hash,
@@ -96,6 +97,7 @@ impl PartialOrd for IterItem<'_> {
 )]
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RecentBlockhashes(Vec<Entry>);
 

--- a/sysvar/src/rewards.rs
+++ b/sysvar/src/rewards.rs
@@ -10,6 +10,7 @@ impl_sysvar_id!(Rewards);
 
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Debug, Default, PartialEq)]
 pub struct Rewards {
     pub validator_point_value: f64,


### PR DESCRIPTION
`SysvarSerialize` isn't touched, since we won't use it for wincode serialization. However a few types should get schema annotations.