### PR TITLE
feat(frozen-abi-macro): enable frozen-abi feature by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -260,7 +260,7 @@ solana-fee-calculator = { path = "fee-calculator", version = "3.2.1" }
 solana-fee-structure = { path = "fee-structure", version = "3.0.0" }
 solana-file-download = { path = "file-download", version = "3.0.0" }
 solana-frozen-abi = { path = "frozen-abi", version = "3.5.0" }
-solana-frozen-abi-macro = { path = "frozen-abi-macro", version = "3.5.0" }
+solana-frozen-abi-macro = { path = "frozen-abi-macro", version = "3.5.0", default-features = false }
 solana-genesis-config = { path = "genesis-config", version = "4.0.0" }
 solana-hard-forks = { path = "hard-forks", version = "3.1.0", default-features = false }
 solana-hash = { path = "hash", version = "4.4.0", default-features = false }

--- a/account/Cargo.toml
+++ b/account/Cargo.toml
@@ -33,7 +33,7 @@ serde_bytes = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 solana-account-info = { workspace = true }
 solana-clock = { workspace = true }
-solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-instruction-error = { workspace = true }
 solana-pubkey = { workspace = true }

--- a/cluster-type/Cargo.toml
+++ b/cluster-type/Cargo.toml
@@ -15,12 +15,12 @@ all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
 [features]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "serde"]
 serde = ["dep:serde", "dep:serde_derive"]
 
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-hash = { workspace = true, features = ["decode"] }

--- a/epoch-rewards/Cargo.toml
+++ b/epoch-rewards/Cargo.toml
@@ -29,7 +29,7 @@ wincode = ["dep:wincode", "solana-hash/wincode"]
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-hash = { workspace = true, features = ["decode"] }
 solana-sdk-ids = { workspace = true, optional = true }

--- a/epoch-schedule/Cargo.toml
+++ b/epoch-schedule/Cargo.toml
@@ -21,7 +21,7 @@ wincode = ["dep:wincode"]
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-sdk-ids = { workspace = true, optional = true }
 solana-sdk-macro = { workspace = true }

--- a/fee-calculator/Cargo.toml
+++ b/fee-calculator/Cargo.toml
@@ -23,7 +23,7 @@ wincode = ["dep:wincode"]
 log = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 wincode = { workspace = true, optional = true }
 

--- a/frozen-abi-macro/Cargo.toml
+++ b/frozen-abi-macro/Cargo.toml
@@ -18,9 +18,10 @@ rustdoc-args = ["--cfg=docsrs"]
 proc-macro = true
 
 [features]
-default = []
-# activate the frozen-abi feature when we actually want to do frozen-abi testing,
-# otherwise leave it off because it requires nightly Rust
+default = ["frozen-abi"]
+# Deprecated: `frozen-abi` is now enabled by default and no longer needs to be
+# requested explicitly. It is retained for backward compatibility and will be
+# removed in a future release.
 frozen-abi = []
 
 [dependencies]

--- a/genesis-config/Cargo.toml
+++ b/genesis-config/Cargo.toml
@@ -40,7 +40,7 @@ solana-clock = { workspace = true }
 solana-cluster-type = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-fee-calculator = { workspace = true }
-solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-hash = { workspace = true }
 solana-inflation = { workspace = true }

--- a/genesis-config/Cargo.toml
+++ b/genesis-config/Cargo.toml
@@ -15,7 +15,18 @@ all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
 [features]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-account/frozen-abi",
+    "solana-cluster-type/frozen-abi",
+    "solana-epoch-schedule/frozen-abi",
+    "solana-fee-calculator/frozen-abi",
+    "solana-inflation/frozen-abi",
+    "solana-poh-config/frozen-abi",
+    "solana-pubkey/frozen-abi",
+    "solana-rent/frozen-abi",
+]
 serde = [
     "dep:serde",
     "dep:serde_derive",

--- a/inflation/Cargo.toml
+++ b/inflation/Cargo.toml
@@ -20,6 +20,6 @@ wincode = ["dep:wincode"]
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 wincode = { workspace = true, optional = true }

--- a/instruction-error/Cargo.toml
+++ b/instruction-error/Cargo.toml
@@ -25,7 +25,7 @@ wincode = ["dep:wincode"]
 num-traits = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-program-error = { workspace = true }
 wincode = { workspace = true, optional = true }

--- a/message/Cargo.toml
+++ b/message/Cargo.toml
@@ -49,7 +49,7 @@ blake3 = { workspace = true, features = ["traits-preview"], optional = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 solana-address = { workspace = true }
-solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-hash = { workspace = true, features = ["decode", "sanitize"] }
 solana-instruction = { workspace = true }

--- a/rent/Cargo.toml
+++ b/rent/Cargo.toml
@@ -21,7 +21,7 @@ wincode = ["dep:wincode"]
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-sdk-ids = { workspace = true, optional = true }
 solana-sdk-macro = { workspace = true }

--- a/reward-info/Cargo.toml
+++ b/reward-info/Cargo.toml
@@ -20,6 +20,6 @@ wincode = ["dep:wincode"]
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 wincode = { workspace = true, optional = true }

--- a/sysvar/Cargo.toml
+++ b/sysvar/Cargo.toml
@@ -59,7 +59,7 @@ solana-clock = { workspace = true, features = ["sysvar"] }
 solana-epoch-rewards = { workspace = true, features = ["sysvar"] }
 solana-epoch-schedule = { workspace = true, features = ["sysvar"] }
 solana-fee-calculator = { workspace = true }
-solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-hash = { workspace = true, features = ["bytemuck"] }
 solana-last-restart-slot = { workspace = true, features = ["sysvar"] }

--- a/transaction-error/Cargo.toml
+++ b/transaction-error/Cargo.toml
@@ -23,7 +23,7 @@ wincode = ["dep:wincode", "solana-instruction-error/wincode"]
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-solana-frozen-abi = { workspace = true, optional = true }
+solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
 solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-instruction-error = { workspace = true }
 solana-sanitize = { workspace = true }


### PR DESCRIPTION
#### Problem
`solana-frozen-abi-macro` defaults to `default = []`, exposing dummy no-op proc-macros unless `frozen-abi` is explicitly enabled. The justifying comments ("requires nightly Rust" / "dummy macros for stable rustc") are obsolete / wrong — the real macros compile fine on stable, and the dummy path is not exercised in any reasonable scenario:
- crates in agave typically depend on macros with the `frozen-abi` feature on — directly or transitively via `solana-frozen-abi/frozen-abi` — so feature unification selects the real macros in any frozen-abi build - if they do not (as in some examples in solana-sdk itself), it's a bug
- **Consumers gate the derives at the call site behind their own `frozen-abi` feature** (e.g. `#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi))]`), so the macro crate's toggle only matters when that gate is active — at which point it's always on.

The bad side-effect of this feature gating is that:
* `scripts/test-stable.sh` skips running any tests for the `frozen-abi-macro` crate itself (which are now present).
* if feature enablement is forgotten, we will silently skip generating digest tests (as in genesis-config)

#### Change
* Enable `frozen-abi` by default and mark it deprecated. The `#[cfg]` gates and dummy macros are left in place — this is deprecation, not removal — so `features = ["frozen-abi"]` and `default-features = false` both keep working.
* Fix some sdk crates to enable the feature on `solana-frozen-abi` (the failure mode is that they declare frozen-abi derives and generate tests, but the library's actual content isn't compiled)