### PR TITLE
refactor: remove manual implementation of is_multiple_of

### DIFF
--- a/message/src/versions/v1/message.rs
+++ b/message/src/versions/v1/message.rs
@@ -476,7 +476,7 @@ impl Message {
 
         // if specified, heap size must be a multiple of 1024 and within valid bounds
         if let Some(heap_size) = self.config.heap_size {
-            if heap_size % 1024 != 0 {
+            if !heap_size.is_multiple_of(1024) {
                 return Err(MessageError::InvalidHeapSize);
             }
 


### PR DESCRIPTION
### Problem
Seeing this when running nightly:

```bash
warning: manual implementation of `.is_multiple_of()`
   --> message/src/versions/v1/message.rs:479:16
    |
479 |             if heap_size % 1024 != 0 {
    |                ^^^^^^^^^^^^^^^^^^^^^ help: replace with: `!heap_size.is_multiple_of(1024)`
```

### Solution
use `is_multiple_of`