### PR TITLE
no-std instructions-sysvar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3897,7 +3897,6 @@ dependencies = [
  "solana-instruction",
  "solana-instruction-error",
  "solana-program-error",
- "solana-pubkey",
  "solana-sanitize",
  "solana-sdk-ids",
  "solana-serialize-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -311,7 +311,7 @@ solana-seed-derivable = { path = "seed-derivable", version = "3.0.0" }
 solana-seed-phrase = { path = "seed-phrase", version = "3.0.0" }
 solana-serde = { path = "serde", version = "3.0.0" }
 solana-serde-varint = { path = "serde-varint", version = "3.0.1" }
-solana-serialize-utils = { path = "serialize-utils", version = "3.1.0" }
+solana-serialize-utils = { path = "serialize-utils", version = "3.1.2", default-features = false }
 solana-sha256-hasher = { path = "sha256-hasher", version = "3.0.0" }
 solana-sha512-hasher = { path = "sha512-hasher", version = "1.0.1" }
 solana-short-vec = { path = "short-vec", version = "3.2.1", default-features = false }

--- a/instructions-sysvar/Cargo.toml
+++ b/instructions-sysvar/Cargo.toml
@@ -20,10 +20,9 @@ dev-context-only-utils = ["dep:qualifier_attr"]
 [dependencies]
 qualifier_attr = { workspace = true, optional = true }
 solana-account-info = { workspace = true }
-solana-instruction = { workspace = true, default-features = false, features = ["std"] }
+solana-instruction = { workspace = true, default-features = false }
 solana-instruction-error = { workspace = true }
 solana-program-error = { workspace = true }
-solana-pubkey = { workspace = true, default-features = false }
 solana-sanitize = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-serialize-utils = { workspace = true }

--- a/instructions-sysvar/src/lib.rs
+++ b/instructions-sysvar/src/lib.rs
@@ -29,23 +29,27 @@
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::arithmetic_side_effects)]
+#![no_std]
+
+extern crate alloc;
 
 #[cfg(feature = "dev-context-only-utils")]
 use qualifier_attr::qualifiers;
 pub use solana_sdk_ids::sysvar::instructions::{check_id, id, ID};
-#[cfg(not(target_os = "solana"))]
 use {
-    bitflags::bitflags,
-    solana_instruction::BorrowedInstruction,
-    solana_serialize_utils::{append_slice, append_u16, append_u8},
-};
-use {
+    alloc::vec::Vec,
     solana_account_info::AccountInfo,
     solana_instruction::{AccountMeta, Instruction},
     solana_instruction_error::InstructionError,
     solana_program_error::ProgramError,
     solana_sanitize::SanitizeError,
     solana_serialize_utils::{read_pubkey, read_slice, read_u16, read_u8},
+};
+#[cfg(not(target_os = "solana"))]
+use {
+    bitflags::bitflags,
+    solana_instruction::BorrowedInstruction,
+    solana_serialize_utils::{append_slice, append_u16, append_u8},
 };
 
 /// Instructions sysvar, dummy type.
@@ -297,6 +301,7 @@ pub fn get_instruction_relative(
 mod tests {
     use {
         super::*,
+        alloc::vec,
         solana_account_info::AccountInfo,
         solana_address::Address,
         solana_instruction::{AccountMeta, BorrowedAccountMeta, BorrowedInstruction, Instruction},

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -79,7 +79,7 @@ solana-rent = { workspace = true, features = ["serde", "sysvar"] }
 solana-sdk-ids = { workspace = true }
 solana-secp256k1-recover = { workspace = true }
 solana-serde-varint = { workspace = true }
-solana-serialize-utils = { workspace = true }
+solana-serialize-utils = { workspace = true, features = ["std"] }
 solana-sha256-hasher = { workspace = true, features = ["sha2"] }
 solana-short-vec = { workspace = true }
 solana-slot-hashes = { workspace = true, features = ["serde", "sysvar"] }

--- a/scripts/check-no-std.sh
+++ b/scripts/check-no-std.sh
@@ -48,6 +48,7 @@ no_std_alloc_crates=(
   -p solana-borsh
   -p solana-curve25519
   -p solana-instruction
+  -p solana-instructions-sysvar
   -p solana-serialize-utils
 )
 

--- a/vote-interface/Cargo.toml
+++ b/vote-interface/Cargo.toml
@@ -63,12 +63,12 @@ solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-serde-varint = { workspace = true, optional = true }
-solana-serialize-utils = { workspace = true, optional = true }
+solana-serialize-utils = { workspace = true, optional = true, features = ["std"] }
 solana-short-vec = { workspace = true, optional = true }
 solana-system-interface = { workspace = true, features = ["bincode"], optional = true }
 
 [target.'cfg(target_os = "solana")'.dependencies]
-solana-serialize-utils = { workspace = true }
+solana-serialize-utils = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 itertools = { workspace = true }


### PR DESCRIPTION
Following https://github.com/anza-xyz/solana-sdk/pull/723, `solana-instructions-sysvar` can be made no-std.