### PR TITLE
feat(vote-interface): support wincode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4826,7 +4826,9 @@ dependencies = [
  "solana-short-vec",
  "solana-system-interface",
  "solana-vote-interface",
+ "solana-wincode-varint",
  "test-case",
+ "wincode",
 ]
 
 [[package]]

--- a/vote-interface/Cargo.toml
+++ b/vote-interface/Cargo.toml
@@ -43,6 +43,15 @@ serde = [
     "solana-pubkey/serde",
     "solana-short-vec/serde",
 ]
+wincode = [
+    "dep:solana-short-vec",
+    "dep:solana-wincode-varint",
+    "dep:wincode",
+    "solana-hash/wincode",
+    "solana-pubkey/wincode",
+    "solana-short-vec/wincode",
+    "wincode/alloc",
+]
 
 [dependencies]
 arbitrary = { workspace = true, features = ["derive"], optional = true }
@@ -66,6 +75,8 @@ solana-serde-varint = { workspace = true, optional = true }
 solana-serialize-utils = { workspace = true, optional = true, features = ["std"] }
 solana-short-vec = { workspace = true, optional = true }
 solana-system-interface = { workspace = true, features = ["bincode"], optional = true }
+solana-wincode-varint = { workspace = true, optional = true }
+wincode = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "solana")'.dependencies]
 solana-serialize-utils = { workspace = true, features = ["std"] }
@@ -75,7 +86,7 @@ itertools = { workspace = true }
 rand = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-pubkey = { workspace = true, features = ["dev-context-only-utils"] }
-solana-vote-interface = { path = ".", features = ["dev-context-only-utils"] }
+solana-vote-interface = { path = ".", features = ["dev-context-only-utils", "wincode"] }
 test-case = { workspace = true }
 
 [lints]

--- a/vote-interface/src/authorized_voters.rs
+++ b/vote-interface/src/authorized_voters.rs
@@ -14,6 +14,7 @@ use {solana_clock::Epoch, solana_pubkey::Pubkey, std::collections::BTreeMap};
 /// sentinel for an uninitialized vote state.
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "dev-context-only-utils", derive(Arbitrary))]
 pub struct AuthorizedVoters {

--- a/vote-interface/src/instruction.rs
+++ b/vote-interface/src/instruction.rs
@@ -16,6 +16,11 @@ use {
     solana_instruction::{AccountMeta, Instruction},
     solana_sdk_ids::sysvar,
 };
+#[cfg(feature = "wincode")]
+use {
+    crate::state::wincode_compact::{CompactTowerSync, CompactVoteStateUpdate},
+    wincode::{SchemaRead, SchemaWrite},
+};
 #[cfg(feature = "serde")]
 use {
     crate::state::{serde_compact_vote_state_update, serde_tower_sync},
@@ -24,6 +29,7 @@ use {
 
 #[repr(u8)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "wincode", derive(SchemaWrite, SchemaRead))]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum CommissionKind {
     InflationRewards = 0,
@@ -31,6 +37,7 @@ pub enum CommissionKind {
 }
 
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "wincode", derive(SchemaWrite, SchemaRead))]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum VoteInstruction {
     /// Initialize a vote account
@@ -161,7 +168,9 @@ pub enum VoteInstruction {
     ///   0. `[Write]` Vote account to vote with
     ///   1. `[SIGNER]` Vote authority
     #[cfg_attr(feature = "serde", serde(with = "serde_compact_vote_state_update"))]
-    CompactUpdateVoteState(VoteStateUpdate),
+    CompactUpdateVoteState(
+        #[cfg_attr(feature = "wincode", wincode(with = "CompactVoteStateUpdate"))] VoteStateUpdate,
+    ),
 
     /// Update the onchain vote state for the signer along with a switching proof.
     ///
@@ -170,6 +179,7 @@ pub enum VoteInstruction {
     ///   1. `[SIGNER]` Vote authority
     CompactUpdateVoteStateSwitch(
         #[cfg_attr(feature = "serde", serde(with = "serde_compact_vote_state_update"))]
+        #[cfg_attr(feature = "wincode", wincode(with = "CompactVoteStateUpdate"))]
         VoteStateUpdate,
         Hash,
     ),
@@ -180,7 +190,7 @@ pub enum VoteInstruction {
     ///   0. `[Write]` Vote account to vote with
     ///   1. `[SIGNER]` Vote authority
     #[cfg_attr(feature = "serde", serde(with = "serde_tower_sync"))]
-    TowerSync(TowerSync),
+    TowerSync(#[cfg_attr(feature = "wincode", wincode(with = "CompactTowerSync"))] TowerSync),
 
     /// Sync the onchain vote state with local tower along with a switching proof
     ///
@@ -188,7 +198,9 @@ pub enum VoteInstruction {
     ///   0. `[Write]` Vote account to vote with
     ///   1. `[SIGNER]` Vote authority
     TowerSyncSwitch(
-        #[cfg_attr(feature = "serde", serde(with = "serde_tower_sync"))] TowerSync,
+        #[cfg_attr(feature = "serde", serde(with = "serde_tower_sync"))]
+        #[cfg_attr(feature = "wincode", wincode(with = "CompactTowerSync"))]
+        TowerSync,
         Hash,
     ),
 

--- a/vote-interface/src/state/mod.rs
+++ b/vote-interface/src/state/mod.rs
@@ -51,6 +51,7 @@ pub const VOTE_CREDITS_MAXIMUM_PER_SLOT: u8 = 16;
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Default, Debug, PartialEq, Eq, Copy, Clone)]
 #[cfg_attr(feature = "dev-context-only-utils", derive(Arbitrary))]
 pub struct Lockout {
@@ -104,6 +105,7 @@ impl Lockout {
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Default, Debug, PartialEq, Eq, Copy, Clone)]
 #[cfg_attr(feature = "dev-context-only-utils", derive(Arbitrary))]
 pub struct LandedVote {
@@ -141,6 +143,7 @@ impl From<Lockout> for LandedVote {
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "dev-context-only-utils", derive(Arbitrary))]
 pub struct BlockTimestamp {
@@ -152,6 +155,7 @@ pub struct BlockTimestamp {
 const MAX_ITEMS: usize = 32;
 
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "dev-context-only-utils", derive(Arbitrary))]
@@ -200,27 +204,76 @@ impl<I> CircBuf<I> {
     }
 }
 
-/// Shared helpers for the compact wire format used by
-/// [`serde_compact_vote_state_update`] and [`serde_tower_sync`]: lockout slots
-/// are stored as varint offsets relative to the previous slot (or the root).
-#[cfg(feature = "serde")]
+/// Shared compact wire-format representations for [`VoteStateUpdate`] and
+/// [`TowerSync`]: lockout slots are stored as varint offsets from the previous
+/// slot in a `short_vec`.
+///
+/// The [`serde_compact_vote_state_update`]/[`serde_tower_sync`] (serde) and
+/// [`wincode_compact`] (wincode) modules bridge the original types to these
+/// representations.
+#[cfg(any(feature = "serde", feature = "wincode"))]
 mod compact {
+    #[cfg(feature = "serde")]
+    use serde_derive::{Deserialize, Serialize};
     #[cfg(feature = "frozen-abi")]
     use solana_frozen_abi_macro::{AbiExample, StableAbi, StableAbiSample};
-    use {super::Lockout, solana_clock::Slot, std::collections::VecDeque};
+    use {
+        super::{Lockout, TowerSync, VoteStateUpdate},
+        solana_clock::{Slot, UnixTimestamp},
+        solana_hash::Hash,
+        std::collections::VecDeque,
+    };
+    #[cfg(feature = "wincode")]
+    use {
+        solana_short_vec::ShortU16,
+        solana_wincode_varint::Leb128Int,
+        wincode::{containers, SchemaRead, SchemaWrite},
+    };
 
     #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-    #[derive(serde_derive::Deserialize, serde_derive::Serialize)]
-    pub(super) struct LockoutOffset {
-        #[serde(with = "solana_serde_varint")]
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[cfg_attr(feature = "wincode", derive(SchemaWrite, SchemaRead))]
+    struct LockoutOffset {
+        #[cfg_attr(feature = "serde", serde(with = "solana_serde_varint"))]
+        #[cfg_attr(feature = "wincode", wincode(with = "Leb128Int<Slot>"))]
         offset: Slot,
         confirmation_count: u8,
     }
 
+    /// `short_vec`-length-encoded `Vec<LockoutOffset>`, the wincode counterpart
+    /// of `#[serde(with = "solana_short_vec")]`.
+    #[cfg(feature = "wincode")]
+    type LockoutOffsetShortVec = containers::Vec<LockoutOffset, ShortU16>;
+
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[cfg_attr(feature = "wincode", derive(SchemaWrite, SchemaRead))]
+    pub(super) struct CompactVoteStateUpdate {
+        root: Slot,
+        #[cfg_attr(feature = "serde", serde(with = "solana_short_vec"))]
+        #[cfg_attr(feature = "wincode", wincode(with = "LockoutOffsetShortVec"))]
+        lockout_offsets: Vec<LockoutOffset>,
+        hash: Hash,
+        timestamp: Option<UnixTimestamp>,
+    }
+
+    #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+    #[cfg_attr(feature = "wincode", derive(SchemaWrite, SchemaRead))]
+    pub(super) struct CompactTowerSync {
+        root: Slot,
+        #[cfg_attr(feature = "serde", serde(with = "solana_short_vec"))]
+        #[cfg_attr(feature = "wincode", wincode(with = "LockoutOffsetShortVec"))]
+        lockout_offsets: Vec<LockoutOffset>,
+        hash: Hash,
+        timestamp: Option<UnixTimestamp>,
+        block_id: Hash,
+    }
+
     /// Convert a tower's absolute lockout slots into the relative, delta-encoded
-    /// offsets used by the compact wire format. The returned error message is
-    /// mapped to the caller's error type.
-    pub(super) fn lockout_offsets(
+    /// offsets used by the compact wire format.
+    ///
+    /// Shared by the serde and wincode encoders; the returned error message is
+    /// mapped to each backend's error type by the caller.
+    fn lockout_offsets(
         lockouts: &VecDeque<Lockout>,
         root: Option<Slot>,
     ) -> Result<Vec<LockoutOffset>, &'static str> {
@@ -244,7 +297,7 @@ mod compact {
 
     /// Reconstruct the absolute lockouts from the relative offsets stored in the
     /// compact wire format. Inverse of [`lockout_offsets`].
-    pub(super) fn lockouts_from_offsets(
+    fn lockouts_from_offsets(
         lockout_offsets: &[LockoutOffset],
         root: Option<Slot>,
     ) -> Result<VecDeque<Lockout>, &'static str> {
@@ -261,25 +314,62 @@ mod compact {
         }
         Ok(lockouts)
     }
+
+    pub(super) fn vote_state_update_to_compact(
+        src: &VoteStateUpdate,
+    ) -> Result<CompactVoteStateUpdate, &'static str> {
+        #[allow(clippy::clone_on_copy)]
+        Ok(CompactVoteStateUpdate {
+            root: src.root.unwrap_or(Slot::MAX),
+            lockout_offsets: lockout_offsets(&src.lockouts, src.root)?,
+            hash: src.hash.clone(),
+            timestamp: src.timestamp,
+        })
+    }
+
+    pub(super) fn vote_state_update_from_compact(
+        repr: CompactVoteStateUpdate,
+    ) -> Result<VoteStateUpdate, &'static str> {
+        let root = (repr.root != Slot::MAX).then_some(repr.root);
+        Ok(VoteStateUpdate {
+            lockouts: lockouts_from_offsets(&repr.lockout_offsets, root)?,
+            root,
+            hash: repr.hash,
+            timestamp: repr.timestamp,
+        })
+    }
+
+    pub(super) fn tower_sync_to_compact(src: &TowerSync) -> Result<CompactTowerSync, &'static str> {
+        #[allow(clippy::clone_on_copy)]
+        Ok(CompactTowerSync {
+            root: src.root.unwrap_or(Slot::MAX),
+            lockout_offsets: lockout_offsets(&src.lockouts, src.root)?,
+            hash: src.hash.clone(),
+            timestamp: src.timestamp,
+            block_id: src.block_id.clone(),
+        })
+    }
+
+    pub(super) fn tower_sync_from_compact(
+        repr: CompactTowerSync,
+    ) -> Result<TowerSync, &'static str> {
+        let root = (repr.root != Slot::MAX).then_some(repr.root);
+        Ok(TowerSync {
+            lockouts: lockouts_from_offsets(&repr.lockout_offsets, root)?,
+            root,
+            hash: repr.hash,
+            timestamp: repr.timestamp,
+            block_id: repr.block_id,
+        })
+    }
 }
 
 #[cfg(feature = "serde")]
 pub mod serde_compact_vote_state_update {
     use {
-        super::{compact, compact::LockoutOffset, *},
+        super::{compact, compact::CompactVoteStateUpdate, *},
         serde::{Deserialize, Deserializer, Serialize, Serializer},
-        solana_hash::Hash,
-        solana_short_vec as short_vec,
     };
-
-    #[derive(serde_derive::Deserialize, serde_derive::Serialize)]
-    struct CompactVoteStateUpdate {
-        root: Slot,
-        #[serde(with = "short_vec")]
-        lockout_offsets: Vec<LockoutOffset>,
-        hash: Hash,
-        timestamp: Option<UnixTimestamp>,
-    }
 
     pub fn serialize<S>(
         vote_state_update: &VoteStateUpdate,
@@ -288,110 +378,137 @@ pub mod serde_compact_vote_state_update {
     where
         S: Serializer,
     {
-        let compact_vote_state_update = CompactVoteStateUpdate {
-            root: vote_state_update.root.unwrap_or(Slot::MAX),
-            lockout_offsets: compact::lockout_offsets(
-                &vote_state_update.lockouts,
-                vote_state_update.root,
-            )
-            .map_err(serde::ser::Error::custom)?,
-            hash: Hash::new_from_array(vote_state_update.hash.to_bytes()),
-            timestamp: vote_state_update.timestamp,
-        };
-        compact_vote_state_update.serialize(serializer)
+        compact::vote_state_update_to_compact(vote_state_update)
+            .map_err(serde::ser::Error::custom)?
+            .serialize(serializer)
     }
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<VoteStateUpdate, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let CompactVoteStateUpdate {
-            root,
-            lockout_offsets,
-            hash,
-            timestamp,
-        } = CompactVoteStateUpdate::deserialize(deserializer)?;
-        let root = (root != Slot::MAX).then_some(root);
-        Ok(VoteStateUpdate {
-            root,
-            lockouts: compact::lockouts_from_offsets(&lockout_offsets, root)
-                .map_err(serde::de::Error::custom)?,
-            hash,
-            timestamp,
-        })
+        let repr = CompactVoteStateUpdate::deserialize(deserializer)?;
+        compact::vote_state_update_from_compact(repr).map_err(serde::de::Error::custom)
     }
 }
 
 #[cfg(feature = "serde")]
 pub mod serde_tower_sync {
     use {
-        super::{compact, compact::LockoutOffset, *},
+        super::{compact, compact::CompactTowerSync, *},
         serde::{Deserialize, Deserializer, Serialize, Serializer},
-        solana_hash::Hash,
-        solana_short_vec as short_vec,
     };
-
-    #[derive(serde_derive::Deserialize, serde_derive::Serialize)]
-    struct CompactTowerSync {
-        root: Slot,
-        #[serde(with = "short_vec")]
-        lockout_offsets: Vec<LockoutOffset>,
-        hash: Hash,
-        timestamp: Option<UnixTimestamp>,
-        block_id: Hash,
-    }
 
     pub fn serialize<S>(tower_sync: &TowerSync, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let compact_tower_sync = CompactTowerSync {
-            root: tower_sync.root.unwrap_or(Slot::MAX),
-            lockout_offsets: compact::lockout_offsets(&tower_sync.lockouts, tower_sync.root)
-                .map_err(serde::ser::Error::custom)?,
-            hash: Hash::new_from_array(tower_sync.hash.to_bytes()),
-            timestamp: tower_sync.timestamp,
-            block_id: Hash::new_from_array(tower_sync.block_id.to_bytes()),
-        };
-        compact_tower_sync.serialize(serializer)
+        compact::tower_sync_to_compact(tower_sync)
+            .map_err(serde::ser::Error::custom)?
+            .serialize(serializer)
     }
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<TowerSync, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let CompactTowerSync {
-            root,
-            lockout_offsets,
-            hash,
-            timestamp,
-            block_id,
-        } = CompactTowerSync::deserialize(deserializer)?;
-        let root = (root != Slot::MAX).then_some(root);
-        Ok(TowerSync {
-            root,
-            lockouts: compact::lockouts_from_offsets(&lockout_offsets, root)
-                .map_err(serde::de::Error::custom)?,
-            hash,
-            timestamp,
-            block_id,
-        })
+        let repr = CompactTowerSync::deserialize(deserializer)?;
+        compact::tower_sync_from_compact(repr).map_err(serde::de::Error::custom)
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use {super::*, itertools::Itertools, rand::Rng, solana_hash::Hash};
+/// Wincode schemas for the compact wire encodings of [`VoteStateUpdate`] and
+/// [`TowerSync`].
+///
+/// These are the wincode analog of [`serde_compact_vote_state_update`] /
+/// [`serde_tower_sync`]: the types' own (derived) wincode schemas encode the
+/// non-compact form, so the compact form is selected per-field via
+/// `#[wincode(with = ...)]` on [`crate::instruction::VoteInstruction`]. Each
+/// schema is a thin marker that converts to/from the shared `compact`
+/// representation (whose derived schema does the actual encoding) and produces
+/// bytes identical to bincode.
+#[cfg(feature = "wincode")]
+pub mod wincode_compact {
+    use {
+        super::{
+            compact,
+            compact::{
+                CompactTowerSync as CompactTowerSyncRepr,
+                CompactVoteStateUpdate as CompactVoteStateUpdateRepr,
+            },
+            TowerSync, VoteStateUpdate,
+        },
+        std::mem::MaybeUninit,
+        wincode::{
+            config::Config,
+            io::{Reader, Writer},
+            ReadError, ReadResult, SchemaRead, SchemaWrite, WriteError, WriteResult,
+        },
+    };
 
-    #[test]
-    fn test_serde_compact_vote_state_update() {
-        let mut rng = rand::rng();
-        for _ in 0..5000 {
-            run_serde_compact_vote_state_update(&mut rng);
+    /// Wincode schema mirroring [`super::serde_compact_vote_state_update`].
+    pub struct CompactVoteStateUpdate;
+
+    unsafe impl<C: Config> SchemaWrite<C> for CompactVoteStateUpdate {
+        type Src = VoteStateUpdate;
+
+        fn size_of(src: &Self::Src) -> WriteResult<usize> {
+            let repr = compact::vote_state_update_to_compact(src).map_err(WriteError::Custom)?;
+            <CompactVoteStateUpdateRepr as SchemaWrite<C>>::size_of(&repr)
+        }
+
+        fn write(writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
+            let repr = compact::vote_state_update_to_compact(src).map_err(WriteError::Custom)?;
+            <CompactVoteStateUpdateRepr as SchemaWrite<C>>::write(writer, &repr)
         }
     }
 
-    fn run_serde_compact_vote_state_update<R: Rng>(rng: &mut R) {
+    unsafe impl<'de, C: Config> SchemaRead<'de, C> for CompactVoteStateUpdate {
+        type Dst = VoteStateUpdate;
+
+        fn read(reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+            let repr = <CompactVoteStateUpdateRepr as SchemaRead<C>>::get(reader)?;
+            dst.write(compact::vote_state_update_from_compact(repr).map_err(ReadError::Custom)?);
+            Ok(())
+        }
+    }
+
+    /// Wincode schema mirroring [`super::serde_tower_sync`].
+    pub struct CompactTowerSync;
+
+    unsafe impl<C: Config> SchemaWrite<C> for CompactTowerSync {
+        type Src = TowerSync;
+
+        fn size_of(src: &Self::Src) -> WriteResult<usize> {
+            let repr = compact::tower_sync_to_compact(src).map_err(WriteError::Custom)?;
+            <CompactTowerSyncRepr as SchemaWrite<C>>::size_of(&repr)
+        }
+
+        fn write(writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
+            let repr = compact::tower_sync_to_compact(src).map_err(WriteError::Custom)?;
+            <CompactTowerSyncRepr as SchemaWrite<C>>::write(writer, &repr)
+        }
+    }
+
+    unsafe impl<'de, C: Config> SchemaRead<'de, C> for CompactTowerSync {
+        type Dst = TowerSync;
+
+        fn read(reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+            let repr = <CompactTowerSyncRepr as SchemaRead<C>>::get(reader)?;
+            dst.write(compact::tower_sync_from_compact(repr).map_err(ReadError::Custom)?);
+            Ok(())
+        }
+    }
+}
+
+#[cfg(all(test, feature = "bincode"))]
+mod tests {
+    use {super::*, itertools::Itertools, rand::Rng, solana_hash::Hash};
+
+    /// Build a random `VoteStateUpdate` with strictly increasing lockout slots
+    /// and an optional root below the first slot, suitable for exercising the
+    /// compact (offset-encoded) wire formats.
+    fn random_vote_state_update<R: Rng>(rng: &mut R) -> VoteStateUpdate {
         let lockouts: VecDeque<_> = std::iter::repeat_with(|| {
             let slot = 149_303_885_u64.saturating_add(rng.random_range(0..10_000));
             let confirmation_count = rng.random_range(0..33);
@@ -408,28 +525,64 @@ mod tests {
         });
         let timestamp = rng.random_bool(0.5).then(|| rng.random());
         let hash = Hash::from(rng.random::<[u8; 32]>());
-        let vote_state_update = VoteStateUpdate {
+        VoteStateUpdate {
             lockouts,
             root,
             hash,
             timestamp,
-        };
+        }
+    }
+
+    #[test]
+    fn test_serde_compact_vote_state_update() {
+        let mut rng = rand::rng();
+        for _ in 0..5000 {
+            run_serde_compact_vote_state_update(&mut rng);
+        }
+    }
+
+    fn run_serde_compact_vote_state_update<R: Rng>(rng: &mut R) {
+        let vote_state_update = random_vote_state_update(rng);
+        #[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
         #[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
         enum VoteInstruction {
             #[serde(with = "serde_compact_vote_state_update")]
-            UpdateVoteState(VoteStateUpdate),
+            UpdateVoteState(
+                #[cfg_attr(
+                    feature = "wincode",
+                    wincode(with = "wincode_compact::CompactVoteStateUpdate")
+                )]
+                VoteStateUpdate,
+            ),
             UpdateVoteStateSwitch(
-                #[serde(with = "serde_compact_vote_state_update")] VoteStateUpdate,
+                #[serde(with = "serde_compact_vote_state_update")]
+                #[cfg_attr(
+                    feature = "wincode",
+                    wincode(with = "wincode_compact::CompactVoteStateUpdate")
+                )]
+                VoteStateUpdate,
                 Hash,
             ),
         }
-        let vote = VoteInstruction::UpdateVoteState(vote_state_update.clone());
-        let bytes = bincode::serialize(&vote).unwrap();
-        assert_eq!(vote, bincode::deserialize(&bytes).unwrap());
+
+        // bincode is the reference encoding; when wincode is enabled, assert it
+        // produces identical bytes and round-trips the same value.
+        let check = |vote: &VoteInstruction| {
+            let bytes = bincode::serialize(vote).unwrap();
+            assert_eq!(*vote, bincode::deserialize(&bytes).unwrap());
+            #[cfg(feature = "wincode")]
+            {
+                assert_eq!(bytes, wincode::serialize(vote).unwrap());
+                assert_eq!(*vote, wincode::deserialize(&bytes).unwrap());
+            }
+        };
+
+        check(&VoteInstruction::UpdateVoteState(vote_state_update.clone()));
         let hash = Hash::from(rng.random::<[u8; 32]>());
-        let vote = VoteInstruction::UpdateVoteStateSwitch(vote_state_update, hash);
-        let bytes = bincode::serialize(&vote).unwrap();
-        assert_eq!(vote, bincode::deserialize(&bytes).unwrap());
+        check(&VoteInstruction::UpdateVoteStateSwitch(
+            vote_state_update,
+            hash,
+        ));
     }
 
     #[test]
@@ -438,5 +591,11 @@ mod tests {
         let data: &[u8] = &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00];
         let circ_buf: CircBuf<()> = bincode::deserialize(data).unwrap();
         assert_eq!(circ_buf.last(), None);
+
+        #[cfg(feature = "wincode")]
+        {
+            let circ_buf: CircBuf<()> = wincode::deserialize(data).unwrap();
+            assert_eq!(circ_buf.last(), None);
+        }
     }
 }

--- a/vote-interface/src/state/vote_instruction_data.rs
+++ b/vote-interface/src/state/vote_instruction_data.rs
@@ -20,11 +20,13 @@ use {
     feature = "frozen-abi",
     frozen_abi(
         api_digest = "GvUzgtcxhKVVxPAjSntXGPqjLZK5ovgZzCiUP1tDpB9q",
-        abi_digest = "6kXER3mQxF3R1Th74tQFGfYUWJfBakNZZVyU4rTrNEek"
+        abi_digest = "6kXER3mQxF3R1Th74tQFGfYUWJfBakNZZVyU4rTrNEek",
+        abi_serializer = "bincode"
     ),
     derive(AbiExample, StableAbi, StableAbiSample)
 )]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Default, Debug, PartialEq, Eq, Clone)]
 pub struct Vote {
     /// A stack of votes starting with the oldest vote
@@ -53,11 +55,13 @@ impl Vote {
     feature = "frozen-abi",
     frozen_abi(
         api_digest = "CxyuwbaEdzP7jDCZyxjgQvLGXadBUZF3LoUvbSpQ6tYN",
-        abi_digest = "CAZasoggS6VYsJWdWf9tWUmqXjmCe1iCa1s1szSkcV3q"
+        abi_digest = "CAZasoggS6VYsJWdWf9tWUmqXjmCe1iCa1s1szSkcV3q",
+        abi_serializer = "bincode"
     ),
     derive(AbiExample, StableAbi, StableAbiSample)
 )]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Default, Debug, PartialEq, Eq, Clone)]
 pub struct VoteStateUpdate {
     /// The proposed tower
@@ -110,11 +114,13 @@ impl VoteStateUpdate {
     feature = "frozen-abi",
     frozen_abi(
         api_digest = "6UDiQMH4wbNwkMHosPMtekMYu2Qa6CHPZ2ymK4mc6FGu",
-        abi_digest = "AFc7BWoFERboQDSN7VmXqXu7MoV3TwksgKoabdarYycF"
+        abi_digest = "AFc7BWoFERboQDSN7VmXqXu7MoV3TwksgKoabdarYycF",
+        abi_serializer = "bincode"
     ),
     derive(AbiExample, StableAbi, StableAbiSample)
 )]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Default, Debug, PartialEq, Eq, Clone)]
 pub struct TowerSync {
     /// The proposed tower
@@ -208,6 +214,7 @@ impl TowerSync {
 }
 
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
 pub struct VoteInit {
     pub node_pubkey: Pubkey,
@@ -218,6 +225,7 @@ pub struct VoteInit {
 
 #[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_as)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct VoteInitV2 {
     pub node_pubkey: Pubkey,
@@ -254,6 +262,7 @@ impl Default for VoteInitV2 {
 
 #[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_as)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct VoterWithBLSArgs {
     #[cfg_attr(
@@ -278,6 +287,7 @@ impl Default for VoterWithBLSArgs {
 }
 
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum VoteAuthorize {
     Voter,
@@ -286,6 +296,7 @@ pub enum VoteAuthorize {
 }
 
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct VoteAuthorizeWithSeedArgs {
     pub authorization_type: VoteAuthorize,
@@ -295,6 +306,7 @@ pub struct VoteAuthorizeWithSeedArgs {
 }
 
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct VoteAuthorizeCheckedWithSeedArgs {
     pub authorization_type: VoteAuthorize,

--- a/vote-interface/src/state/vote_instruction_data.rs
+++ b/vote-interface/src/state/vote_instruction_data.rs
@@ -21,7 +21,7 @@ use {
     frozen_abi(
         api_digest = "GvUzgtcxhKVVxPAjSntXGPqjLZK5ovgZzCiUP1tDpB9q",
         abi_digest = "6kXER3mQxF3R1Th74tQFGfYUWJfBakNZZVyU4rTrNEek",
-        abi_serializer = "bincode"
+        abi_serializer = ["bincode", "wincode"]
     ),
     derive(AbiExample, StableAbi, StableAbiSample)
 )]
@@ -56,7 +56,7 @@ impl Vote {
     frozen_abi(
         api_digest = "CxyuwbaEdzP7jDCZyxjgQvLGXadBUZF3LoUvbSpQ6tYN",
         abi_digest = "CAZasoggS6VYsJWdWf9tWUmqXjmCe1iCa1s1szSkcV3q",
-        abi_serializer = "bincode"
+        abi_serializer = ["bincode", "wincode"]
     ),
     derive(AbiExample, StableAbi, StableAbiSample)
 )]
@@ -115,7 +115,7 @@ impl VoteStateUpdate {
     frozen_abi(
         api_digest = "6UDiQMH4wbNwkMHosPMtekMYu2Qa6CHPZ2ymK4mc6FGu",
         abi_digest = "AFc7BWoFERboQDSN7VmXqXu7MoV3TwksgKoabdarYycF",
-        abi_serializer = "bincode"
+        abi_serializer = ["bincode", "wincode"]
     ),
     derive(AbiExample, StableAbi, StableAbiSample)
 )]

--- a/vote-interface/src/state/vote_state_1_14_11.rs
+++ b/vote-interface/src/state/vote_state_1_14_11.rs
@@ -11,11 +11,13 @@ const DEFAULT_PRIOR_VOTERS_OFFSET: usize = 82;
     feature = "frozen-abi",
     frozen_abi(
         api_digest = "2rjXSWaNeAdoUNJDC5otC7NPR1qXHvLMuAs5faE4DPEt",
-        abi_digest = "AiZEyXQnygp5KQWY9godna9h8fZQ7nFPJvdvkuNkyAWc"
+        abi_digest = "AiZEyXQnygp5KQWY9godna9h8fZQ7nFPJvdvkuNkyAWc",
+        abi_serializer = "bincode"
     ),
     derive(AbiExample, StableAbi, StableAbiSample)
 )]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "dev-context-only-utils", derive(Arbitrary))]
 pub struct VoteState1_14_11 {

--- a/vote-interface/src/state/vote_state_1_14_11.rs
+++ b/vote-interface/src/state/vote_state_1_14_11.rs
@@ -12,7 +12,7 @@ const DEFAULT_PRIOR_VOTERS_OFFSET: usize = 82;
     frozen_abi(
         api_digest = "2rjXSWaNeAdoUNJDC5otC7NPR1qXHvLMuAs5faE4DPEt",
         abi_digest = "AiZEyXQnygp5KQWY9godna9h8fZQ7nFPJvdvkuNkyAWc",
-        abi_serializer = "bincode"
+        abi_serializer = ["bincode", "wincode"]
     ),
     derive(AbiExample, StableAbi, StableAbiSample)
 )]

--- a/vote-interface/src/state/vote_state_v3.rs
+++ b/vote-interface/src/state/vote_state_v3.rs
@@ -23,11 +23,13 @@ use {
     feature = "frozen-abi",
     frozen_abi(
         api_digest = "pZqasQc6duzMYzpzU7eriHH9cMXmubuUP4NmCrkWZjt",
-        abi_digest = "6xrS3B1cUyFYdPAwavAQ4DKpGTWsdoV4fkaGfiEBRmtQ"
+        abi_digest = "6xrS3B1cUyFYdPAwavAQ4DKpGTWsdoV4fkaGfiEBRmtQ",
+        abi_serializer = "bincode"
     ),
     derive(AbiExample, StableAbi, StableAbiSample)
 )]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "dev-context-only-utils", derive(Arbitrary))]
 pub struct VoteStateV3 {

--- a/vote-interface/src/state/vote_state_v3.rs
+++ b/vote-interface/src/state/vote_state_v3.rs
@@ -24,7 +24,7 @@ use {
     frozen_abi(
         api_digest = "pZqasQc6duzMYzpzU7eriHH9cMXmubuUP4NmCrkWZjt",
         abi_digest = "6xrS3B1cUyFYdPAwavAQ4DKpGTWsdoV4fkaGfiEBRmtQ",
-        abi_serializer = "bincode"
+        abi_serializer = ["bincode", "wincode"]
     ),
     derive(AbiExample, StableAbi, StableAbiSample)
 )]

--- a/vote-interface/src/state/vote_state_v4.rs
+++ b/vote-interface/src/state/vote_state_v4.rs
@@ -22,12 +22,14 @@ use {
     feature = "frozen-abi",
     frozen_abi(
         api_digest = "ALZS4x22Ga8M6KkLVgdEJu3ZQUUSBkFHAkErmSvFLzUM",
-        abi_digest = "EhUJhYgvsX9T4hJPJovYbNLRiMR8irkT7K4BQQwZ797b"
+        abi_digest = "EhUJhYgvsX9T4hJPJovYbNLRiMR8irkT7K4BQQwZ797b",
+        abi_serializer = "bincode"
     ),
     derive(AbiExample, StableAbi, StableAbiSample)
 )]
 #[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_as)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "dev-context-only-utils", derive(Arbitrary))]
 pub struct VoteStateV4 {

--- a/vote-interface/src/state/vote_state_v4.rs
+++ b/vote-interface/src/state/vote_state_v4.rs
@@ -23,7 +23,7 @@ use {
     frozen_abi(
         api_digest = "ALZS4x22Ga8M6KkLVgdEJu3ZQUUSBkFHAkErmSvFLzUM",
         abi_digest = "EhUJhYgvsX9T4hJPJovYbNLRiMR8irkT7K4BQQwZ797b",
-        abi_serializer = "bincode"
+        abi_serializer = ["bincode", "wincode"]
     ),
     derive(AbiExample, StableAbi, StableAbiSample)
 )]

--- a/vote-interface/src/state/vote_state_versions.rs
+++ b/vote-interface/src/state/vote_state_versions.rs
@@ -14,6 +14,7 @@ use {
     feature = "serde",
     derive(serde_derive::Deserialize, serde_derive::Serialize)
 )]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum VoteStateVersions {
     Uninitialized,


### PR DESCRIPTION
Adds a `wincode` feature mirroring the existing `serde`/`bincode` support, deriving `wincode::SchemaWrite`/`SchemaRead` on every type that derives serde `Serialize`/`Deserialize`. The schemas are bincode-wire-compatible - this is verified by switching `abi_serializer` to `wincode`, which maintains the `abi_digest` unchanged.

**The bulk of the change is the compact encoding** (`CompactUpdateVoteState*` / `TowerSync*`), which serde implements via custom `serde(with = …)` modules that delta-encode lockout slots as varint offsets in a `short_vec`. To support this without duplicating the wire layout:
- A new private `compact` module defines the wire-format repr structs **once**, with per-backend field annotations (`serde(with)` / `wincode(with = "Leb128Int…/LockoutOffsetShortVec")`), and owns the shared `VoteStateUpdate`/`TowerSync` ⇄ repr conversions.
- `serde_compact_*` and a new `wincode_compact` module are thin bridges over those conversions; the wincode schemas are tiny marker types referenced from `VoteInstruction` via `wincode(with = …)` (a type can only carry one `SchemaWrite`/`SchemaRead`, so the non-compact derived schema and the compact one must live on different types — same reason serde needs `with`-modules).

**Worth a closer review:** factoring the conversions out re-implements the slot-delta calculation. The serde code used `iter().scan(…).collect()`; the shared `lockout_offsets`/`lockouts_from_offsets` use explicit loops over `Vec::with_capacity`/`VecDeque::with_capacity`, so the target collections are now correctly pre-allocated (the `scan`+`collect` path didn't size-hint). Logic is otherwise equivalent.
