### PR TITLE
account-view: Remove unnecessary safety comment

### DIFF
--- a/account-view/src/lib.rs
+++ b/account-view/src/lib.rs
@@ -189,7 +189,6 @@ impl AccountView {
     /// An account is considered empty if the data length is zero.
     #[inline(always)]
     pub fn is_data_empty(&self) -> bool {
-        // SAFETY: The `raw` pointer is guaranteed to be valid.
         self.data_len() == 0
     }
 


### PR DESCRIPTION
### Problem

There is an unnecessary safety comment.

### Solution

Remove it.