### PR TITLE
stable-layout: change fields visibility of StableVec<T> from public to private

### DIFF
--- a/stable-layout/src/stable_vec.rs
+++ b/stable-layout/src/stable_vec.rs
@@ -28,9 +28,9 @@ use std::{
 /// ```
 #[repr(C)]
 pub struct StableVec<T> {
-    pub addr: u64,
-    pub cap: u64,
-    pub len: u64,
+    addr: u64,
+    cap: u64,
+    len: u64,
     _marker: PhantomData<T>,
 }
 


### PR DESCRIPTION
This pull request solves the issue #615 which mentions that public fields may have potential risks. This PR makes improvements to the `StableVec` struct in the `stable-layout` crate, focusing on encapsulation and API usability. The most important changes are:

Encapsulation improvements:

* Changed the fields `addr`, `cap`, and `len` in the `StableVec` struct from public to private, preventing direct modification from outside the struct and improving safety.

API enhancements:

* Added a new public method `cap()` to the `StableVec` implementation, allowing users to access the capacity of the vector in a controlled manner.