### PR TITLE
frozen-abi: fix stable abi tests block formatting

### DIFF
--- a/frozen-abi/src/stable_abi.rs
+++ b/frozen-abi/src/stable_abi.rs
@@ -188,7 +188,7 @@ mod tests {
                     }
                 }
             }
-        }
+        };
     }
 
     linked_stable_abi_pair!(
@@ -359,13 +359,13 @@ mod tests {
         "G7kuFGzwY6HwSytv6UsjWVEAbhrfv2n2gmchE27mSRiM";
     #[derive(Debug, wincode::SchemaWrite)]
     #[cfg_attr(
-                feature = "frozen-abi",
-                derive(solana_frozen_abi_macro::StableAbi, solana_frozen_abi_macro::StableAbiSample),
-                solana_frozen_abi_macro::frozen_abi(
-                    abi_digest = ABI_DIGEST_EQUIVALENT_FIELD_STRUCTURES,
-                    abi_serializer = "wincode",
-                )
-            )]
+        feature = "frozen-abi",
+        derive(solana_frozen_abi_macro::StableAbi, solana_frozen_abi_macro::StableAbiSample),
+        solana_frozen_abi_macro::frozen_abi(
+            abi_digest = ABI_DIGEST_EQUIVALENT_FIELD_STRUCTURES,
+            abi_serializer = "wincode",
+        )
+    )]
     struct TestEquivalentWincodeStruct {
         a: u8,
         b: u64,
@@ -374,26 +374,26 @@ mod tests {
 
     #[derive(Debug, serde_derive::Serialize)]
     #[cfg_attr(
-                feature = "frozen-abi",
-                derive(solana_frozen_abi_macro::StableAbi, solana_frozen_abi_macro::StableAbiSample),
-                solana_frozen_abi_macro::frozen_abi(
-                    abi_digest = ABI_DIGEST_EQUIVALENT_FIELD_STRUCTURES,
-                    abi_serializer = "bincode",
-                )
-            )]
+        feature = "frozen-abi",
+        derive(solana_frozen_abi_macro::StableAbi, solana_frozen_abi_macro::StableAbiSample),
+        solana_frozen_abi_macro::frozen_abi(
+            abi_digest = ABI_DIGEST_EQUIVALENT_FIELD_STRUCTURES,
+            abi_serializer = "bincode",
+        )
+    )]
     struct TestEquivalentBincodeTuple(u8, u64, u8, [u8; 3]);
 
     const ABI_DIGEST_EQUIVALENT_BYTE_SEQUENCES: &str =
         "14qLvWX4UebbLBaKi6v31A8xDfXU8ifX8DqCGbpAwjtD";
     #[derive(Debug, wincode::SchemaWrite)]
     #[cfg_attr(
-                feature = "frozen-abi",
-                derive(solana_frozen_abi_macro::StableAbi, solana_frozen_abi_macro::StableAbiSample),
-                solana_frozen_abi_macro::frozen_abi(
-                    abi_digest = ABI_DIGEST_EQUIVALENT_BYTE_SEQUENCES,
-                    abi_serializer = "wincode",
-                )
-            )]
+        feature = "frozen-abi",
+        derive(solana_frozen_abi_macro::StableAbi, solana_frozen_abi_macro::StableAbiSample),
+        solana_frozen_abi_macro::frozen_abi(
+            abi_digest = ABI_DIGEST_EQUIVALENT_BYTE_SEQUENCES,
+            abi_serializer = "wincode",
+        )
+    )]
     struct TestEquivalentCollectionsWincode {
         #[stable_abi_sample(
             with = "(0..rng.random::<u8>() % 4).map(|_| rng.random::<u8>()).collect()"
@@ -404,13 +404,13 @@ mod tests {
 
     #[derive(Debug, serde_derive::Serialize)]
     #[cfg_attr(
-                feature = "frozen-abi",
-                derive(solana_frozen_abi_macro::StableAbi, solana_frozen_abi_macro::StableAbiSample),
-                solana_frozen_abi_macro::frozen_abi(
-                    abi_digest = ABI_DIGEST_EQUIVALENT_BYTE_SEQUENCES,
-                    abi_serializer = "bincode",
-                )
-            )]
+        feature = "frozen-abi",
+        derive(solana_frozen_abi_macro::StableAbi, solana_frozen_abi_macro::StableAbiSample),
+        solana_frozen_abi_macro::frozen_abi(
+            abi_digest = ABI_DIGEST_EQUIVALENT_BYTE_SEQUENCES,
+            abi_serializer = "bincode",
+        )
+    )]
     struct TestEquivalentCollectionsBincode(
         #[stable_abi_sample(
             with = "(0..rng.random::<u8>() % 4).map(|_| rng.random::<u8>()).collect()"
@@ -423,13 +423,13 @@ mod tests {
         "9pGP5GGD2HxDRCQeDv3rPGTfVH9SzkZCXMSGHpZnzz4G";
     #[derive(Debug, wincode::SchemaWrite)]
     #[cfg_attr(
-                feature = "frozen-abi",
-                derive(solana_frozen_abi_macro::StableAbi, solana_frozen_abi_macro::StableAbiSample),
-                solana_frozen_abi_macro::frozen_abi(
-                    abi_digest = ABI_DIGEST_EQUIVALENT_KEY_VALUE_SEQUENCES,
-                    abi_serializer = "wincode",
-                )
-            )]
+        feature = "frozen-abi",
+        derive(solana_frozen_abi_macro::StableAbi, solana_frozen_abi_macro::StableAbiSample),
+        solana_frozen_abi_macro::frozen_abi(
+            abi_digest = ABI_DIGEST_EQUIVALENT_KEY_VALUE_SEQUENCES,
+            abi_serializer = "wincode",
+        )
+    )]
     struct TestEquivalentBTreeMapVsVecWincode {
         #[stable_abi_sample(
             with = "(0..rng.random::<u16>() % 4).map(|i| (((i << 8) + rng.random::<u8>() as u16), rng.random())).collect()"
@@ -440,13 +440,13 @@ mod tests {
 
     #[derive(Debug, serde_derive::Serialize)]
     #[cfg_attr(
-                feature = "frozen-abi",
-                derive(solana_frozen_abi_macro::StableAbi, solana_frozen_abi_macro::StableAbiSample),
-                solana_frozen_abi_macro::frozen_abi(
-                    abi_digest = ABI_DIGEST_EQUIVALENT_KEY_VALUE_SEQUENCES,
-                    abi_serializer = "bincode",
-                )
-            )]
+        feature = "frozen-abi",
+        derive(solana_frozen_abi_macro::StableAbi, solana_frozen_abi_macro::StableAbiSample),
+        solana_frozen_abi_macro::frozen_abi(
+            abi_digest = ABI_DIGEST_EQUIVALENT_KEY_VALUE_SEQUENCES,
+            abi_serializer = "bincode",
+        )
+    )]
     struct TestEquivalentBTreeMapVsVecBincode {
         #[stable_abi_sample(
             with = "(0..rng.random::<u16>() % 4).map(|i| (((i << 8) + rng.random::<u8>() as u16), rng.random())).collect()"


### PR DESCRIPTION
### Issue

Incorrect indentation in block with StableAbi test types


### Summary of changes
- Fixed formatting