### PR TITLE
svm-transaction: add std deps

### DIFF
--- a/svm-transaction/Cargo.toml
+++ b/svm-transaction/Cargo.toml
@@ -21,7 +21,7 @@ solana-message = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-signature = { workspace = true }
-solana-transaction = { workspace = true }
+solana-transaction = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 solana-message = { workspace = true, features = ["wincode"] }


### PR DESCRIPTION
Currently a master failing run: https://github.com/anza-xyz/solana-sdk/actions/runs/27023882611

Caused by the merge of https://github.com/anza-xyz/solana-sdk/pull/749 on a stale master that had https://github.com/anza-xyz/solana-sdk/pull/745 merged before it. 