### PR TITLE
frozen-abi: fix value parsing in sampling option 'with=' 

### DIFF
--- a/frozen-abi-macro/src/lib.rs
+++ b/frozen-abi-macro/src/lib.rs
@@ -163,7 +163,7 @@ fn parse_stable_abi_sample_options(field: &syn::Field) -> Result<StableAbiSample
                     return Err(meta.error("duplicate `with` in `#[stable_abi_sample(...)]`"));
                 }
                 let value = meta.value()?.parse::<LitStr>()?;
-                let expr = value.parse::<Expr>().map_err(|err| {
+                let expr = syn::parse_str::<Expr>(&value.value()).map_err(|err| {
                     Error::new(value.span(), format!("invalid `with` expression: {err}"))
                 })?;
                 with_expr = Some(quote! { #expr });

--- a/frozen-abi/src/stable_abi/impls.rs
+++ b/frozen-abi/src/stable_abi/impls.rs
@@ -504,4 +504,28 @@ mod tests {
         b: Option<NonZero<u8>>,
         c: NonZero<i16>,
     }
+
+    macro_rules! mk_stable_abi_sample_with_from_macro_rules {
+        ({ $($body:tt)* }) => {
+            #[derive(wincode::SchemaWrite)]
+            #[cfg_attr(
+                feature = "frozen-abi",
+                derive(
+                    solana_frozen_abi_macro::StableAbi,
+                    solana_frozen_abi_macro::StableAbiSample
+                ),
+                solana_frozen_abi_macro::frozen_abi(
+                    abi_digest = "33q22jGb8M6yo7fWeZvMoSUJBAoBEf4w2VQpjwXuHVXM",
+                    abi_serializer = "wincode",
+                )
+            )]
+            struct TestStableAbiSampleWithFromMacroRules {
+                $($body)*
+            }
+        };
+    }
+    mk_stable_abi_sample_with_from_macro_rules!({
+        #[stable_abi_sample(with = "rng.random::<u8>()")]
+        a: u8,
+    });
 }


### PR DESCRIPTION
### Description

StableAbi sampling `with = "...rng..."` expressions failed when attribute was emitted from a macro_rules!.
The issue was caused by a span hygiene difference between parsing paths.

`LitStr::parse::<Expr>()` parses string literal and assigns the resulting tokens span of the original `LitStr`. When the literal comes from a macro_rules! body, that span carries the macro definition context.

### Summary of changes
The change doesn't break compatibility with current usage.

- instead of parsing the expression thru `LitStr::parse`, we now parse the raw string contents with `syn::parse_str::<Expr>(&value.value())`