### PR TITLE
address: derive stableabi on address

### DIFF
--- a/address/src/lib.rs
+++ b/address/src/lib.rs
@@ -84,7 +84,14 @@ pub const PDA_MARKER: &[u8; 21] = b"ProgramDerivedAddress";
 /// [pdas]: https://solana.com/docs/core/cpi#program-derived-addresses
 /// [`Keypair`]: https://docs.rs/solana-sdk/latest/solana_sdk/signer/keypair/struct.Keypair.html
 #[repr(transparent)]
-#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(
+        solana_frozen_abi_macro::AbiExample,
+        solana_frozen_abi_macro::StableAbi,
+        solana_frozen_abi_macro::StableAbiSample
+    )
+)]
 #[cfg_attr(
     feature = "borsh",
     derive(BorshSerialize, BorshDeserialize),


### PR DESCRIPTION
### Issue

Missing StableAbi implementation for commonly used `Address` type.

### Summary of changes
- derived `StableAbi` and `StableAbiSample`