### PR TITLE
no-std feature: solana-serialize-utils

### DIFF
--- a/scripts/check-no-std.sh
+++ b/scripts/check-no-std.sh
@@ -48,6 +48,7 @@ no_std_alloc_crates=(
   -p solana-borsh
   -p solana-curve25519
   -p solana-instruction
+  -p solana-serialize-utils
 )
 
 # Use the upstream BPF target, which doesn't support std, to make sure that our

--- a/serialize-utils/Cargo.toml
+++ b/serialize-utils/Cargo.toml
@@ -12,6 +12,10 @@ edition = { workspace = true }
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[features]
+default = ["std"]
+std = []
+
 [dependencies]
 solana-instruction-error = { workspace = true }
 solana-pubkey = { workspace = true, default-features = false }

--- a/serialize-utils/src/cursor.rs
+++ b/serialize-utils/src/cursor.rs
@@ -104,7 +104,11 @@ pub fn read_bool<T: AsRef<[u8]>>(cursor: &mut Cursor<T>) -> Result<bool, Instruc
 
 #[cfg(test)]
 mod test {
-    use {super::*, rand::Rng, std::fmt::Debug};
+    use {
+        super::*,
+        rand::Rng,
+        std::{fmt::Debug, vec::Vec},
+    };
 
     #[test]
     fn test_read_u8() {

--- a/serialize-utils/src/lib.rs
+++ b/serialize-utils/src/lib.rs
@@ -1,11 +1,11 @@
 //! Helpers for reading and writing bytes.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::arithmetic_side_effects)]
 
 extern crate alloc;
-#[cfg(test)]
+#[cfg(feature = "std")]
 extern crate std;
 
 use {alloc::vec::Vec, solana_pubkey::Pubkey, solana_sanitize::SanitizeError};

--- a/serialize-utils/src/lib.rs
+++ b/serialize-utils/src/lib.rs
@@ -1,9 +1,16 @@
 //! Helpers for reading and writing bytes.
 
+#![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::arithmetic_side_effects)]
-use {solana_pubkey::Pubkey, solana_sanitize::SanitizeError};
 
+extern crate alloc;
+#[cfg(test)]
+extern crate std;
+
+use {alloc::vec::Vec, solana_pubkey::Pubkey, solana_sanitize::SanitizeError};
+
+#[cfg(feature = "std")]
 pub mod cursor;
 
 pub fn append_u16(buf: &mut Vec<u8>, data: u16) {
@@ -36,7 +43,7 @@ pub fn read_u8(current: &mut usize, data: &[u8]) -> Result<u8, SanitizeError> {
 }
 
 pub fn read_pubkey(current: &mut usize, data: &[u8]) -> Result<Pubkey, SanitizeError> {
-    let len = std::mem::size_of::<Pubkey>();
+    let len = core::mem::size_of::<Pubkey>();
     if data.len() < *current + len {
         return Err(SanitizeError::IndexOutOfBounds);
     }


### PR DESCRIPTION
Putting standard library usage behind a feature flag so consumers can do a no-std build. 

This is a dep of solana-instructions-sysvar which is a dep of token-2022-interface.