### PR TITLE
zero-copy: Remove custom PartialEq and ParialOrd impl

### DIFF
--- a/zero-copy/src/unaligned.rs
+++ b/zero-copy/src/unaligned.rs
@@ -386,42 +386,6 @@ macro_rules! impl_int_conversion {
                 *self = *self - rhs;
             }
         }
-        impl core::cmp::PartialEq<$I> for $P {
-            #[inline(always)]
-            fn eq(&self, other: &$I) -> bool {
-                let s: $I = (*self).into();
-                s == *other
-            }
-        }
-        impl core::cmp::PartialEq<$P> for $I {
-            #[inline(always)]
-            fn eq(&self, other: &$P) -> bool {
-                let o: $I = (*other).into();
-                *self == o
-            }
-        }
-        impl core::cmp::PartialOrd<$I> for $P {
-            #[inline(always)]
-            fn partial_cmp(&self, other: &$I) -> Option<core::cmp::Ordering> {
-                let s: $I = (*self).into();
-                s.partial_cmp(other)
-            }
-        }
-        impl core::cmp::PartialOrd<$P> for $I {
-            #[inline(always)]
-            fn partial_cmp(&self, other: &$P) -> Option<core::cmp::Ordering> {
-                let o: $I = (*other).into();
-                self.partial_cmp(&o)
-            }
-        }
-        impl core::cmp::PartialOrd<$P> for $P {
-            #[inline(always)]
-            fn partial_cmp(&self, other: &$P) -> Option<core::cmp::Ordering> {
-                let s: $I = (*self).into();
-                let o: $I = (*other).into();
-                s.partial_cmp(&o)
-            }
-        }
     };
 }
 
@@ -757,8 +721,6 @@ mod tests {
         MulAssign,
         RemAssign,
         SubAssign,
-        PartialEq,
-        PartialOrd,
     }
 
     macro_rules! test_arithmetic_methods {
@@ -782,8 +744,6 @@ mod tests {
             #[test_case::test_case(ArithmeticMethod::MulAssign ; "mul_assign")]
             #[test_case::test_case(ArithmeticMethod::RemAssign ; "rem_assign")]
             #[test_case::test_case(ArithmeticMethod::SubAssign ; "sub_assign")]
-            #[test_case::test_case(ArithmeticMethod::PartialEq ; "partial_eq")]
-            #[test_case::test_case(ArithmeticMethod::PartialOrd ; "partial_ord")]
             #[allow(clippy::arithmetic_side_effects)]
             fn $test_name(method: ArithmeticMethod) {
                 let min = <$UnalignedType>::from_primitive($min);
@@ -910,27 +870,6 @@ mod tests {
                         let mut value = <$UnalignedType>::from_primitive(forty_four);
                         value -= two;
                         assert_eq!(value, <$UnalignedType>::from_primitive(forty_two));
-                    }
-                    ArithmeticMethod::PartialEq => {
-                        assert_eq!(<$UnalignedType>::from_primitive(forty_two), forty_two);
-                        assert_eq!(
-                            <$UnalignedType>::from_primitive(forty_two),
-                            <$UnalignedType>::from_primitive(forty_two)
-                        );
-                        assert_ne!(<$UnalignedType>::from_primitive(forty_two), forty_three);
-                        assert_ne!(min, max);
-                    }
-                    ArithmeticMethod::PartialOrd => {
-                        assert!(
-                            <$UnalignedType>::from_primitive(forty_one)
-                                < <$UnalignedType>::from_primitive(forty_two)
-                        );
-                        assert!(<$UnalignedType>::from_primitive(forty_three) > forty_two);
-                        assert!(max > min);
-                        assert_eq!(
-                            <$UnalignedType>::from_primitive(forty_two).partial_cmp(&forty_two),
-                            Some(core::cmp::Ordering::Equal)
-                        );
                     }
                 }
             }

--- a/zero-copy/src/unaligned.rs
+++ b/zero-copy/src/unaligned.rs
@@ -386,6 +386,14 @@ macro_rules! impl_int_conversion {
                 *self = *self - rhs;
             }
         }
+        impl core::cmp::PartialOrd<$P> for $P {
+            #[inline(always)]
+            fn partial_cmp(&self, other: &$P) -> Option<core::cmp::Ordering> {
+                let s: $I = (*self).into();
+                let o: $I = (*other).into();
+                s.partial_cmp(&o)
+            }
+        }
     };
 }
 
@@ -721,6 +729,7 @@ mod tests {
         MulAssign,
         RemAssign,
         SubAssign,
+        PartialOrd,
     }
 
     macro_rules! test_arithmetic_methods {
@@ -744,6 +753,7 @@ mod tests {
             #[test_case::test_case(ArithmeticMethod::MulAssign ; "mul_assign")]
             #[test_case::test_case(ArithmeticMethod::RemAssign ; "rem_assign")]
             #[test_case::test_case(ArithmeticMethod::SubAssign ; "sub_assign")]
+            #[test_case::test_case(ArithmeticMethod::PartialOrd ; "partial_ord")]
             #[allow(clippy::arithmetic_side_effects)]
             fn $test_name(method: ArithmeticMethod) {
                 let min = <$UnalignedType>::from_primitive($min);
@@ -870,6 +880,13 @@ mod tests {
                         let mut value = <$UnalignedType>::from_primitive(forty_four);
                         value -= two;
                         assert_eq!(value, <$UnalignedType>::from_primitive(forty_two));
+                    }
+                    ArithmeticMethod::PartialOrd => {
+                        assert!(
+                            <$UnalignedType>::from_primitive(forty_one)
+                                < <$UnalignedType>::from_primitive(forty_two)
+                        );
+                        assert!(max > min);
                     }
                 }
             }


### PR DESCRIPTION
### Problem

PR #718 added custom implementations for `PartialEq` and `PartialOrd` to work with both primitive and unaligned types, but this creates problems with existing code that is using `into()` to do the conversion. E.g.:
```rust
if epoch >= self.newer_transfer_fee.epoch.into() {
    &self.newer_transfer_fee
} else {
    &self.older_transfer_fee
}
```
The code above does not compile.

### Solution

Remove the custom implementations, reverting to the previous behaviour.

Fixes #733 