### PR TITLE
frozen-abi: fix propagate generic bounds in stableabi derives

### DIFF
--- a/frozen-abi-macro/src/lib.rs
+++ b/frozen-abi-macro/src/lib.rs
@@ -33,11 +33,11 @@ pub fn derive_stable_abi(_item: TokenStream) -> TokenStream {
 #[proc_macro_derive(StableAbi)]
 pub fn derive_stable_abi(item: TokenStream) -> TokenStream {
     let item = parse_macro_input!(item as Item);
-    let (ident, generics) = match &item {
-        Item::Struct(s) => (&s.ident, &s.generics),
-        Item::Enum(e) => (&e.ident, &e.generics),
-        Item::Type(t) => (&t.ident, &t.generics),
-        _ => {
+    let (ident, generics) = match item {
+        Item::Struct(s) => (s.ident, s.generics),
+        Item::Enum(e) => (e.ident, e.generics),
+        Item::Type(t) => (t.ident, t.generics),
+        item => {
             return Error::new_spanned(
                 item,
                 "StableAbi can only be derived for struct, enum, or type alias",
@@ -46,6 +46,7 @@ pub fn derive_stable_abi(item: TokenStream) -> TokenStream {
             .into();
         }
     };
+    let generics = add_stable_abi_type_param_bounds(generics);
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     let expanded = quote! {
@@ -217,9 +218,21 @@ fn stable_abi_sample_field_expr(field: &syn::Field) -> Result<TokenStream2, Erro
 }
 
 #[cfg(feature = "frozen-abi")]
+fn add_stable_abi_type_param_bounds(mut generics: syn::Generics) -> syn::Generics {
+    generics.type_params_mut().for_each(|type_param| {
+        type_param.bounds.push(syn::parse_quote!(
+            ::solana_frozen_abi::stable_abi::StableAbi
+        ));
+    });
+    generics
+}
+
+#[cfg(feature = "frozen-abi")]
 fn derive_stable_abi_sample_struct_type(input: ItemStruct) -> Result<TokenStream2, Error> {
     let type_name = &input.ident;
-    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let generics = add_stable_abi_type_param_bounds(input.generics);
+
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let turbofish = ty_generics.as_turbofish();
     let sample_expr = match &input.fields {
         Fields::Named(named_fields) => {
@@ -297,7 +310,9 @@ fn stable_abi_sample_enum_variant_expr(
 fn derive_stable_abi_sample_enum_type(input: ItemEnum) -> Result<TokenStream2, Error> {
     let type_name = &input.ident;
     let variants = &input.variants;
-    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let generics = add_stable_abi_type_param_bounds(input.generics);
+
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let variant_count = variants.len();
     let match_arms = variants
         .iter()

--- a/frozen-abi/src/stable_abi/impls.rs
+++ b/frozen-abi/src/stable_abi/impls.rs
@@ -839,4 +839,50 @@ mod tests {
             ],
         ]
     );
+
+    const ARRAY_LEN: usize = 1;
+    #[derive(wincode::SchemaWrite)]
+    #[cfg_attr(
+        feature = "frozen-abi",
+        derive(
+            solana_frozen_abi_macro::StableAbi,
+            solana_frozen_abi_macro::StableAbiSample
+        )
+    )]
+    pub struct TestGenericArrayWrapper<I> {
+        a: [I; ARRAY_LEN],
+    }
+
+    #[derive(wincode::SchemaWrite)]
+    #[cfg_attr(
+        feature = "frozen-abi",
+        derive(
+            solana_frozen_abi_macro::StableAbi,
+            solana_frozen_abi_macro::StableAbiSample
+        )
+    )]
+    pub struct TestGenericArrayWrapperMore<I, T> {
+        a: [I; ARRAY_LEN],
+        b: [T; ARRAY_LEN],
+        c: Option<(I, T)>,
+    }
+
+    type More = (bool, u64, usize, Option<usize>);
+
+    #[derive(wincode::SchemaWrite)]
+    #[cfg_attr(
+        feature = "frozen-abi",
+        derive(
+            solana_frozen_abi_macro::StableAbi,
+            solana_frozen_abi_macro::StableAbiSample
+        ),
+        solana_frozen_abi_macro::frozen_abi(
+            abi_digest = "z3Tk2mbrbe6j266gAp6Eo9D9Z5NgvxFQRVHvyJEubrv",
+            abi_serializer = "wincode"
+        )
+    )]
+    struct TestNestedGenericBounds {
+        a: TestGenericArrayWrapper<([u8; 32], u64, u64)>,
+        b: TestGenericArrayWrapperMore<([u8; 32], u64, u64), More>,
+    }
 }


### PR DESCRIPTION
### Description

Derive macros did not propagate generic bounds, which rendered those unusable on types such e.g. `CircBuf` which originally exposed the issue.

### Summary

- fixed StableAbi derives for generic types by adding bounds before generating impls
- added new test type to cover the case