### PR TITLE
frozen-abi: skip field sampling

### DIFF
--- a/frozen-abi-macro/src/lib.rs
+++ b/frozen-abi-macro/src/lib.rs
@@ -236,12 +236,14 @@ fn filter_allow_attrs(attrs: &mut Vec<Attribute>) {
 struct StableAbiSampleOptions {
     with_expr: Option<TokenStream2>,
     ctx_expr: Option<TokenStream2>,
+    skip: bool,
 }
 
 #[cfg(feature = "frozen-abi")]
 fn parse_stable_abi_sample_options(field: &syn::Field) -> Result<StableAbiSampleOptions, Error> {
     let mut with_expr: Option<TokenStream2> = None;
     let mut ctx_expr: Option<TokenStream2> = None;
+    let mut skip = false;
     for attr in &field.attrs {
         if !attr.path().is_ident("stable_abi_sample") {
             continue;
@@ -266,22 +268,30 @@ fn parse_stable_abi_sample_options(field: &syn::Field) -> Result<StableAbiSample
                 let expr = meta.value()?.parse::<Expr>()?;
                 ctx_expr = Some(quote! { #expr });
                 Ok(())
+            } else if meta.path.is_ident("skip") {
+                // reject duplicate `skip` on the same field
+                if skip {
+                    return Err(meta.error("duplicate `skip` in `#[stable_abi_sample(...)]`"));
+                }
+                skip = true;
+                Ok(())
             } else {
                 Err(meta.error(
-                    "unsupported `stable_abi_sample` option; expected `with = \"...\"` or `ctx = <expr>`",
+                    "unsupported `stable_abi_sample` option; expected `with`, `ctx`, or `skip`",
                 ))
             }
         })?;
     }
-    if with_expr.is_some() && ctx_expr.is_some() {
+    if with_expr.is_some() && ctx_expr.is_some() && skip {
         return Err(Error::new_spanned(
             field,
-            "cannot combine `with` and `ctx` in `#[stable_abi_sample(...)]`",
+            "cannot combine `with`, `ctx` or `skip` in `#[stable_abi_sample(...)]`",
         ));
     }
     Ok(StableAbiSampleOptions {
         with_expr,
         ctx_expr,
+        skip,
     })
 }
 
@@ -289,21 +299,30 @@ fn parse_stable_abi_sample_options(field: &syn::Field) -> Result<StableAbiSample
 fn stable_abi_sample_field_expr(field: &syn::Field) -> Result<TokenStream2, Error> {
     let options = parse_stable_abi_sample_options(field)?;
     let ty = &field.ty;
-    Ok(match (options.with_expr, options.ctx_expr) {
-        (Some(expr), None) => expr,
-        (None, Some(ctx_expr)) => quote! {
+
+    match (options.with_expr, options.ctx_expr, options.skip) {
+        (Some(expr), None, false) => Ok(expr),
+
+        (None, Some(ctx_expr), false) => Ok(quote! {
             <#ty as ::solana_frozen_abi::stable_abi::StableAbi<_>>::random_with_context(
                 rng,
                 #ctx_expr,
             )
-        },
-        (None, None) => {
-            quote! {
-                <#ty as ::solana_frozen_abi::stable_abi::StableAbi>::random(rng)
-            }
-        }
-        (Some(_), Some(_)) => unreachable!("`with` and `ctx` are mutually exclusive"),
-    })
+        }),
+
+        (None, None, true) => Ok(quote! {
+            ::core::default::Default::default()
+        }),
+
+        (None, None, false) => Ok(quote! {
+            <#ty as ::solana_frozen_abi::stable_abi::StableAbi>::random(rng)
+        }),
+
+        _ => Err(Error::new_spanned(
+            field,
+            "`with`, `ctx`, and `skip` are mutually exclusive",
+        )),
+    }
 }
 
 #[cfg(feature = "frozen-abi")]

--- a/frozen-abi/src/lib.rs
+++ b/frozen-abi/src/lib.rs
@@ -98,6 +98,17 @@
 //! }
 //! ```
 //!
+//! `skip` is useful for fields that should be sampled as `Default::default()`:
+//!
+//! ```rust,ignore
+//! #[derive(StableAbi, StableAbiSample)]
+//! #[frozen_abi(abi_digest = "...")]
+//! struct MyTypeWithSkippedFields {
+//!     #[stable_abi_sample(skip)]
+//!     a: Option<u64>,
+//! }
+//! ```
+//!
 //! 2. Write a manual `Distribution` implementation
 //!
 //! ```rust,ignore

--- a/frozen-abi/src/stable_abi/impls.rs
+++ b/frozen-abi/src/stable_abi/impls.rs
@@ -1102,4 +1102,45 @@ mod tests {
         b: bool,
         c: Option<Vec<u16>>,
     }
+
+    #[derive(Default, wincode::SchemaWrite, wincode::SchemaRead)]
+    struct TestSkippedFieldWithoutStableAbi;
+
+    const SKIP_VS_UNIT_DIGEST: &str = "8po7NHArG1np5zmKWjxaG5WzZwDz8uzZRr4u3WJ8LDuX";
+    #[derive(wincode::SchemaWrite, wincode::SchemaRead)]
+    #[cfg_attr(
+        feature = "frozen-abi",
+        derive(
+            solana_frozen_abi_macro::StableAbi,
+            solana_frozen_abi_macro::StableAbiSample
+        ),
+        solana_frozen_abi_macro::frozen_abi(
+            abi_digest = SKIP_VS_UNIT_DIGEST,
+            abi_serializer = "wincode",
+        )
+    )]
+    struct TestSkipFieldSampling {
+        a: u64,
+        #[stable_abi_sample(skip)]
+        b: TestSkippedFieldWithoutStableAbi,
+        c: bool,
+    }
+
+    #[derive(wincode::SchemaWrite, wincode::SchemaRead)]
+    #[cfg_attr(
+        feature = "frozen-abi",
+        derive(
+            solana_frozen_abi_macro::StableAbi,
+            solana_frozen_abi_macro::StableAbiSample
+        ),
+        solana_frozen_abi_macro::frozen_abi(
+            abi_digest = SKIP_VS_UNIT_DIGEST,
+            abi_serializer = "wincode",
+        )
+    )]
+    struct TestUnitFieldSampling {
+        a: u64,
+        b: (),
+        c: bool,
+    }
 }


### PR DESCRIPTION
### Description

StableAbi sampling does not include option to skip field sampling path, which might be problematic in some scenarios.

### Summary of changes
- added sampling option `skip` to redirect from field sampling path to defaults
- updated docs
- added new test type

ref #754 