### PR TITLE
frozen-abi: extend support for collections in StableAbi

### DIFF
--- a/frozen-abi/src/lib.rs
+++ b/frozen-abi/src/lib.rs
@@ -63,8 +63,24 @@
 //! Field override is optional and only needed for fields that cannot be sampled with plain
 //! `rng.random()` (for example `Vec<_>` or `HashMap<_, _>`), or when you want a specific shape.
 //!
-//! `StableAbiSample` supports passing explicit context to context-aware types via
-//! `ctx = <expr>`, forwarded to `StableAbi::random_with_context(...)`.
+//! `StableAbiSample` also supports passing an explicit context to context-aware types:
+//!
+//! ```rust,ignore
+//! #[derive(StableAbi, StableAbiSample)]
+//! #[frozen_abi(abi_digest = "...")]
+//! struct MyTypeWithCtx {
+//!     #[stable_abi_sample(ctx = SequenceLenMax(32))]
+//!     a: Vec<u8>,
+//!     #[stable_abi_sample(ctx = SequenceLenMax(8))]
+//!     b: std::collections::VecDeque<u16>,
+//!     #[stable_abi_sample(ctx = SequenceLenRange { min: 1, max: 4 })]
+//!     c: std::collections::BTreeMap<u8, u16>,
+//! }
+//! ```
+//!
+//! `ctx = <expr>` evaluates the given expression and forwards it as the context to
+//! `StableAbi::random_with_context(...)`. The expression's type must match a
+//! context type the field's type implements (e.g. `SequenceLenMax` or `SequenceLenRange` for collections).
 //!
 //! ```rust,ignore
 //! #[derive(StableAbi, StableAbiSample)]

--- a/frozen-abi/src/stable_abi/context.rs
+++ b/frozen-abi/src/stable_abi/context.rs
@@ -1,0 +1,68 @@
+use core::ops::{Bound, RangeBounds};
+
+/// Context for `StableAbi<...>` impls on sequence-like collections
+/// (`Vec`, `VecDeque`, `HashMap`, `BTreeMap`) that bounds the sampled length
+/// to an inclusive range `min..=max`.
+///
+/// The collection's `random_with_context` draws a length uniformly from
+/// `min..=max` and produces that many elements. `min == max` pins the length
+/// exactly; `min == 0` means "up to `max` elements" (equivalent to
+/// `SequenceLenMax(max)`).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct SequenceLenRange {
+    pub min: usize,
+    pub max: usize,
+}
+
+impl SequenceLenRange {
+    pub fn new(range: impl RangeBounds<usize>) -> Self {
+        let min = match range.start_bound() {
+            Bound::Included(&min) => min,
+            Bound::Excluded(&min) => min.checked_add(1).expect("invalid min in range"),
+            Bound::Unbounded => 0,
+        };
+        let max = match range.end_bound() {
+            Bound::Included(&max) => max,
+            Bound::Excluded(&max) => max.checked_sub(1).expect("invalid max in range"),
+            Bound::Unbounded => usize::MAX,
+        };
+        assert!(min <= max, "invalid sequence length range");
+
+        Self { min, max }
+    }
+}
+
+/// Context for `StableAbi<...>` impls on sequence-like collections
+/// that caps the sampled length at `0..=N`.
+///
+/// Equivalent to `SequenceLenRange { min: 0, max: N }`; the per-collection
+/// impl delegates to the `SequenceLenRange` impl.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SequenceLenMax(pub usize);
+
+impl From<SequenceLenMax> for SequenceLenRange {
+    fn from(max: SequenceLenMax) -> Self {
+        Self::new(0..=max.0)
+    }
+}
+
+macro_rules! impl_with_context_via {
+    (
+        impl<$($g:tt),+ $(,)?> StableAbi<$ctx:ty> for $self_ty:ty
+        where { $($wc:tt)* },
+        |$bind:pat_param| $convert:expr $(,)?
+    ) => {
+        impl<$($g),+> StableAbi<$ctx> for $self_ty
+        where $($wc)*
+        {
+            fn random_with_context(
+                rng: &mut (impl RngCore + ?Sized),
+                $bind: $ctx,
+            ) -> Self {
+                Self::random_with_context(rng, $convert)
+            }
+        }
+    };
+}
+
+pub(crate) use impl_with_context_via;

--- a/frozen-abi/src/stable_abi/impls.rs
+++ b/frozen-abi/src/stable_abi/impls.rs
@@ -1,8 +1,18 @@
 use {
-    crate::stable_abi::StableAbi,
+    crate::stable_abi::{
+        context::{impl_with_context_via, SequenceLenMax, SequenceLenRange},
+        StableAbi,
+    },
     core::{array, num::NonZero},
     rand::{Rng, RngCore},
+    std::{
+        collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
+        hash::{BuildHasher, Hash},
+    },
 };
+
+const DEFAULT_COLLECTION_MAX_SAMPLE_LEN: usize = 5;
+const DEFAULT_COLLECTION_MAX_SAMPLE_LEN_NON_DETERMINISTIC_ORDER: usize = 1;
 
 macro_rules! impl_stable_abi_via_standard_uniform {
     ($($t:ty),* $(,)?) => {
@@ -104,11 +114,154 @@ where
     }
 }
 
+// keep at most one element to mitigate iteration order differences
+impl_with_context_via! {
+    impl<K, V, S> StableAbi<()> for HashMap<K, V, S>
+    where { K: StableAbi + Eq + Hash, V: StableAbi, S: BuildHasher + Default },
+    |_| SequenceLenRange::new(0..=DEFAULT_COLLECTION_MAX_SAMPLE_LEN_NON_DETERMINISTIC_ORDER),
+}
+
+impl<K, V, S> StableAbi<SequenceLenRange> for HashMap<K, V, S>
+where
+    K: StableAbi + Eq + Hash,
+    V: StableAbi,
+    S: BuildHasher + Default,
+{
+    fn random_with_context(rng: &mut (impl RngCore + ?Sized), ctx: SequenceLenRange) -> Self {
+        let len = rng.random_range(ctx.min..=ctx.max);
+        (0..len).map(|_| (K::random(rng), V::random(rng))).collect()
+    }
+}
+
+impl_with_context_via! {
+    impl<K, V, S> StableAbi<SequenceLenMax> for HashMap<K, V, S>
+    where { K: StableAbi + Eq + Hash, V: StableAbi, S: BuildHasher + Default },
+    |ctx| SequenceLenRange::from(ctx),
+}
+
+// keep at most one element to mitigate iteration order differences
+impl_with_context_via! {
+    impl<T, S> StableAbi<()> for HashSet<T, S>
+    where { T: StableAbi + Eq + Hash, S: BuildHasher + Default },
+    |_| SequenceLenRange::new(0..=DEFAULT_COLLECTION_MAX_SAMPLE_LEN_NON_DETERMINISTIC_ORDER),
+}
+
+impl<T, S> StableAbi<SequenceLenRange> for HashSet<T, S>
+where
+    T: StableAbi + Eq + Hash,
+    S: BuildHasher + Default,
+{
+    fn random_with_context(rng: &mut (impl RngCore + ?Sized), ctx: SequenceLenRange) -> Self {
+        let len = rng.random_range(ctx.min..=ctx.max);
+        (0..len).map(|_| T::random(rng)).collect()
+    }
+}
+
+impl_with_context_via! {
+    impl<T, S> StableAbi<SequenceLenMax> for HashSet<T, S>
+    where { T: StableAbi + Eq + Hash, S: BuildHasher + Default },
+    |ctx| SequenceLenRange::from(ctx),
+}
+
+impl_with_context_via! {
+    impl<T> StableAbi<()> for Vec<T>
+    where { T: StableAbi },
+    |_| SequenceLenRange::new(0..=DEFAULT_COLLECTION_MAX_SAMPLE_LEN),
+}
+
+impl<T> StableAbi<SequenceLenRange> for Vec<T>
+where
+    T: StableAbi,
+{
+    fn random_with_context(rng: &mut (impl RngCore + ?Sized), ctx: SequenceLenRange) -> Self {
+        let len = rng.random_range(ctx.min..=ctx.max);
+        (0..len).map(|_| T::random(rng)).collect()
+    }
+}
+
+impl_with_context_via! {
+    impl<T> StableAbi<SequenceLenMax> for Vec<T>
+    where { T: StableAbi },
+    |ctx| SequenceLenRange::from(ctx),
+}
+
+impl_with_context_via! {
+    impl<T> StableAbi<()> for VecDeque<T>
+    where { T: StableAbi },
+    |_| SequenceLenRange::new(0..=DEFAULT_COLLECTION_MAX_SAMPLE_LEN),
+}
+
+impl<T> StableAbi<SequenceLenRange> for VecDeque<T>
+where
+    T: StableAbi,
+{
+    fn random_with_context(rng: &mut (impl RngCore + ?Sized), ctx: SequenceLenRange) -> Self {
+        let len = rng.random_range(ctx.min..=ctx.max);
+        (0..len).map(|_| T::random(rng)).collect()
+    }
+}
+
+impl_with_context_via! {
+    impl<T> StableAbi<SequenceLenMax> for VecDeque<T>
+    where { T: StableAbi },
+    |ctx| SequenceLenRange::from(ctx),
+}
+
+impl_with_context_via! {
+    impl<K, V> StableAbi<()> for BTreeMap<K, V>
+    where { K: StableAbi + Ord, V: StableAbi },
+    |_| SequenceLenRange::new(0..DEFAULT_COLLECTION_MAX_SAMPLE_LEN),
+}
+
+impl<K, V> StableAbi<SequenceLenRange> for BTreeMap<K, V>
+where
+    K: StableAbi + Ord,
+    V: StableAbi,
+{
+    fn random_with_context(rng: &mut (impl RngCore + ?Sized), ctx: SequenceLenRange) -> Self {
+        let len = rng.random_range(ctx.min..=ctx.max);
+        (0..len).map(|_| (K::random(rng), V::random(rng))).collect()
+    }
+}
+
+impl_with_context_via! {
+    impl<K, V> StableAbi<SequenceLenMax> for BTreeMap<K, V>
+    where { K: StableAbi + Ord, V: StableAbi },
+    |ctx| SequenceLenRange::from(ctx),
+}
+
+impl_with_context_via! {
+    impl<T> StableAbi<()> for BTreeSet<T>
+    where { T: StableAbi + Ord },
+    |_| SequenceLenRange::new(0..=DEFAULT_COLLECTION_MAX_SAMPLE_LEN),
+}
+
+impl<T> StableAbi<SequenceLenRange> for BTreeSet<T>
+where
+    T: StableAbi + Ord,
+{
+    fn random_with_context(rng: &mut (impl RngCore + ?Sized), ctx: SequenceLenRange) -> Self {
+        let len = rng.random_range(ctx.min..=ctx.max);
+        (0..len).map(|_| T::random(rng)).collect()
+    }
+}
+
+impl_with_context_via! {
+    impl<T> StableAbi<SequenceLenMax> for BTreeSet<T>
+    where { T: StableAbi + Ord },
+    |ctx| SequenceLenRange::from(ctx),
+}
+
+impl StableAbi for () {
+    fn random_with_context(_rng: &mut (impl RngCore + ?Sized), _ctx: ()) -> Self {}
+}
+
 #[cfg(all(test, feature = "frozen-abi"))]
 mod tests {
     use {
+        crate::stable_abi::context::{SequenceLenMax, SequenceLenRange},
         core::num::NonZero,
-        std::collections::{BTreeMap, VecDeque},
+        std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
     };
 
     const ABI_SHARED_WINCODE_VS_BINCODE: &str = "AgNkEpErnFBuy7iTAEUUAC1fbvokEkhbsfFnx4DtXAvY";
@@ -281,9 +434,7 @@ mod tests {
         )]
         a: Vec<bool>,
         // Keep a single entry so HashMap iteration order cannot affect the digest.
-        #[stable_abi_sample(
-            with = "std::collections::HashMap::from_iter([(rng.random(), rng.random())])"
-        )]
+        #[stable_abi_sample(with = "HashMap::from_iter([(rng.random(), rng.random())])")]
         b: std::collections::HashMap<u64, bool>,
         #[stable_abi_sample(with = "rng.random::<u64>()")]
         c: u64,
@@ -528,4 +679,164 @@ mod tests {
         #[stable_abi_sample(with = "rng.random::<u8>()")]
         a: u8,
     });
+
+    type AliasVec = Vec<(u8, u16, u32, u64)>;
+    type AliasHashMap = HashMap<u8, u128>;
+    type AliasVecDeque = VecDeque<i16>;
+
+    #[derive(Debug, wincode::SchemaWrite)]
+    #[cfg_attr(
+        feature = "frozen-abi",
+        derive(
+            solana_frozen_abi_macro::StableAbi,
+            solana_frozen_abi_macro::StableAbiSample
+        ),
+        solana_frozen_abi_macro::frozen_abi(
+            abi_digest = "hsD1Hmwbrwnfw4rdiBospgofHtJTftbN9vHUGXf7N2t",
+            abi_serializer = "wincode",
+        )
+    )]
+    struct TestCollectionsDerive {
+        a: Vec<u8>,
+        b: Option<Vec<u8>>,
+        c: AliasVec,
+        d: HashMap<u8, char>,
+        e: AliasHashMap,
+        f: Option<HashMap<u16, i64>>,
+        g: VecDeque<char>,
+        h: Option<VecDeque<bool>>,
+        i: AliasVecDeque,
+    }
+
+    macro_rules! impl_sequence_sample_test_types {
+        (
+            digests = [$(
+                $abi_digest:expr => [$(
+                    struct $struct_name:ident { $($body:tt)* }
+                ),+ $(,)?]
+            ),+ $(,)?]
+        ) => {
+            mod sequence_sample_test_types {
+                macro_rules! test_types {
+                    ($derive:path, $serializer:literal) => {
+                        $($(
+                            #[derive($derive)]
+                            #[cfg_attr(
+                                feature = "frozen-abi",
+                                derive(
+                                    solana_frozen_abi_macro::StableAbi,
+                                    solana_frozen_abi_macro::StableAbiSample
+                                ),
+                                solana_frozen_abi_macro::frozen_abi(
+                                    abi_digest = $abi_digest,
+                                    abi_serializer = $serializer,
+                                )
+                            )]
+                            struct $struct_name { $($body)* }
+                        )+)+
+                    };
+                }
+                mod wincode {use super::super::*; test_types!(wincode::SchemaWrite, "wincode");}
+                mod bincode {use super::super::*; test_types!(serde_derive::Serialize, "bincode");}
+            }
+        };
+    }
+
+    impl_sequence_sample_test_types!(
+        digests = [
+            "762V1KB6NRDroyHo31bjg7gwX9nx8QqHCP9EJ3Y7nLGE" => [
+                struct MultiElementsWith {
+                    #[stable_abi_sample(
+                        with = "(0..rng.random_range(0..=5)).map(|_| rng.random()).collect()"
+                    )]
+                    a: Vec<u8>,
+                },
+                struct MultiElementsVec {
+                    #[stable_abi_sample(ctx = SequenceLenMax(5))]
+                    a: Vec<u8>,
+                },
+                struct MultiElementsVecDefault {
+                    a: Vec<u8>,
+                },
+                struct MultiElementsVecDeque {
+                    #[stable_abi_sample(ctx = SequenceLenMax(5))]
+                    a: VecDeque<u8>,
+                },
+            ],
+            "7dXyMka1Z72sENE9vva8vmE65F7y6kXZKQ2DHu9aTWyz" => [
+                struct UpToOneElementWith {
+                    #[stable_abi_sample(
+                        with = "(0..rng.random_range(0..=1)).map(|_| rng.random()).collect()"
+                    )]
+                    a: Vec<u8>,
+                },
+                struct UpToOneElementVec {
+                    #[stable_abi_sample(ctx = SequenceLenMax(1))]
+                    a: Vec<u8>,
+                },
+                struct UpToOneElementBTreeSet {
+                    #[stable_abi_sample(ctx = SequenceLenMax(1))]
+                    a: BTreeSet<u8>,
+                },
+                struct UpToOneElementHashMap {
+                    #[stable_abi_sample(ctx = SequenceLenMax(1))]
+                    a: HashMap<u8, ()>,
+                },
+                struct UpToOneElementHashMapDefault {
+                    a: HashMap<u8, ()>,
+                },
+                struct UpToOneElementHashSet {
+                    #[stable_abi_sample(ctx = SequenceLenMax(1))]
+                    a: HashSet<u8>,
+                },
+                struct UpToOneElementHashSetDefault {
+                    a: HashSet<u8>,
+                },
+                struct UpToOneElementBTreeMap {
+                    #[stable_abi_sample(ctx = SequenceLenMax(1))]
+                    a: BTreeMap<u8, ()>,
+                },
+            ],
+            "Du8dTBApdeSxYTQVprkbMGvc5dLgCfUKKZ2z63qqr5Bj" => [
+                struct UpToOneKeyValueHashMapWith {
+                    #[stable_abi_sample(
+                        with = "(0..rng.random_range(0..=1)).map(|_| (rng.random(), rng.random())).collect()"
+                    )]
+                    a: HashMap<u8, u16>,
+                },
+                struct UpToOneKeyValueVec {
+                    #[stable_abi_sample(ctx = SequenceLenMax(1))]
+                    a: Vec<(u8, u16)>,
+                },
+                struct UpToOneKeyValueHashMap {
+                    #[stable_abi_sample(ctx = SequenceLenMax(1))]
+                    a: HashMap<u8, u16>,
+                },
+                struct UpToOneKeyValueBTreeMap {
+                    #[stable_abi_sample(ctx = SequenceLenMax(1))]
+                    a: BTreeMap<u8, u16>,
+                },
+            ],
+            "57dywdByMU7XcWbsfnXY5ChZdqne57zjJCn7uEjDKGNc" => [
+                struct UpToOneKeyValueHashMapWithRange {
+                    #[stable_abi_sample(
+                        with = "(0..rng.random_range(1..=1)).map(|_| (rng.random(), rng.random())).collect()"
+                    )]
+                    a: HashMap<u8, u16>,
+                },
+                struct UpToOneKeyValueVecRange {
+                    #[stable_abi_sample(ctx = SequenceLenRange::new(1..=1))]
+                    a: Vec<(u8, u16)>,
+                },
+                struct UpToOneKeyValueHashMapRange {
+                    #[stable_abi_sample(ctx = SequenceLenRange::new(1..=1))]
+                    a: HashMap<u8, u16>,
+                },
+                struct UpToOneKeyValueBTreeMapRange {
+                    #[stable_abi_sample(ctx = SequenceLenRange::new(1..=1))]
+                    a: BTreeMap<u8, u16>,
+                },
+            ],
+        ]
+    );
 }

--- a/frozen-abi/src/stable_abi/mod.rs
+++ b/frozen-abi/src/stable_abi/mod.rs
@@ -1,5 +1,6 @@
 use rand::RngCore;
 
+pub mod context;
 mod impls;
 
 pub trait StableAbi<Ctx = ()>: Sized {


### PR DESCRIPTION

### Description

Collections in StableAbi were supported thru sampling expression using `stable_abi_sample(with = "<code>")` and thru manual implementation of rand distribution, which demanded highly verbose treatment in every case.

### Summary of changes
- added support for Vec, VecDeque, HashMap, HashSet, BtreeMap, BtreeSet
- added two context types SequenceLenRange and SequenceLenMax
- added new macro impl_with_context_via
- added test macros, to generate equivalent test types for collections, with split for multiple and single element
- updated docs