### PR TITLE
feat(signature): add stable abi derives

### DIFF
--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -92,7 +92,14 @@ fn push_batch_verification_inputs<'a>(
 
 /// A 64-byte Ed25519 signature.
 #[repr(transparent)]
-#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(
+        solana_frozen_abi_macro::AbiExample,
+        solana_frozen_abi_macro::StableAbi,
+        solana_frozen_abi_macro::StableAbiSample
+    )
+)]
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[cfg_attr(
     feature = "bytemuck",


### PR DESCRIPTION
This will allow generating randomly sampled instances of `Signature` in frozen-abi tests.
