### PR TITLE
feat(frozen-abi): add helper for creating sample FromIterator collections

### DIFF
--- a/frozen-abi/src/stable_abi/impls.rs
+++ b/frozen-abi/src/stable_abi/impls.rs
@@ -14,7 +14,7 @@ use {
     },
 };
 
-const DEFAULT_COLLECTION_MAX_SAMPLE_LEN: usize = 5;
+pub(crate) const DEFAULT_COLLECTION_MAX_SAMPLE_LEN: usize = 5;
 const DEFAULT_COLLECTION_MAX_SAMPLE_LEN_NON_DETERMINISTIC_ORDER: usize = 1;
 
 macro_rules! impl_stable_abi_via_standard_uniform {
@@ -353,7 +353,7 @@ mod tests {
     use {
         crate::stable_abi::context::{SequenceLenMax, SequenceLenRange},
         core::num::NonZero,
-        std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
+        std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, LinkedList, VecDeque},
     };
 
     const ABI_SHARED_WINCODE_VS_BINCODE: &str = "AgNkEpErnFBuy7iTAEUUAC1fbvokEkhbsfFnx4DtXAvY";
@@ -788,7 +788,6 @@ mod tests {
         e: std::net::SocketAddrV6,
         f: std::net::SocketAddr,
     }
-
     macro_rules! mk_stable_abi_sample_with_from_macro_rules {
         ({ $($body:tt)* }) => {
             #[derive(wincode::SchemaWrite)]
@@ -895,6 +894,18 @@ mod tests {
                     #[stable_abi_sample(ctx = SequenceLenMax(5))]
                     a: VecDeque<u8>,
                 },
+                // `LinkedList` has no dedicated `StableAbi` impl; exercise the
+                // sampling helpers on it as an arbitrary `FromIterator` collection.
+                struct MultiElementsLinkedListDefault {
+                    #[stable_abi_sample(with = "crate::stable_abi::sample_collection(rng)")]
+                    a: LinkedList<u8>,
+                },
+                struct MultiElementsLinkedListSized {
+                    #[stable_abi_sample(
+                        with = "crate::stable_abi::sample_collection_sized(rng, SequenceLenMax(5))"
+                    )]
+                    a: LinkedList<u8>,
+                },
             ],
             "7dXyMka1Z72sENE9vva8vmE65F7y6kXZKQ2DHu9aTWyz" => [
                 struct UpToOneElementWith {
@@ -929,6 +940,12 @@ mod tests {
                     #[stable_abi_sample(ctx = SequenceLenMax(1))]
                     a: BTreeMap<u8, ()>,
                 },
+                struct UpToOneElementLinkedListSized {
+                    #[stable_abi_sample(
+                        with = "crate::stable_abi::sample_collection_sized(rng, SequenceLenMax(1))"
+                    )]
+                    a: LinkedList<u8>,
+                },
             ],
             "Du8dTBApdeSxYTQVprkbMGvc5dLgCfUKKZ2z63qqr5Bj" => [
                 struct UpToOneKeyValueHashMapWith {
@@ -949,6 +966,12 @@ mod tests {
                     #[stable_abi_sample(ctx = SequenceLenMax(1))]
                     a: BTreeMap<u8, u16>,
                 },
+                struct UpToOneKeyValueLinkedListSized {
+                    #[stable_abi_sample(
+                        with = "crate::stable_abi::sample_collection_sized(rng, SequenceLenMax(1))"
+                    )]
+                    a: LinkedList<(u8, u16)>,
+                },
             ],
             "57dywdByMU7XcWbsfnXY5ChZdqne57zjJCn7uEjDKGNc" => [
                 struct UpToOneKeyValueHashMapWithRange {
@@ -968,6 +991,12 @@ mod tests {
                 struct UpToOneKeyValueBTreeMapRange {
                     #[stable_abi_sample(ctx = SequenceLenRange::new(1..=1))]
                     a: BTreeMap<u8, u16>,
+                },
+                struct UpToOneKeyValueLinkedListRange {
+                    #[stable_abi_sample(
+                        with = "crate::stable_abi::sample_collection_sized(rng, SequenceLenRange::new(1..=1))"
+                    )]
+                    a: LinkedList<(u8, u16)>,
                 },
             ],
         ]

--- a/frozen-abi/src/stable_abi/mod.rs
+++ b/frozen-abi/src/stable_abi/mod.rs
@@ -1,4 +1,10 @@
-use rand::RngCore;
+use {
+    crate::stable_abi::{
+        context::{SequenceLenMax, SequenceLenRange},
+        impls::DEFAULT_COLLECTION_MAX_SAMPLE_LEN,
+    },
+    rand::{Rng, RngCore},
+};
 
 pub mod context;
 mod impls;
@@ -12,4 +18,40 @@ pub trait StableAbi<Ctx = ()>: Sized {
     {
         Self::random_with_context(rng, Ctx::default())
     }
+}
+
+/// Samples a random collection of `T` items, drawing the element count the same
+/// way the built-in sequence containers do (at most
+/// `DEFAULT_COLLECTION_MAX_SAMPLE_LEN`).
+///
+/// Handy for collections that lack a dedicated `StableAbi` impl, via
+/// `#[stable_abi_sample(with = "...")]`:
+///
+/// ```ignore
+/// #[stable_abi_sample(with = "sample_collection(rng)")]
+/// a: SomeCollection<SomeItem>,
+/// ```
+///
+/// See [`sample_collection_sized`] to control the sampled length.
+pub fn sample_collection<C, T>(rng: &mut (impl RngCore + ?Sized)) -> C
+where
+    T: StableAbi,
+    C: FromIterator<T>,
+{
+    sample_collection_sized(rng, SequenceLenMax(DEFAULT_COLLECTION_MAX_SAMPLE_LEN))
+}
+
+/// Like [`sample_collection`], but with an explicit length spec, e.g.
+/// `SequenceLenMax(8)` or `SequenceLenRange::new(1..=4)`.
+pub fn sample_collection_sized<C, T>(
+    rng: &mut (impl RngCore + ?Sized),
+    ctx: impl Into<SequenceLenRange>,
+) -> C
+where
+    T: StableAbi,
+    C: FromIterator<T>,
+{
+    let SequenceLenRange { min, max } = ctx.into();
+    let len = rng.random_range(min..=max);
+    (0..len).map(|_| T::random(rng)).collect()
 }


### PR DESCRIPTION
It's unlikely we would be able (or want to) implement relevant traits (`StableAbi` or random distribution) for all external crates we might need.

In particular a common use-case are purpose-optimized collections.  Several such types are used in the codebase (e.g. `BitVec` or `imbl::HashMap`), we should be able to support stable abi for collections in such a way that:
* it's convenient to use in the types containing them
* the constants and algorithm used for generating them conforms to the way other collections are created and converting from custom collection to standard one (or vice-verse) doesn't cause `abi_digest` differences

Currently providing sampling capability for most of such collections is possible using `frozen_abi(with = "(0..rng.random_range(0..=5)).map(|_| rng.random()).collect()")`, but it's not necessarily meeting above criteria.

This PR adds a helper function that relies on `FromIterator` trait implemented by most collections to conveniently generate sample instances using standard algorithm from `StablAbi` impls.