### PR TITLE
instructions-sysvar: handle overflow

### DIFF
--- a/instructions-sysvar/src/lib.rs
+++ b/instructions-sysvar/src/lib.rs
@@ -67,15 +67,16 @@ pub struct Instructions();
 solana_sysvar_id::impl_sysvar_id!(Instructions);
 
 /// Construct the account data for the instructions sysvar.
+/// Returns None if the instructions cannot be serialized correctly.
 ///
 /// This function is used by the runtime and not available to Solana programs.
 #[cfg(not(target_os = "solana"))]
-pub fn construct_instructions_data(instructions: &[BorrowedInstruction]) -> Vec<u8> {
-    let mut data = serialize_instructions(instructions);
+pub fn construct_instructions_data(instructions: &[BorrowedInstruction]) -> Option<Vec<u8>> {
+    let mut data = serialize_instructions(instructions)?;
     // add room for current instruction index.
     data.resize(data.len() + 2, 0);
 
-    data
+    Some(data)
 }
 
 #[cfg(not(target_os = "solana"))]
@@ -110,9 +111,11 @@ bitflags! {
 // - N = num_instructions
 // - A = number of accounts in a particular instruction
 // - D = data_len
+//
+// Returns None if the instructions cannot be serialized correctly.
 #[cfg(not(target_os = "solana"))]
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
-fn serialize_instructions(instructions: &[BorrowedInstruction]) -> Vec<u8> {
+fn serialize_instructions(instructions: &[BorrowedInstruction]) -> Option<Vec<u8>> {
     // 64 bytes is a reasonable guess, calculating exactly is slower in benchmarks
     let mut data = Vec::with_capacity(instructions.len() * (32 * 2));
     append_u16(&mut data, instructions.len() as u16);
@@ -121,7 +124,7 @@ fn serialize_instructions(instructions: &[BorrowedInstruction]) -> Vec<u8> {
     }
 
     for (i, instruction) in instructions.iter().enumerate() {
-        let start_instruction_offset = data.len() as u16;
+        let start_instruction_offset = u16::try_from(data.len()).ok()?;
         let start = 2 + (2 * i);
         data[start..start + 2].copy_from_slice(&start_instruction_offset.to_le_bytes());
         append_u16(&mut data, instruction.accounts.len() as u16);
@@ -141,7 +144,7 @@ fn serialize_instructions(instructions: &[BorrowedInstruction]) -> Vec<u8> {
         append_u16(&mut data, instruction.data.len() as u16);
         append_slice(&mut data, instruction.data);
     }
-    data
+    Some(data)
 }
 
 /// Load the current `Instruction`'s index in the currently executing
@@ -395,7 +398,8 @@ mod tests {
         let borrowed_instruction1 = make_borrowed_instruction(&params1);
         let key = id();
         let mut lamports = 0;
-        let mut data = construct_instructions_data(&[borrowed_instruction0, borrowed_instruction1]);
+        let mut data =
+            construct_instructions_data(&[borrowed_instruction0, borrowed_instruction1]).unwrap();
         let owner = solana_sdk_ids::sysvar::id();
         let mut account_info =
             AccountInfo::new(&key, false, false, &mut lamports, &mut data, &owner, false);
@@ -444,7 +448,8 @@ mod tests {
 
         let key = id();
         let mut lamports = 0;
-        let mut data = construct_instructions_data(&[borrowed_instruction0, borrowed_instruction1]);
+        let mut data =
+            construct_instructions_data(&[borrowed_instruction0, borrowed_instruction1]).unwrap();
         let res = store_current_index_checked(&mut data, 1);
         assert!(res.is_ok());
         let owner = solana_sdk_ids::sysvar::id();
@@ -506,7 +511,8 @@ mod tests {
             borrowed_instruction0,
             borrowed_instruction1,
             borrowed_instruction2,
-        ]);
+        ])
+        .unwrap();
         let res = store_current_index_checked(&mut data, 1);
         assert!(res.is_ok());
         let owner = solana_sdk_ids::sysvar::id();
@@ -606,7 +612,7 @@ mod tests {
         let borrowed_instructions: Vec<BorrowedInstruction> =
             params.iter().map(make_borrowed_instruction).collect();
 
-        let serialized = serialize_instructions(&borrowed_instructions);
+        let serialized = serialize_instructions(&borrowed_instructions).unwrap();
 
         // assert that deserialize_instruction is compatible with SanitizedMessage::serialize_instructions
         for (i, instruction) in instructions.iter().enumerate() {
@@ -615,6 +621,63 @@ mod tests {
                 *instruction
             );
         }
+    }
+
+    #[test]
+    fn test_serialize_instructions_rejects_instruction_offset_overflow() {
+        fn make_borrowed_instruction_with_accounts<'a>(
+            program_id: &'a Address,
+            account_key: &'a Address,
+            num_account_refs: usize,
+            data: &'a [u8],
+        ) -> BorrowedInstruction<'a> {
+            BorrowedInstruction {
+                program_id,
+                accounts: (0..num_account_refs)
+                    .map(|_| BorrowedAccountMeta {
+                        pubkey: account_key,
+                        is_signer: false,
+                        is_writable: false,
+                    })
+                    .collect(),
+                data,
+            }
+        }
+
+        fn make_instructions<'a>(
+            program_id: &'a Address,
+            account_key: &'a Address,
+            padding_data: &'a [u8],
+        ) -> Vec<BorrowedInstruction<'a>> {
+            let mut instructions = (0..7)
+                .map(|_| make_borrowed_instruction_with_accounts(program_id, account_key, 255, &[]))
+                .collect::<Vec<_>>();
+            instructions.push(make_borrowed_instruction_with_accounts(
+                program_id,
+                account_key,
+                191,
+                padding_data,
+            ));
+            instructions.push(make_borrowed_instruction_with_accounts(
+                program_id,
+                account_key,
+                255,
+                &[],
+            ));
+            instructions
+        }
+
+        let program_id = Address::new_unique();
+        let account_key = Address::new_unique();
+
+        let boundary_padding_data = [0; 19];
+        let instructions = make_instructions(&program_id, &account_key, &boundary_padding_data);
+        assert!(serialize_instructions(&instructions).is_some());
+
+        let overflow_padding_data = [0; 20];
+        let instructions = make_instructions(&program_id, &account_key, &overflow_padding_data);
+        assert_eq!(serialize_instructions(&instructions), None);
+        assert_eq!(construct_instructions_data(&instructions), None);
     }
 
     #[test]
@@ -641,7 +704,7 @@ mod tests {
         let borrowed_instructions: Vec<BorrowedInstruction> =
             params.iter().map(make_borrowed_instruction).collect();
 
-        let serialized = serialize_instructions(&borrowed_instructions);
+        let serialized = serialize_instructions(&borrowed_instructions).unwrap();
         assert_eq!(
             deserialize_instruction(instructions.len(), &serialized).unwrap_err(),
             SanitizeError::IndexOutOfBounds,

--- a/instructions-sysvar/src/lib.rs
+++ b/instructions-sysvar/src/lib.rs
@@ -67,7 +67,6 @@ pub struct Instructions();
 solana_sysvar_id::impl_sysvar_id!(Instructions);
 
 /// Construct the account data for the instructions sysvar.
-/// Returns None if the instructions cannot be serialized correctly.
 ///
 /// This function is used by the runtime and not available to Solana programs.
 #[cfg(not(target_os = "solana"))]
@@ -119,8 +118,6 @@ pub enum InstructionsSysvarError {
 // - N = num_instructions
 // - A = number of accounts in a particular instruction
 // - D = data_len
-//
-// Returns None if the instructions cannot be serialized correctly.
 #[cfg(not(target_os = "solana"))]
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 fn serialize_instructions(

--- a/instructions-sysvar/src/lib.rs
+++ b/instructions-sysvar/src/lib.rs
@@ -71,12 +71,14 @@ solana_sysvar_id::impl_sysvar_id!(Instructions);
 ///
 /// This function is used by the runtime and not available to Solana programs.
 #[cfg(not(target_os = "solana"))]
-pub fn construct_instructions_data(instructions: &[BorrowedInstruction]) -> Option<Vec<u8>> {
+pub fn construct_instructions_data(
+    instructions: &[BorrowedInstruction],
+) -> Result<Vec<u8>, InstructionsSysvarError> {
     let mut data = serialize_instructions(instructions)?;
     // add room for current instruction index.
     data.resize(data.len() + 2, 0);
 
-    Some(data)
+    Ok(data)
 }
 
 #[cfg(not(target_os = "solana"))]
@@ -85,6 +87,12 @@ bitflags! {
         const IS_SIGNER = 0b00000001;
         const IS_WRITABLE = 0b00000010;
     }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum InstructionsSysvarError {
+    /// The instruction index stored in the instructions sysvar account data is out of bounds.
+    InstructionIndexOutOfBounds,
 }
 
 // Instructions memory layout
@@ -115,7 +123,9 @@ bitflags! {
 // Returns None if the instructions cannot be serialized correctly.
 #[cfg(not(target_os = "solana"))]
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
-fn serialize_instructions(instructions: &[BorrowedInstruction]) -> Option<Vec<u8>> {
+fn serialize_instructions(
+    instructions: &[BorrowedInstruction],
+) -> Result<Vec<u8>, InstructionsSysvarError> {
     // 64 bytes is a reasonable guess, calculating exactly is slower in benchmarks
     let mut data = Vec::with_capacity(instructions.len() * (32 * 2));
     append_u16(&mut data, instructions.len() as u16);
@@ -124,7 +134,8 @@ fn serialize_instructions(instructions: &[BorrowedInstruction]) -> Option<Vec<u8
     }
 
     for (i, instruction) in instructions.iter().enumerate() {
-        let start_instruction_offset = u16::try_from(data.len()).ok()?;
+        let start_instruction_offset = u16::try_from(data.len())
+            .map_err(|_| InstructionsSysvarError::InstructionIndexOutOfBounds)?;
         let start = 2 + (2 * i);
         data[start..start + 2].copy_from_slice(&start_instruction_offset.to_le_bytes());
         append_u16(&mut data, instruction.accounts.len() as u16);
@@ -144,7 +155,7 @@ fn serialize_instructions(instructions: &[BorrowedInstruction]) -> Option<Vec<u8
         append_u16(&mut data, instruction.data.len() as u16);
         append_slice(&mut data, instruction.data);
     }
-    Some(data)
+    Ok(data)
 }
 
 /// Load the current `Instruction`'s index in the currently executing
@@ -672,12 +683,18 @@ mod tests {
 
         let boundary_padding_data = [0; 19];
         let instructions = make_instructions(&program_id, &account_key, &boundary_padding_data);
-        assert!(serialize_instructions(&instructions).is_some());
+        assert!(serialize_instructions(&instructions).is_ok());
 
         let overflow_padding_data = [0; 20];
         let instructions = make_instructions(&program_id, &account_key, &overflow_padding_data);
-        assert_eq!(serialize_instructions(&instructions), None);
-        assert_eq!(construct_instructions_data(&instructions), None);
+        assert_eq!(
+            serialize_instructions(&instructions),
+            Err(InstructionsSysvarError::InstructionIndexOutOfBounds)
+        );
+        assert_eq!(
+            construct_instructions_data(&instructions),
+            Err(InstructionsSysvarError::InstructionIndexOutOfBounds)
+        );
     }
 
     #[test]

--- a/sdk/benches/serialize_instructions.rs
+++ b/sdk/benches/serialize_instructions.rs
@@ -37,7 +37,7 @@ fn bench_construct_instructions_data(b: &mut Bencher) {
     .unwrap();
     b.iter(|| {
         let instructions = message.decompile_instructions();
-        test::black_box(construct_instructions_data(&instructions));
+        test::black_box(construct_instructions_data(&instructions).unwrap());
     });
 }
 

--- a/sdk/benches/serialize_instructions.rs
+++ b/sdk/benches/serialize_instructions.rs
@@ -58,7 +58,7 @@ fn bench_manual_instruction_deserialize(b: &mut Bencher) {
         &HashSet::default(),
     )
     .unwrap();
-    let serialized = construct_instructions_data(&message.decompile_instructions());
+    let serialized = construct_instructions_data(&message.decompile_instructions()).unwrap();
     b.iter(|| {
         for i in 0..instructions.len() {
             #[allow(deprecated)]
@@ -75,7 +75,7 @@ fn bench_manual_instruction_deserialize_single(b: &mut Bencher) {
         &HashSet::default(),
     )
     .unwrap();
-    let serialized = construct_instructions_data(&message.decompile_instructions());
+    let serialized = construct_instructions_data(&message.decompile_instructions()).unwrap();
     b.iter(|| {
         #[allow(deprecated)]
         test::black_box(instructions::load_instruction_at(3, &serialized).unwrap());

--- a/transaction-error/src/lib.rs
+++ b/transaction-error/src/lib.rs
@@ -155,6 +155,9 @@ pub enum TransactionError {
 
     /// Commit cancelled internally.
     CommitCancelled,
+
+    /// Instruction sysvar overflow.
+    InstructionsSysvarOverflow,
 }
 
 impl core::error::Error for TransactionError {}
@@ -240,6 +243,7 @@ impl fmt::Display for TransactionError {
              => f.write_str("Program cache hit max limit"),
             Self::CommitCancelled
              => f.write_str("CommitCancelled"),
+            Self::InstructionsSysvarOverflow => f.write_str("Instruction sysvar format overflow"),
         }
     }
 }

--- a/transaction-error/src/lib.rs
+++ b/transaction-error/src/lib.rs
@@ -19,7 +19,7 @@ pub type TransactionResult<T> = Result<T, TransactionError>;
     feature = "frozen-abi",
     derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample),
     frozen_abi(
-        abi_digest = "6qvmfr8X2536Tt5964pUX2mhSggRQxcyHPBVVonnbbhE",
+        abi_digest = "DQJRmVrrXp8rnoN2fjcHuvZNE6yorCxLEnifgoc3CQNA",
         abi_serializer = ["bincode", "wincode"],
         test_roundtrip = "eq_and_wire"
     )


### PR DESCRIPTION
### Problem
- txv1's larger size introduces the possibility of overflowing the instructions sysvar format

### Solution
- handle overflow in instruction sysvar construction
- add transaction error variant for the overflow