### PR TITLE
frozen-abi: introduce context to StableAbi

### DIFF
--- a/frozen-abi-macro/src/lib.rs
+++ b/frozen-abi-macro/src/lib.rs
@@ -51,7 +51,10 @@ pub fn derive_stable_abi(item: TokenStream) -> TokenStream {
     let expanded = quote! {
         #[automatically_derived]
         impl #impl_generics ::solana_frozen_abi::stable_abi::StableAbi for #ident #ty_generics #where_clause {
-            fn random(rng: &mut (impl ::solana_frozen_abi::rand::RngCore + ?Sized)) -> Self {
+            fn random_with_context(
+                rng: &mut (impl ::solana_frozen_abi::rand::RngCore + ?Sized),
+                _ctx: (),
+            ) -> Self {
                 ::solana_frozen_abi::rand::Rng::random::<Self>(rng)
             }
         }
@@ -140,8 +143,15 @@ fn filter_allow_attrs(attrs: &mut Vec<Attribute>) {
 }
 
 #[cfg(feature = "frozen-abi")]
-fn parse_stable_abi_sample_override(field: &syn::Field) -> Result<Option<TokenStream2>, Error> {
-    let mut override_expr: Option<TokenStream2> = None;
+struct StableAbiSampleOptions {
+    with_expr: Option<TokenStream2>,
+    ctx_expr: Option<TokenStream2>,
+}
+
+#[cfg(feature = "frozen-abi")]
+fn parse_stable_abi_sample_options(field: &syn::Field) -> Result<StableAbiSampleOptions, Error> {
+    let mut with_expr: Option<TokenStream2> = None;
+    let mut ctx_expr: Option<TokenStream2> = None;
     for attr in &field.attrs {
         if !attr.path().is_ident("stable_abi_sample") {
             continue;
@@ -149,33 +159,60 @@ fn parse_stable_abi_sample_override(field: &syn::Field) -> Result<Option<TokenSt
         attr.parse_nested_meta(|meta| {
             if meta.path.is_ident("with") {
                 // reject duplicate `with` on the same field
-                if override_expr.is_some() {
+                if with_expr.is_some() {
                     return Err(meta.error("duplicate `with` in `#[stable_abi_sample(...)]`"));
                 }
                 let value = meta.value()?.parse::<LitStr>()?;
                 let expr = value.parse::<Expr>().map_err(|err| {
                     Error::new(value.span(), format!("invalid `with` expression: {err}"))
                 })?;
-                override_expr = Some(quote! { #expr });
+                with_expr = Some(quote! { #expr });
+                Ok(())
+            } else if meta.path.is_ident("ctx") {
+                // reject duplicate `ctx` on the same field
+                if ctx_expr.is_some() {
+                    return Err(meta.error("duplicate `ctx` in `#[stable_abi_sample(...)]`"));
+                }
+                let expr = meta.value()?.parse::<Expr>()?;
+                ctx_expr = Some(quote! { #expr });
                 Ok(())
             } else {
-                Err(meta.error("unsupported `stable_abi_sample` option; expected `with = \"...\"`"))
+                Err(meta.error(
+                    "unsupported `stable_abi_sample` option; expected `with = \"...\"` or `ctx = <expr>`",
+                ))
             }
         })?;
     }
-    Ok(override_expr)
+    if with_expr.is_some() && ctx_expr.is_some() {
+        return Err(Error::new_spanned(
+            field,
+            "cannot combine `with` and `ctx` in `#[stable_abi_sample(...)]`",
+        ));
+    }
+    Ok(StableAbiSampleOptions {
+        with_expr,
+        ctx_expr,
+    })
 }
 
 #[cfg(feature = "frozen-abi")]
 fn stable_abi_sample_field_expr(field: &syn::Field) -> Result<TokenStream2, Error> {
-    Ok(match parse_stable_abi_sample_override(field)? {
-        Some(expr) => expr,
-        None => {
-            let ty = &field.ty;
+    let options = parse_stable_abi_sample_options(field)?;
+    let ty = &field.ty;
+    Ok(match (options.with_expr, options.ctx_expr) {
+        (Some(expr), None) => expr,
+        (None, Some(ctx_expr)) => quote! {
+            <#ty as ::solana_frozen_abi::stable_abi::StableAbi<_>>::random_with_context(
+                rng,
+                #ctx_expr,
+            )
+        },
+        (None, None) => {
             quote! {
                 <#ty as ::solana_frozen_abi::stable_abi::StableAbi>::random(rng)
             }
         }
+        (Some(_), Some(_)) => unreachable!("`with` and `ctx` are mutually exclusive"),
     })
 }
 

--- a/frozen-abi/src/lib.rs
+++ b/frozen-abi/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! The macro would generate the `test_abi_digest` test that verifies binary layout stability:
 //! - Initializes a deterministic random number generator with fixed seed
-//! - Generates 10_000 instances of the type via `StableAbi::random()`
+//! - Generates 10_000 instances of the type
 //! - Serializes each instance
 //! - Hashes all serialized bytes together
 //! - Compares the resulting hash against the provided in `abi_digest` attribute
@@ -30,7 +30,10 @@
 //!
 //! ```rust,ignore
 //! impl ::solana_frozen_abi::stable_abi::StableAbi for MyType {
-//!     fn random(rng: &mut (impl ::solana_frozen_abi::rand::RngCore + ?Sized)) -> Self {
+//!     fn random_with_context(
+//!         rng: &mut (impl ::solana_frozen_abi::rand::RngCore + ?Sized),
+//!         _ctx: (),
+//!     ) -> Self {
 //!         ::solana_frozen_abi::rand::Rng::random::<Self>(rng)
 //!     }
 //! }
@@ -59,6 +62,9 @@
 //!
 //! Field override is optional and only needed for fields that cannot be sampled with plain
 //! `rng.random()` (for example `Vec<_>` or `HashMap<_, _>`), or when you want a specific shape.
+//!
+//! `StableAbiSample` supports passing explicit context to context-aware types via
+//! `ctx = <expr>`, forwarded to `StableAbi::random_with_context(...)`.
 //!
 //! ```rust,ignore
 //! #[derive(StableAbi, StableAbiSample)]

--- a/frozen-abi/src/stable_abi/impls.rs
+++ b/frozen-abi/src/stable_abi/impls.rs
@@ -8,8 +8,8 @@ macro_rules! impl_stable_abi_via_standard_uniform {
     ($($t:ty),* $(,)?) => {
         $(
             impl StableAbi for $t {
-                fn random(rng: &mut (impl RngCore + ?Sized)) -> Self {
-                    rng.random::<Self>()
+                fn random_with_context(rng: &mut (impl RngCore + ?Sized), _ctx: ()) -> Self {
+                    rng.random()
                 }
             }
         )*
@@ -20,8 +20,8 @@ macro_rules! impl_stable_abi_via_size_of_from_bytes {
     ($from_bytes:ident, $($t:ty),* $(,)?) => {
         $(
             impl StableAbi for $t {
-                fn random(rng: &mut (impl RngCore + ?Sized)) -> Self {
-                    Self::$from_bytes(rng.random::<[u8; core::mem::size_of::<Self>()]>())
+                fn random_with_context(rng: &mut (impl RngCore + ?Sized), _ctx: ()) -> Self {
+                    Self::$from_bytes(rng.random())
                 }
             }
         )*
@@ -33,9 +33,9 @@ macro_rules! impl_stable_abi_for_tuples {
         $(
             impl<$($t),+> StableAbi for ($($t,)+)
             where
-                $($t: StableAbi),+
+                $($t: StableAbi),+,
             {
-                fn random(rng: &mut (impl RngCore + ?Sized)) -> Self {
+                fn random_with_context(rng: &mut (impl RngCore + ?Sized), _ctx: ()) -> Self {
                     ($($t::random(rng),)+)
                 }
             }
@@ -90,7 +90,7 @@ impl<T, const N: usize> StableAbi for [T; N]
 where
     T: StableAbi,
 {
-    fn random(rng: &mut (impl RngCore + ?Sized)) -> Self {
+    fn random_with_context(rng: &mut (impl RngCore + ?Sized), _ctx: ()) -> Self {
         array::from_fn(|_| T::random(rng))
     }
 }
@@ -99,7 +99,7 @@ impl<T> StableAbi for Option<T>
 where
     T: StableAbi,
 {
-    fn random(rng: &mut (impl RngCore + ?Sized)) -> Self {
+    fn random_with_context(rng: &mut (impl RngCore + ?Sized), _ctx: ()) -> Self {
         rng.random::<bool>().then(|| T::random(rng))
     }
 }

--- a/frozen-abi/src/stable_abi/mod.rs
+++ b/frozen-abi/src/stable_abi/mod.rs
@@ -2,6 +2,13 @@ use rand::RngCore;
 
 mod impls;
 
-pub trait StableAbi: Sized {
-    fn random(rng: &mut (impl RngCore + ?Sized)) -> Self;
+pub trait StableAbi<Ctx = ()>: Sized {
+    fn random_with_context(rng: &mut (impl RngCore + ?Sized), ctx: Ctx) -> Self;
+
+    fn random(rng: &mut (impl RngCore + ?Sized)) -> Self
+    where
+        Ctx: Default,
+    {
+        Self::random_with_context(rng, Ctx::default())
+    }
 }


### PR DESCRIPTION
### Description

This PR improves the StableAbi trait by extending it with a generic context, which can be used to provide additional data used in the generation process.

### Summary of changes
- extended StableAbi trait to operate on generic context
- added random_with_context() to StableAbi trait and delegate random()
- fixed dependent macros; impl_stable_abi_via_standard_uniform, impl_stable_abi_via_size_of_from_bytes

---
https://github.com/anza-xyz/solana-sdk/pull/739 PR with collections