### PR TITLE
signer: no-std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -318,7 +318,7 @@ solana-sha512-hasher = { path = "sha512-hasher", version = "1.0.1" }
 solana-short-vec = { path = "short-vec", version = "3.2.1", default-features = false }
 solana-shred-version = { path = "shred-version", version = "3.0.0" }
 solana-signature = { path = "signature", version = "3.4.1", default-features = false }
-solana-signer = { path = "signer", version = "3.0.0" }
+solana-signer = { path = "signer", version = "3.0.0", default-features = false }
 solana-signer-store = { path = "signer-store", version = "0.1.0" }
 solana-slot-hashes = { path = "slot-hashes", version = "3.0.2" }
 solana-slot-history = { path = "slot-history", version = "3.0.1" }

--- a/keypair/Cargo.toml
+++ b/keypair/Cargo.toml
@@ -33,7 +33,7 @@ solana-derivation-path = { workspace = true, optional = true }
 solana-seed-derivable = { workspace = true, optional = true }
 solana-seed-phrase = { workspace = true }
 solana-signature = { workspace = true, features = ["std", "verify"] }
-solana-signer = { workspace = true }
+solana-signer = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/scripts/check-no-std.sh
+++ b/scripts/check-no-std.sh
@@ -53,6 +53,7 @@ no_std_alloc_crates=(
   -p solana-instructions-sysvar
   -p solana-message
   -p solana-serialize-utils
+  -p solana-signer
   -p solana-short-vec
   -p solana-transaction
 )

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -15,6 +15,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
+[features]
+default = ["std"]
+std = []
+
 [dependencies]
 solana-pubkey = { workspace = true }
 solana-signature = { workspace = true }

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -1,17 +1,26 @@
 //! Abstractions and implementations for transaction signers.
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![no_std]
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(feature = "std")]
 use {
-    core::fmt,
-    solana_pubkey::Pubkey,
-    solana_signature::Signature,
-    solana_transaction_error::TransactionError,
+    alloc::{boxed::Box, string::ToString},
     std::{
         error,
         fs::{self, File, OpenOptions},
         io::{Read, Write},
-        ops::Deref,
         path::Path,
     },
+};
+use {
+    alloc::{collections::BTreeSet, string::String, vec::Vec},
+    core::{fmt, ops::Deref},
+    solana_pubkey::Pubkey,
+    solana_signature::Signature,
+    solana_transaction_error::TransactionError,
 };
 
 pub mod null_signer;
@@ -154,21 +163,21 @@ impl PartialEq for dyn Signer {
 
 impl Eq for dyn Signer {}
 
-impl std::fmt::Debug for dyn Signer {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Debug for dyn Signer {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "Signer: {:?}", self.pubkey())
     }
 }
 
-/// Removes duplicate signers while preserving order. O(n²)
+/// Removes duplicate signers while preserving order. O(n log n)
 pub fn unique_signers(signers: Vec<&dyn Signer>) -> Vec<&dyn Signer> {
     let capacity = signers.len();
     let mut out = Vec::with_capacity(capacity);
-    let mut seen = std::collections::HashSet::with_capacity(capacity);
+    let mut seen = BTreeSet::new();
     for signer in signers {
         let pubkey = signer.pubkey();
-        if !seen.contains(&pubkey) {
-            seen.insert(pubkey);
+        let is_unique = seen.insert(pubkey);
+        if is_unique {
             out.push(signer);
         }
     }
@@ -177,6 +186,7 @@ pub fn unique_signers(signers: Vec<&dyn Signer>) -> Vec<&dyn Signer> {
 
 /// The `EncodableKey` trait defines the interface by which cryptographic keys/keypairs are read,
 /// written, and derived from sources.
+#[cfg(feature = "std")]
 pub trait EncodableKey: Sized {
     fn read<R: Read>(reader: &mut R) -> Result<Self, Box<dyn error::Error>>;
     fn read_from_file<F: AsRef<Path>>(path: F) -> Result<Self, Box<dyn error::Error>> {
@@ -213,6 +223,7 @@ pub trait EncodableKey: Sized {
 
 /// The `EncodableKeypair` trait extends `EncodableKey` for asymmetric keypairs, i.e. have
 /// associated public keys.
+#[cfg(feature = "std")]
 pub trait EncodableKeypair: EncodableKey {
     type Pubkey: ToString;
 

--- a/signer/src/signers.rs
+++ b/signer/src/signers.rs
@@ -1,5 +1,6 @@
 use {
     crate::{Signer, SignerError},
+    alloc::vec::Vec,
     solana_pubkey::Pubkey,
     solana_signature::Signature,
 };
@@ -55,7 +56,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use {
+        super::*,
+        alloc::{boxed::Box, vec},
+    };
 
     struct Foo;
     impl Signer for Foo {

--- a/transaction/Cargo.toml
+++ b/transaction/Cargo.toml
@@ -35,9 +35,10 @@ serde = [
     "solana-transaction-error/serde",
     "solana-short-vec/serde",
 ]
-std = ["dep:solana-signer", "solana-message/std"]
+std = ["solana-message/std"]
 verify = ["blake3", "solana-signature/verify"]
 wincode = [
+    "dep:solana-signer",
     "dep:wincode",
     "solana-short-vec/wincode",
     "solana-message/wincode",

--- a/transaction/src/lib.rs
+++ b/transaction/src/lib.rs
@@ -117,7 +117,7 @@ extern crate std;
 
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::{frozen_abi, AbiExample, StableAbi};
-#[cfg(all(feature = "wincode", feature = "std"))]
+#[cfg(feature = "wincode")]
 pub use solana_signer::{signers::Signers, SignerError};
 use {
     alloc::{vec, vec::Vec},
@@ -403,7 +403,7 @@ impl Transaction {
     /// #
     /// # Ok::<(), anyhow::Error>(())
     /// ```
-    #[cfg(all(feature = "wincode", feature = "std"))]
+    #[cfg(feature = "wincode")]
     pub fn new<T: Signers + ?Sized>(
         from_keypairs: &T,
         message: Message,
@@ -557,7 +557,7 @@ impl Transaction {
     /// #
     /// # Ok::<(), anyhow::Error>(())
     /// ```
-    #[cfg(all(feature = "wincode", feature = "std"))]
+    #[cfg(feature = "wincode")]
     pub fn new_signed_with_payer<T: Signers + ?Sized>(
         instructions: &[Instruction],
         payer: Option<&Address>,
@@ -583,7 +583,7 @@ impl Transaction {
     ///
     /// Panics when signing fails. See [`Transaction::try_sign`] and for a full
     /// description of failure conditions.
-    #[cfg(all(feature = "wincode", feature = "std"))]
+    #[cfg(feature = "wincode")]
     pub fn new_with_compiled_instructions<T: Signers + ?Sized>(
         from_keypairs: &T,
         keys: &[Address],
@@ -763,7 +763,7 @@ impl Transaction {
     /// #
     /// # Ok::<(), anyhow::Error>(())
     /// ```
-    #[cfg(all(feature = "wincode", feature = "std"))]
+    #[cfg(feature = "wincode")]
     pub fn sign<T: Signers + ?Sized>(&mut self, keypairs: &T, recent_blockhash: Hash) {
         if let Err(e) = self.try_sign(keypairs, recent_blockhash) {
             panic!("Transaction::sign failed with error {e:?}");
@@ -790,7 +790,7 @@ impl Transaction {
     /// handle the error. See the documentation for
     /// [`Transaction::try_partial_sign`] for a full description of failure
     /// conditions.
-    #[cfg(all(feature = "wincode", feature = "std"))]
+    #[cfg(feature = "wincode")]
     pub fn partial_sign<T: Signers + ?Sized>(&mut self, keypairs: &T, recent_blockhash: Hash) {
         if let Err(e) = self.try_partial_sign(keypairs, recent_blockhash) {
             panic!("Transaction::partial_sign failed with error {e:?}");
@@ -810,7 +810,7 @@ impl Transaction {
     ///
     /// Panics if signing fails. Use [`Transaction::try_partial_sign_unchecked`]
     /// to handle the error.
-    #[cfg(all(feature = "wincode", feature = "std"))]
+    #[cfg(feature = "wincode")]
     pub fn partial_sign_unchecked<T: Signers + ?Sized>(
         &mut self,
         keypairs: &T,
@@ -903,7 +903,7 @@ impl Transaction {
     /// #
     /// # Ok::<(), anyhow::Error>(())
     /// ```
-    #[cfg(all(feature = "wincode", feature = "std"))]
+    #[cfg(feature = "wincode")]
     pub fn try_sign<T: Signers + ?Sized>(
         &mut self,
         keypairs: &T,
@@ -967,7 +967,7 @@ impl Transaction {
     /// [`PresignerError::VerificationFailure`]: https://docs.rs/solana-signer/latest/solana_signer/enum.PresignerError.html#variant.WrongSize
     /// [`solana-remote-wallet`]: https://docs.rs/solana-remote-wallet/latest/
     /// [`RemoteKeypair`]: https://docs.rs/solana-remote-wallet/latest/solana_remote_wallet/remote_keypair/struct.RemoteKeypair.html
-    #[cfg(all(feature = "wincode", feature = "std"))]
+    #[cfg(feature = "wincode")]
     pub fn try_partial_sign<T: Signers + ?Sized>(
         &mut self,
         keypairs: &T,
@@ -994,7 +994,7 @@ impl Transaction {
     /// # Errors
     ///
     /// Returns an error if signing fails.
-    #[cfg(all(feature = "wincode", feature = "std"))]
+    #[cfg(feature = "wincode")]
     pub fn try_partial_sign_unchecked<T: Signers + ?Sized>(
         &mut self,
         keypairs: &T,

--- a/transaction/src/versioned/mod.rs
+++ b/transaction/src/versioned/mod.rs
@@ -9,7 +9,7 @@ use {
     solana_sdk_ids::system_program,
     solana_signature::Signature,
 };
-#[cfg(all(feature = "wincode", feature = "std"))]
+#[cfg(feature = "wincode")]
 use {
     alloc::string::ToString,
     solana_signer::{signers::Signers, SignerError},
@@ -91,7 +91,7 @@ impl From<Transaction> for VersionedTransaction {
 impl VersionedTransaction {
     /// Signs a versioned message and if successful, returns a signed
     /// transaction.
-    #[cfg(all(feature = "wincode", feature = "std"))]
+    #[cfg(feature = "wincode")]
     pub fn try_new<T: Signers + ?Sized>(
         message: VersionedMessage,
         keypairs: &T,


### PR DESCRIPTION
Follow up from https://github.com/anza-xyz/solana-sdk/pull/749

Makes the signer crate no-std compatible and creates a new default `std` feature that is default on. 