### PR TITLE
expose sec-p params

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4397,13 +4397,11 @@ version = "3.0.1"
 dependencies = [
  "anyhow",
  "bincode",
- "digest",
  "hex",
  "k256",
  "rand 0.8.5",
  "serde",
  "serde_derive",
- "sha3",
  "solana-account-info",
  "solana-example-mocks",
  "solana-instruction",

--- a/scripts/build-sbf.sh
+++ b/scripts/build-sbf.sh
@@ -16,7 +16,6 @@ build_sbf_excludes=(
   --exclude solana-presigner
   --exclude solana-sdk-wasm-js
   --exclude solana-sdk-wasm-js-tests
-  --exclude solana-secp256k1-program
   --exclude solana-secp256r1-program
   --exclude solana-system-transaction
   --exclude solana-system-wasm-js

--- a/scripts/check-no-std.sh
+++ b/scripts/check-no-std.sh
@@ -35,6 +35,7 @@ no_std_crates=(
   -p solana-rent
   -p solana-sanitize
   -p solana-sdk-ids
+  -p solana-secp256k1-program
   -p solana-sha256-hasher
   -p solana-signature
   -p solana-sysvar-id

--- a/secp256k1-program/Cargo.toml
+++ b/secp256k1-program/Cargo.toml
@@ -20,11 +20,13 @@ dev-context-only-utils = ["bincode"]
 serde = ["dep:serde", "dep:serde_derive"]
 
 [dependencies]
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
+
+[target.'cfg(not(any(target_os = "solana", target_arch = "bpf")))'.dependencies]
 bincode = { workspace = true, optional = true }
 digest = { workspace = true }
 k256 = { workspace = true, features = ["ecdsa-core"] }
-serde = { workspace = true, optional = true }
-serde_derive = { workspace = true, optional = true }
 sha3 = { workspace = true }
 solana-instruction = { workspace = true, features = ["std"], optional = true }
 solana-sdk-ids = { workspace = true, optional = true }
@@ -42,3 +44,6 @@ solana-keccak-hasher = { workspace = true, features = ["sha3"] }
 solana-msg = { workspace = true, features = ["std"] }
 solana-program-error = { workspace = true }
 solana-secp256k1-program = { path = ".", features = ["bincode"] }
+
+[lints]
+workspace = true

--- a/secp256k1-program/Cargo.toml
+++ b/secp256k1-program/Cargo.toml
@@ -20,14 +20,13 @@ dev-context-only-utils = ["bincode"]
 serde = ["dep:serde", "dep:serde_derive"]
 
 [dependencies]
+solana-keccak-hasher = { workspace = true, features = ["sha3"] }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 
 [target.'cfg(not(any(target_os = "solana", target_arch = "bpf")))'.dependencies]
 bincode = { workspace = true, optional = true }
-digest = { workspace = true }
 k256 = { workspace = true, features = ["ecdsa-core"] }
-sha3 = { workspace = true }
 solana-instruction = { workspace = true, features = ["std"], optional = true }
 solana-sdk-ids = { workspace = true, optional = true }
 solana-signature = { workspace = true, features = ["std"] }
@@ -40,7 +39,6 @@ solana-account-info = { workspace = true }
 solana-example-mocks = { path = "../example-mocks" }
 solana-instruction = { workspace = true }
 solana-instructions-sysvar = { workspace = true }
-solana-keccak-hasher = { workspace = true, features = ["sha3"] }
 solana-msg = { workspace = true, features = ["std"] }
 solana-program-error = { workspace = true }
 solana-secp256k1-program = { path = ".", features = ["bincode"] }

--- a/secp256k1-program/Cargo.toml
+++ b/secp256k1-program/Cargo.toml
@@ -20,9 +20,9 @@ dev-context-only-utils = ["bincode"]
 serde = ["dep:serde", "dep:serde_derive"]
 
 [dependencies]
-solana-keccak-hasher = { workspace = true, features = ["sha3"] }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
+solana-keccak-hasher = { workspace = true, features = ["sha3"] }
 
 [target.'cfg(not(any(target_os = "solana", target_arch = "bpf")))'.dependencies]
 bincode = { workspace = true, optional = true }

--- a/secp256k1-program/src/lib.rs
+++ b/secp256k1-program/src/lib.rs
@@ -799,7 +799,7 @@ use serde_derive::{Deserialize, Serialize};
 ))]
 use solana_instruction::Instruction;
 #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
-use {digest::Digest, solana_signature::error::Error};
+use solana_signature::error::Error;
 
 pub const SECP256K1_PUBKEY_SIZE: usize = 64;
 pub const SECP256K1_PRIVATE_KEY_SIZE: usize = 32;
@@ -841,11 +841,7 @@ pub fn sign_message(
 ) -> Result<([u8; SIGNATURE_SERIALIZED_SIZE], u8), Error> {
     let priv_key = k256::ecdsa::SigningKey::from_slice(priv_key_bytes)
         .map_err(|e| Error::from_source(format!("{e}")))?;
-    let mut hasher = sha3::Keccak256::new();
-    hasher.update(message);
-    let message_hash = hasher.finalize();
-    let mut message_hash_arr = [0u8; 32];
-    message_hash_arr.copy_from_slice(message_hash.as_slice());
+    let message_hash_arr = solana_keccak_hasher::hash(message).to_bytes();
     let (signature, recovery_id) = priv_key
         .sign_prehash_recoverable(&message_hash_arr)
         .map_err(|e| Error::from_source(format!("{e}")))?;
@@ -906,12 +902,37 @@ pub fn new_secp256k1_instruction_with_signature(
 }
 
 /// Creates an Ethereum address from a secp256k1 public key.
-#[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
 pub fn eth_address_from_pubkey(
     pubkey: &[u8; SECP256K1_PUBKEY_SIZE],
 ) -> [u8; HASHED_PUBKEY_SERIALIZED_SIZE] {
+    let pubkey_hash = solana_keccak_hasher::hash(pubkey);
+    let address_offset = solana_keccak_hasher::HASH_BYTES - HASHED_PUBKEY_SERIALIZED_SIZE;
     let mut addr = [0u8; HASHED_PUBKEY_SERIALIZED_SIZE];
-    addr.copy_from_slice(&sha3::Keccak256::digest(pubkey)[12..]);
-    assert_eq!(addr.len(), HASHED_PUBKEY_SERIALIZED_SIZE);
+    addr.copy_from_slice(&pubkey_hash.as_bytes()[address_offset..]);
     addr
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_eth_address_from_pubkey() {
+        // Secp256k1 generator
+        let pubkey = [
+            0x79, 0xbe, 0x66, 0x7e, 0xf9, 0xdc, 0xbb, 0xac, 0x55, 0xa0, 0x62, 0x95, 0xce, 0x87,
+            0x0b, 0x07, 0x02, 0x9b, 0xfc, 0xdb, 0x2d, 0xce, 0x28, 0xd9, 0x59, 0xf2, 0x81, 0x5b,
+            0x16, 0xf8, 0x17, 0x98, 0x48, 0x3a, 0xda, 0x77, 0x26, 0xa3, 0xc4, 0x65, 0x5d, 0xa4,
+            0xfb, 0xfc, 0x0e, 0x11, 0x08, 0xa8, 0xfd, 0x17, 0xb4, 0x48, 0xa6, 0x85, 0x54, 0x19,
+            0x9c, 0x47, 0xd0, 0x8f, 0xfb, 0x10, 0xd4, 0xb8,
+        ];
+        // keccak256(pubkey)[12..32] = 0x7e5f4552091a69125d5dfcb7b8c2659029395bdf
+        assert_eq!(
+            eth_address_from_pubkey(&pubkey),
+            [
+                0x7e, 0x5f, 0x45, 0x52, 0x09, 0x1a, 0x69, 0x12, 0x5d, 0x5d, 0xfc, 0xb7, 0xb8, 0xc2,
+                0x65, 0x90, 0x29, 0x39, 0x5b, 0xdf,
+            ]
+        );
+    }
 }

--- a/secp256k1-program/src/lib.rs
+++ b/secp256k1-program/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(any(target_os = "solana", target_arch = "bpf"), no_std)]
 //! Instructions for the [secp256k1 native program][np].
 //!
 //! [np]: https://docs.solanalabs.com/runtime/programs#secp256k1-program
@@ -117,12 +118,16 @@
 //! - 0 or more bytes of arbitrary data, which may contain signatures,
 //!   messages or Ethereum addresses.
 //!
-//! The signature offset structure is defined by [`SecpSignatureOffsets`],
-//! and can be serialized to the correct format with [`bincode::serialize_into`].
-//! Note that the bincode format may not be stable,
-//! and callers should ensure they use the same version of `bincode` as the Solana SDK.
-//! This data structure is not provided to Solana programs,
-//! which are expected to interpret the signature offsets manually.
+//! The signature offset structure is defined by [`SecpSignatureOffsets`].
+//! Host clients can serialize it to the correct format with
+//! [`bincode::serialize_into`] by enabling the `bincode` feature. Note that the
+//! bincode format may not be stable, and callers should ensure they use the
+//! same version of `bincode` as the Solana SDK.
+//!
+//! Solana programs can use this crate for the offset structure and layout
+//! constants, but should still parse the 11-byte little-endian wire format
+//! explicitly. [`SecpSignatureOffsets`] is not a packed view of the instruction
+//! data bytes.
 //!
 //! [`bincode::serialize_into`]: https://docs.rs/bincode/1.3.3/bincode/fn.serialize_into.html
 //!
@@ -788,8 +793,12 @@
 
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
-#[cfg(feature = "bincode")]
+#[cfg(all(
+    feature = "bincode",
+    not(any(target_os = "solana", target_arch = "bpf"))
+))]
 use solana_instruction::Instruction;
+#[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
 use {digest::Digest, solana_signature::error::Error};
 
 pub const SECP256K1_PUBKEY_SIZE: usize = 64;
@@ -825,6 +834,7 @@ pub struct SecpSignatureOffsets {
 }
 
 /// Signs a message from the given private key bytes
+#[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
 pub fn sign_message(
     priv_key_bytes: &[u8; SECP256K1_PRIVATE_KEY_SIZE],
     message: &[u8],
@@ -842,7 +852,10 @@ pub fn sign_message(
     Ok((signature.to_bytes().into(), recovery_id.to_byte()))
 }
 
-#[cfg(feature = "bincode")]
+#[cfg(all(
+    feature = "bincode",
+    not(any(target_os = "solana", target_arch = "bpf"))
+))]
 pub fn new_secp256k1_instruction_with_signature(
     message_arr: &[u8],
     signature: &[u8; SIGNATURE_SERIALIZED_SIZE],
@@ -893,6 +906,7 @@ pub fn new_secp256k1_instruction_with_signature(
 }
 
 /// Creates an Ethereum address from a secp256k1 public key.
+#[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
 pub fn eth_address_from_pubkey(
     pubkey: &[u8; SECP256K1_PUBKEY_SIZE],
 ) -> [u8; HASHED_PUBKEY_SERIALIZED_SIZE] {


### PR DESCRIPTION
as discussed here https://github.com/solana-program/secp256k1/pull/1#discussion_r3270320618

we want to expose `SecpSignatureOffsets` via `#[cfg(target_os = "solana")]` so downstream can reuse the same struct without new definitions.

this will help to ensure BFP and the precompile share an identical API