### PR TITLE
short-vec: no-std

### DIFF
--- a/scripts/check-no-std.sh
+++ b/scripts/check-no-std.sh
@@ -51,6 +51,7 @@ no_std_alloc_crates=(
   -p solana-instruction
   -p solana-instructions-sysvar
   -p solana-serialize-utils
+  -p solana-short-vec
 )
 
 # Use the upstream BPF target, which doesn't support std, to make sure that our

--- a/short-vec/src/lib.rs
+++ b/short-vec/src/lib.rs
@@ -1,18 +1,24 @@
 //! Compact serde-encoding of vectors with small length.
+#![no_std]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::arithmetic_side_effects)]
+
+extern crate alloc;
+#[cfg(feature = "frozen-abi")]
+extern crate std;
+
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::AbiExample;
-use std::convert::TryFrom;
+use {alloc::vec::Vec, core::convert::TryFrom};
 #[cfg(feature = "serde")]
 use {
+    core::{fmt, marker::PhantomData},
     serde_core::{
         de::{self, Deserializer, SeqAccess, Visitor},
         ser::{self, SerializeTuple, Serializer},
         Deserialize, Serialize,
     },
-    std::{fmt, marker::PhantomData},
 };
 
 #[cfg(feature = "wincode")]
@@ -289,6 +295,7 @@ pub fn decode_shortu16_len(bytes: &[u8]) -> Result<(usize, usize), ()> {
 mod tests {
     use {
         super::*,
+        alloc::vec,
         assert_matches::assert_matches,
         bincode::{deserialize, serialize},
     };

--- a/short-vec/src/wincode.rs
+++ b/short-vec/src/wincode.rs
@@ -231,6 +231,7 @@ mod tests {
     use {
         super::*,
         crate::ShortU16,
+        alloc::vec::Vec,
         proptest::prelude::*,
         serde_derive::{Deserialize, Serialize},
         wincode::{containers, io::Cursor},


### PR DESCRIPTION
Converts `solana-short-vec` crate to no-std + alloc.

Required for getting tx parsing in pinocchio programs (e.g. [solana-program/nonce](https://github.com/solana-program/nonce)). Next needing to convert:

- [ ] https://github.com/anza-xyz/solana-sdk/pull/743
- message
- transaction
