### PR TITLE
nullable: Add int primitives impl

### DIFF
--- a/nullable/src/maybe_null.rs
+++ b/nullable/src/maybe_null.rs
@@ -196,10 +196,6 @@ where
 mod tests {
     use super::*;
 
-    impl Nullable for u64 {
-        const NONE: Self = 0;
-    }
-
     #[test]
     fn test_try_from_option() {
         let some = Some(42u64);

--- a/nullable/src/nullable.rs
+++ b/nullable/src/nullable.rs
@@ -16,3 +16,19 @@ pub trait Nullable: PartialEq + Sized {
         !self.is_none()
     }
 }
+
+macro_rules! nullable_integer {
+    ( $type:tt ) => {
+        #[doc = concat!("Implements `Nullable` for the `", stringify!($type), "` type, reserving `0` as the `NONE` value.")]
+        impl Nullable for $type {
+            const NONE: Self = 0;
+        }
+    };
+}
+
+nullable_integer!(u8);
+nullable_integer!(u16);
+nullable_integer!(u32);
+nullable_integer!(u64);
+#[cfg(not(target_arch = "bpf"))]
+nullable_integer!(u128);


### PR DESCRIPTION
### Problem

Currently it is not possible to use integer primitives with `MaybeNull` since they do not have a `Nullable` impl.

### Solution

Add a `Nullable` impl that reserves `0` as the "null" value.