### PR TITLE
transaction: no-std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -328,7 +328,7 @@ solana-system-wasm-js = { path = "system-wasm-js", version = "1.0" }
 solana-sysvar = { path = "sysvar", version = "4.0.0" }
 solana-sysvar-id = { path = "sysvar-id", version = "3.0.0" }
 solana-time-utils = { path = "time-utils", version = "3.0.0" }
-solana-transaction = { path = "transaction", version = "4.1.1" }
+solana-transaction = { path = "transaction", version = "4.1.1", default-features = false }
 solana-transaction-error = { path = "transaction-error", version = "3.2.0" }
 solana-validator-exit = { path = "validator-exit", version = "3.0.0" }
 solana-vote-interface = { path = "vote-interface", version = "6.0.0" }

--- a/client-traits/Cargo.toml
+++ b/client-traits/Cargo.toml
@@ -25,5 +25,5 @@ solana-pubkey = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 solana-system-interface = { workspace = true, features = ["bincode"] }
-solana-transaction = { workspace = true, features = ["wincode"] }
+solana-transaction = { workspace = true, features = ["std", "wincode"] }
 solana-transaction-error = { workspace = true }

--- a/scripts/check-no-std.sh
+++ b/scripts/check-no-std.sh
@@ -54,6 +54,7 @@ no_std_alloc_crates=(
   -p solana-message
   -p solana-serialize-utils
   -p solana-short-vec
+  -p solana-transaction
 )
 
 # Use the upstream BPF target, which doesn't support std, to make sure that our

--- a/sdk-wasm-js/Cargo.toml
+++ b/sdk-wasm-js/Cargo.toml
@@ -27,7 +27,7 @@ solana-message = { workspace = true }
 solana-packet = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }
-solana-transaction = { workspace = true, features = ["verify", "wincode"] }
+solana-transaction = { workspace = true, features = ["std", "verify", "wincode"] }
 wincode = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -84,7 +84,7 @@ solana-shred-version = { workspace = true, optional = true }
 solana-signature = { workspace = true, features = ["rand", "serde", "std", "verify"], optional = true }
 solana-signer = { workspace = true, optional = true }
 solana-time-utils = { workspace = true }
-solana-transaction = { workspace = true, features = ["blake3", "serde", "verify"], optional = true }
+solana-transaction = { workspace = true, features = ["blake3", "serde", "std", "verify"], optional = true }
 solana-transaction-error = { workspace = true, features = ["serde"], optional = true }
 thiserror = { workspace = true }
 

--- a/system-transaction/Cargo.toml
+++ b/system-transaction/Cargo.toml
@@ -20,4 +20,4 @@ solana-message = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-signer = { workspace = true }
 solana-system-interface = { workspace = true, features = ["bincode"] }
-solana-transaction = { workspace = true, features = ["wincode"] }
+solana-transaction = { workspace = true, features = ["std", "wincode"] }

--- a/transaction/Cargo.toml
+++ b/transaction/Cargo.toml
@@ -16,6 +16,7 @@ all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
 [features]
+default = ["std"]
 blake3 = ["solana-message/blake3", "wincode"]
 dev-context-only-utils = ["blake3", "serde", "verify", "solana-hash/atomic"]
 frozen-abi = [
@@ -34,9 +35,9 @@ serde = [
     "solana-transaction-error/serde",
     "solana-short-vec/serde",
 ]
+std = ["dep:solana-signer", "solana-message/std"]
 verify = ["blake3", "solana-signature/verify"]
 wincode = [
-    "dep:solana-signer",
     "dep:wincode",
     "solana-short-vec/wincode",
     "solana-message/wincode",
@@ -52,7 +53,7 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = ["froz
 solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-instruction-error = { workspace = true }
-solana-message = { workspace = true, features = ["std"] }
+solana-message = { workspace = true }
 solana-sanitize = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-short-vec = { workspace = true, optional = true }

--- a/transaction/src/lib.rs
+++ b/transaction/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![no_std]
 //! Atomically-committed sequences of instructions.
 //!
 //! While [`Instruction`]s are the basic unit of computation in Solana, they are
@@ -110,8 +111,20 @@
 //! # Ok::<(), anyhow::Error>(())
 //! ```
 
+extern crate alloc;
+#[cfg(any(feature = "frozen-abi", feature = "std"))]
+extern crate std;
+
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::{frozen_abi, AbiExample, StableAbi};
+#[cfg(all(feature = "wincode", feature = "std"))]
+pub use solana_signer::{signers::Signers, SignerError};
+use {
+    alloc::{vec, vec::Vec},
+    solana_message::inline_nonce::is_advance_nonce_instruction_data,
+    solana_sanitize::{Sanitize, SanitizeError},
+    solana_sdk_ids::system_program,
+};
 #[cfg(feature = "serde")]
 use {
     serde_derive::{Deserialize, Serialize},
@@ -129,16 +142,10 @@ pub use {
 pub use {
     solana_hash::Hash,
     solana_short_vec::ShortU16,
-    solana_signer::{signers::Signers, SignerError},
     wincode::{containers, SchemaRead, SchemaWrite},
 };
-use {
-    solana_message::inline_nonce::is_advance_nonce_instruction_data,
-    solana_sanitize::{Sanitize, SanitizeError},
-    solana_sdk_ids::system_program,
-    std::result,
-};
 
+#[cfg(feature = "std")]
 pub mod sanitized;
 pub mod simple_vote_transaction_checker;
 pub mod versioned;
@@ -214,7 +221,7 @@ impl solana_frozen_abi::rand::prelude::Distribution<Transaction>
 {
     fn sample<R: solana_frozen_abi::rand::Rng + ?Sized>(&self, rng: &mut R) -> Transaction {
         let signatures: Vec<Signature> = (0..rng.random_range(1..4))
-            .map(|_| Signature::from(std::array::from_fn(|_| rng.random::<u8>())))
+            .map(|_| Signature::from(core::array::from_fn(|_| rng.random::<u8>())))
             .collect();
         let accounts: Vec<AccountMeta> = (0..rng.random_range(1..6))
             .map(|_| AccountMeta {
@@ -242,7 +249,7 @@ impl solana_frozen_abi::rand::prelude::Distribution<Transaction>
 }
 
 impl Sanitize for Transaction {
-    fn sanitize(&self) -> result::Result<(), SanitizeError> {
+    fn sanitize(&self) -> Result<(), SanitizeError> {
         if self.message.header.num_required_signatures as usize > self.signatures.len() {
             return Err(SanitizeError::IndexOutOfBounds);
         }
@@ -396,7 +403,7 @@ impl Transaction {
     /// #
     /// # Ok::<(), anyhow::Error>(())
     /// ```
-    #[cfg(feature = "wincode")]
+    #[cfg(all(feature = "wincode", feature = "std"))]
     pub fn new<T: Signers + ?Sized>(
         from_keypairs: &T,
         message: Message,
@@ -550,7 +557,7 @@ impl Transaction {
     /// #
     /// # Ok::<(), anyhow::Error>(())
     /// ```
-    #[cfg(feature = "wincode")]
+    #[cfg(all(feature = "wincode", feature = "std"))]
     pub fn new_signed_with_payer<T: Signers + ?Sized>(
         instructions: &[Instruction],
         payer: Option<&Address>,
@@ -576,7 +583,7 @@ impl Transaction {
     ///
     /// Panics when signing fails. See [`Transaction::try_sign`] and for a full
     /// description of failure conditions.
-    #[cfg(feature = "wincode")]
+    #[cfg(all(feature = "wincode", feature = "std"))]
     pub fn new_with_compiled_instructions<T: Signers + ?Sized>(
         from_keypairs: &T,
         keys: &[Address],
@@ -756,7 +763,7 @@ impl Transaction {
     /// #
     /// # Ok::<(), anyhow::Error>(())
     /// ```
-    #[cfg(feature = "wincode")]
+    #[cfg(all(feature = "wincode", feature = "std"))]
     pub fn sign<T: Signers + ?Sized>(&mut self, keypairs: &T, recent_blockhash: Hash) {
         if let Err(e) = self.try_sign(keypairs, recent_blockhash) {
             panic!("Transaction::sign failed with error {e:?}");
@@ -783,7 +790,7 @@ impl Transaction {
     /// handle the error. See the documentation for
     /// [`Transaction::try_partial_sign`] for a full description of failure
     /// conditions.
-    #[cfg(feature = "wincode")]
+    #[cfg(all(feature = "wincode", feature = "std"))]
     pub fn partial_sign<T: Signers + ?Sized>(&mut self, keypairs: &T, recent_blockhash: Hash) {
         if let Err(e) = self.try_partial_sign(keypairs, recent_blockhash) {
             panic!("Transaction::partial_sign failed with error {e:?}");
@@ -803,7 +810,7 @@ impl Transaction {
     ///
     /// Panics if signing fails. Use [`Transaction::try_partial_sign_unchecked`]
     /// to handle the error.
-    #[cfg(feature = "wincode")]
+    #[cfg(all(feature = "wincode", feature = "std"))]
     pub fn partial_sign_unchecked<T: Signers + ?Sized>(
         &mut self,
         keypairs: &T,
@@ -896,12 +903,12 @@ impl Transaction {
     /// #
     /// # Ok::<(), anyhow::Error>(())
     /// ```
-    #[cfg(feature = "wincode")]
+    #[cfg(all(feature = "wincode", feature = "std"))]
     pub fn try_sign<T: Signers + ?Sized>(
         &mut self,
         keypairs: &T,
         recent_blockhash: Hash,
-    ) -> result::Result<(), SignerError> {
+    ) -> Result<(), SignerError> {
         self.try_partial_sign(keypairs, recent_blockhash)?;
 
         if !self.is_signed() {
@@ -960,12 +967,12 @@ impl Transaction {
     /// [`PresignerError::VerificationFailure`]: https://docs.rs/solana-signer/latest/solana_signer/enum.PresignerError.html#variant.WrongSize
     /// [`solana-remote-wallet`]: https://docs.rs/solana-remote-wallet/latest/
     /// [`RemoteKeypair`]: https://docs.rs/solana-remote-wallet/latest/solana_remote_wallet/remote_keypair/struct.RemoteKeypair.html
-    #[cfg(feature = "wincode")]
+    #[cfg(all(feature = "wincode", feature = "std"))]
     pub fn try_partial_sign<T: Signers + ?Sized>(
         &mut self,
         keypairs: &T,
         recent_blockhash: Hash,
-    ) -> result::Result<(), SignerError> {
+    ) -> Result<(), SignerError> {
         let positions: Vec<usize> = self
             .get_signing_keypair_positions(&keypairs.pubkeys())?
             .into_iter()
@@ -987,13 +994,13 @@ impl Transaction {
     /// # Errors
     ///
     /// Returns an error if signing fails.
-    #[cfg(feature = "wincode")]
+    #[cfg(all(feature = "wincode", feature = "std"))]
     pub fn try_partial_sign_unchecked<T: Signers + ?Sized>(
         &mut self,
         keypairs: &T,
         positions: Vec<usize>,
         recent_blockhash: Hash,
-    ) -> result::Result<(), SignerError> {
+    ) -> Result<(), SignerError> {
         // if you change the blockhash, you're re-signing...
         if recent_blockhash != self.message.recent_blockhash {
             self.message.recent_blockhash = recent_blockhash;
@@ -1150,14 +1157,15 @@ mod tests {
 
     use {
         super::*,
+        alloc::{boxed::Box, vec},
         bincode::{deserialize, serialize, serialized_size},
+        core::mem::size_of,
         solana_instruction::AccountMeta,
         solana_keypair::Keypair,
         solana_presigner::Presigner,
         solana_sha256_hasher::hash,
         solana_signer::Signer,
         solana_system_interface::instruction as system_instruction,
-        std::mem::size_of,
     };
 
     fn get_program_id(tx: &Transaction, instruction_index: usize) -> &Address {

--- a/transaction/src/sanitized.rs
+++ b/transaction/src/sanitized.rs
@@ -1,5 +1,6 @@
 use {
     crate::versioned::{sanitized::SanitizedVersionedTransaction, VersionedTransaction},
+    alloc::vec::Vec,
     solana_address::Address,
     solana_hash::Hash,
     solana_message::{
@@ -327,6 +328,7 @@ impl SanitizedTransaction {
 mod tests {
     use {
         super::*,
+        alloc::vec,
         solana_instruction::{AccountMeta, Instruction},
         solana_keypair::Keypair,
         solana_message::{MessageHeader, SimpleAddressLoader},

--- a/transaction/src/versioned/mod.rs
+++ b/transaction/src/versioned/mod.rs
@@ -2,18 +2,23 @@
 
 use {
     crate::Transaction,
+    alloc::vec::Vec,
+    core::cmp::Ordering,
     solana_message::{inline_nonce::is_advance_nonce_instruction_data, VersionedMessage},
     solana_sanitize::SanitizeError,
     solana_sdk_ids::system_program,
     solana_signature::Signature,
-    std::cmp::Ordering,
+};
+#[cfg(all(feature = "wincode", feature = "std"))]
+use {
+    alloc::string::ToString,
+    solana_signer::{signers::Signers, SignerError},
 };
 #[cfg(feature = "wincode")]
 use {
     core::mem::MaybeUninit,
     solana_message::{v1::SIGNATURE_SIZE, MESSAGE_VERSION_PREFIX},
     solana_short_vec::ShortU16,
-    solana_signer::{signers::Signers, SignerError},
     wincode::{
         config::Config,
         containers, context,
@@ -86,11 +91,11 @@ impl From<Transaction> for VersionedTransaction {
 impl VersionedTransaction {
     /// Signs a versioned message and if successful, returns a signed
     /// transaction.
-    #[cfg(feature = "wincode")]
+    #[cfg(all(feature = "wincode", feature = "std"))]
     pub fn try_new<T: Signers + ?Sized>(
         message: VersionedMessage,
         keypairs: &T,
-    ) -> std::result::Result<Self, SignerError> {
+    ) -> Result<Self, SignerError> {
         let static_account_keys = message.static_account_keys();
         if static_account_keys.len() < message.header().num_required_signatures as usize {
             return Err(SignerError::InvalidInput("invalid message".to_string()));
@@ -115,7 +120,7 @@ impl VersionedTransaction {
                     .position(|key| key == signer_key)
                     .ok_or(SignerError::KeypairPubkeyMismatch)
             })
-            .collect::<std::result::Result<_, SignerError>>()?;
+            .collect::<Result<_, SignerError>>()?;
 
         let unordered_signatures = keypairs.try_sign_message(&message_data)?;
         let signatures: Vec<Signature> = signature_indexes
@@ -126,7 +131,7 @@ impl VersionedTransaction {
                     .copied()
                     .ok_or_else(|| SignerError::InvalidInput("invalid keypairs".to_string()))
             })
-            .collect::<std::result::Result<_, SignerError>>()?;
+            .collect::<Result<_, SignerError>>()?;
 
         Ok(Self {
             signatures,
@@ -134,13 +139,13 @@ impl VersionedTransaction {
         })
     }
 
-    pub fn sanitize(&self) -> std::result::Result<(), SanitizeError> {
+    pub fn sanitize(&self) -> Result<(), SanitizeError> {
         self.message.sanitize()?;
         self.sanitize_signatures()?;
         Ok(())
     }
 
-    pub(crate) fn sanitize_signatures(&self) -> std::result::Result<(), SanitizeError> {
+    pub(crate) fn sanitize_signatures(&self) -> Result<(), SanitizeError> {
         Self::sanitize_signatures_inner(
             usize::from(self.message.header().num_required_signatures),
             self.message.static_account_keys().len(),
@@ -152,7 +157,7 @@ impl VersionedTransaction {
         num_required_signatures: usize,
         num_static_account_keys: usize,
         num_signatures: usize,
-    ) -> std::result::Result<(), SanitizeError> {
+    ) -> Result<(), SanitizeError> {
         match num_required_signatures.cmp(&num_signatures) {
             Ordering::Greater => Err(SanitizeError::IndexOutOfBounds),
             Ordering::Less => Err(SanitizeError::InvalidValue),
@@ -362,6 +367,7 @@ unsafe impl<'de, C: Config> SchemaRead<'de, C> for VersionedTransaction {
 mod tests {
     use {
         super::*,
+        alloc::vec,
         solana_address::{Address, ADDRESS_BYTES},
         solana_hash::Hash,
         solana_instruction::{AccountMeta, Instruction},

--- a/transaction/src/versioned/sanitized.rs
+++ b/transaction/src/versioned/sanitized.rs
@@ -1,6 +1,7 @@
 use {
-    crate::versioned::VersionedTransaction, solana_message::SanitizedVersionedMessage,
-    solana_sanitize::SanitizeError, solana_signature::Signature,
+    crate::versioned::VersionedTransaction, alloc::vec::Vec,
+    solana_message::SanitizedVersionedMessage, solana_sanitize::SanitizeError,
+    solana_signature::Signature,
 };
 
 /// Wraps a sanitized `VersionedTransaction` to provide a safe API
@@ -42,6 +43,7 @@ impl SanitizedVersionedTransaction {
 mod tests {
     use {
         super::*,
+        alloc::vec,
         solana_hash::Hash,
         solana_message::{v0, VersionedMessage},
         solana_pubkey::Pubkey,


### PR DESCRIPTION
Continues work of https://github.com/anza-xyz/solana-sdk/pull/746 https://github.com/anza-xyz/solana-sdk/pull/744  https://github.com/anza-xyz/solana-sdk/pull/743 that will enable pinnochio programs to parse tx data.

The PR makes the `solana-transaction` crate no-std with default enabled `std` feature for backwards compatibility. 