### PR TITLE
feat: support and check StableAbi for message and transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3871,6 +3871,7 @@ dependencies = [
  "serde_derive",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
+ "solana-instruction-error",
  "solana-program-error",
  "wincode",
 ]
@@ -4790,6 +4791,7 @@ dependencies = [
  "solana-frozen-abi-macro",
  "solana-instruction-error",
  "solana-sanitize",
+ "solana-transaction-error",
  "wincode",
 ]
 

--- a/instruction-error/Cargo.toml
+++ b/instruction-error/Cargo.toml
@@ -30,5 +30,10 @@ solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-program-error = { workspace = true }
 wincode = { workspace = true, optional = true }
 
+[dev-dependencies]
+# Self-dependency enabling `wincode` so the `frozen_abi` wincode digest test can
+# serialize `InstructionError` during unit tests.
+solana-instruction-error = { path = ".", features = ["wincode"] }
+
 [lints]
 workspace = true

--- a/instruction-error/src/lib.rs
+++ b/instruction-error/src/lib.rs
@@ -24,7 +24,9 @@ pub use {
 #[allow(deprecated)]
 mod instruction_error_module {
     #[cfg(feature = "frozen-abi")]
-    use solana_frozen_abi_macro::{AbiEnumVisitor, AbiExample};
+    use solana_frozen_abi_macro::{
+        frozen_abi, AbiEnumVisitor, AbiExample, StableAbi, StableAbiSample,
+    };
 
     /// Reasons the runtime might have rejected an instruction.
     ///
@@ -33,7 +35,15 @@ mod instruction_error_module {
     /// an error be consistent across software versions.  For example, it is
     /// dangerous to include error strings from 3rd party crates because they could
     /// change at any time and changes to them are difficult to detect.
-    #[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+    #[cfg_attr(
+        feature = "frozen-abi",
+        derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample),
+        frozen_abi(
+            abi_digest = "99sLbFrZmSAM4i28P5vPDJFtB6xDgvyT92iEJpKiMPpF",
+            abi_serializer = ["bincode", "wincode"],
+            test_roundtrip = "eq_and_wire"
+        )
+    )]
     #[cfg_attr(
         feature = "serde",
         derive(serde_derive::Serialize, serde_derive::Deserialize)

--- a/message/src/compiled_instruction.rs
+++ b/message/src/compiled_instruction.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "frozen-abi")]
-use solana_frozen_abi_macro::AbiExample;
+use solana_frozen_abi_macro::{frozen_abi, AbiExample, StableAbi, StableAbiSample};
 use {alloc::vec::Vec, solana_address::Address, solana_sanitize::Sanitize};
 #[cfg(feature = "wincode")]
 use {
@@ -16,7 +16,15 @@ use {
 /// construction of `Message`. Most users will not interact with it directly.
 ///
 /// [`Message`]: crate::Message
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, StableAbi, StableAbiSample),
+    frozen_abi(
+        abi_digest = "ANAoDM13eiKa3WRnfiwYi8jcgaEgC32xHWyA8xVAkUGV",
+        abi_serializer = ["bincode", "wincode"],
+        test_roundtrip = "eq_and_wire"
+    )
+)]
 #[cfg_attr(
     feature = "serde",
     derive(Deserialize, Serialize),

--- a/message/src/lib.rs
+++ b/message/src/lib.rs
@@ -47,7 +47,7 @@ extern crate std;
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "frozen-abi")]
-use solana_frozen_abi_macro::AbiExample;
+use solana_frozen_abi_macro::{frozen_abi, AbiExample, StableAbi, StableAbiSample};
 #[cfg(feature = "std")]
 use std::collections::HashSet;
 #[cfg(feature = "wincode")]
@@ -119,7 +119,15 @@ pub const MESSAGE_HEADER_LENGTH: usize = 3;
 /// access the same read-write accounts are processed sequentially.
 ///
 /// [PoH]: https://docs.solanalabs.com/consensus/synchronization
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, StableAbi, StableAbiSample),
+    frozen_abi(
+        abi_digest = "BoNk47PmBYTf1fzuJoZ8tcFm9EVnFjv8v7bDccreDvgB",
+        abi_serializer = ["bincode", "wincode"],
+        test_roundtrip = "eq_and_wire"
+    )
+)]
 #[cfg_attr(
     feature = "serde",
     derive(Deserialize, Serialize),

--- a/message/src/versions/v0/mod.rs
+++ b/message/src/versions/v0/mod.rs
@@ -13,7 +13,7 @@ pub use loaded::*;
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "frozen-abi")]
-use solana_frozen_abi_macro::AbiExample;
+use solana_frozen_abi_macro::{frozen_abi, AbiExample, StableAbi, StableAbiSample};
 use {
     crate::{
         compiled_instruction::CompiledInstruction,
@@ -38,7 +38,15 @@ mod loaded;
 
 /// Address table lookups describe an on-chain address lookup table to use
 /// for loading more readonly and writable accounts in a single tx.
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, StableAbi, StableAbiSample),
+    frozen_abi(
+        abi_digest = "BgfDMK6KNGWbvzMmSAcwMsMoL25jmE7x7CCzCeYtMnqa",
+        abi_serializer = ["bincode", "wincode"],
+        test_roundtrip = "eq_and_wire"
+    )
+)]
 #[cfg_attr(
     feature = "serde",
     derive(Deserialize, Serialize),

--- a/message/src/versions/v1/config.rs
+++ b/message/src/versions/v1/config.rs
@@ -1,10 +1,17 @@
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "frozen-abi")]
-use solana_frozen_abi_macro::AbiExample;
+use solana_frozen_abi_macro::{frozen_abi, AbiExample, StableAbi, StableAbiSample};
 
 /// Compute budget configuration for V1 transactions.
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, StableAbi, StableAbiSample),
+    frozen_abi(
+        abi_digest = "7vsBq6gqhX7ZZE6LHVDjiwK5YmSA9Dvc5rCXgLyr32UP",
+        test_roundtrip = "eq_and_wire"
+    )
+)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),

--- a/transaction-error/Cargo.toml
+++ b/transaction-error/Cargo.toml
@@ -16,7 +16,12 @@ all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
 [features]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "serde"]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "serde",
+    "solana-instruction-error/frozen-abi",
+]
 serde = ["dep:serde", "dep:serde_derive", "solana-instruction-error/serde"]
 wincode = ["dep:wincode", "solana-instruction-error/wincode"]
 
@@ -28,6 +33,11 @@ solana-frozen-abi-macro = { workspace = true, optional = true }
 solana-instruction-error = { workspace = true }
 solana-sanitize = { workspace = true }
 wincode = { workspace = true, optional = true }
+
+[dev-dependencies]
+# Self-dependency enabling `wincode` so the `frozen_abi` wincode digest test can
+# serialize `TransactionError` during unit tests.
+solana-transaction-error = { path = ".", features = ["wincode"] }
 
 [lints]
 workspace = true

--- a/transaction-error/src/lib.rs
+++ b/transaction-error/src/lib.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "frozen-abi")]
-use solana_frozen_abi_macro::{AbiEnumVisitor, AbiExample};
+use solana_frozen_abi_macro::{frozen_abi, AbiEnumVisitor, AbiExample, StableAbi, StableAbiSample};
 #[cfg(any(
     feature = "frozen-abi",
     not(any(target_os = "solana", target_arch = "bpf"))
@@ -15,7 +15,15 @@ use {core::fmt, solana_instruction_error::InstructionError, solana_sanitize::San
 pub type TransactionResult<T> = Result<T, TransactionError>;
 
 /// Reasons a transaction might be rejected.
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample),
+    frozen_abi(
+        abi_digest = "6qvmfr8X2536Tt5964pUX2mhSggRQxcyHPBVVonnbbhE",
+        abi_serializer = ["bincode", "wincode"],
+        test_roundtrip = "eq_and_wire"
+    )
+)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/transaction/src/versioned/mod.rs
+++ b/transaction/src/versioned/mod.rs
@@ -1,5 +1,7 @@
 //! Defines a transaction which supports multiple versions of messages.
 
+#[cfg(feature = "frozen-abi")]
+use solana_frozen_abi_macro::{frozen_abi, AbiExample, StableAbi};
 use {
     crate::Transaction,
     alloc::vec::Vec,
@@ -63,7 +65,15 @@ impl TransactionVersion {
 
 // NOTE: Serialization-related changes must be paired with the direct read at sigverify.
 /// An atomic transaction
-#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, StableAbi),
+    frozen_abi(
+        abi_digest = "DFvqfzN7BvZXod7qDFqR2g3Qo6fXvHNtghaxyAgmuhJX",
+        abi_serializer = "wincode",
+        test_roundtrip = "eq_and_wire"
+    )
+)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "wincode", derive(UninitBuilder))]
 #[derive(Debug, PartialEq, Default, Eq, Clone)]
@@ -77,6 +87,94 @@ pub struct VersionedTransaction {
     pub signatures: Vec<Signature>,
     /// Message to sign.
     pub message: VersionedMessage,
+}
+
+// `StableAbi` is provided through a manual `Distribution` (rather than the
+// `StableAbiSample` derive) because the sampled value must be self-consistent to
+// survive a serialize/deserialize roundtrip. The component types are still
+// sampled with their derived `StableAbi::random`; only the parts that the wire
+// format couples together are constrained here:
+//   * The legacy message has no version prefix, so its first byte (the header's
+//     `num_required_signatures`) must stay below `MESSAGE_VERSION_PREFIX`,
+//     otherwise it would decode as a versioned message. Legacy is therefore only
+//     selected when the sampled header allows it.
+//   * V0/legacy signatures use a `ShortU16` length prefix; the derived 0..=5
+//     count fits in a single prefix byte, so the derived sampling is reused.
+//   * V1 writes signatures as a fixed-length array sized by the header, so the
+//     signature count must equal `num_required_signatures`.
+#[cfg(feature = "frozen-abi")]
+impl solana_frozen_abi::rand::prelude::Distribution<VersionedTransaction>
+    for solana_frozen_abi::rand::distr::StandardUniform
+{
+    fn sample<R: solana_frozen_abi::rand::Rng + ?Sized>(
+        &self,
+        rng: &mut R,
+    ) -> VersionedTransaction {
+        use {
+            solana_address::Address,
+            solana_frozen_abi::stable_abi::StableAbi,
+            solana_message::{
+                compiled_instruction::CompiledInstruction, v0, v1, Message as LegacyMessage,
+                MessageHeader, MESSAGE_VERSION_PREFIX,
+            },
+        };
+
+        let header = MessageHeader::random(rng);
+        let legacy_representable = header.num_required_signatures & MESSAGE_VERSION_PREFIX == 0;
+
+        // 0 = legacy, 1 = v0, 2 = v1.
+        let version = if legacy_representable {
+            rng.random_range(0u8..3)
+        } else {
+            rng.random_range(1u8..3)
+        };
+
+        // `Vec` has several context-specific `StableAbi` impls, so the element
+        // type is named explicitly to select the default-context one (which draws
+        // a small, single-byte-prefix-sized length); the other fields infer it.
+        let (message, signatures) = match version {
+            0 => (
+                VersionedMessage::Legacy(LegacyMessage {
+                    header,
+                    account_keys: <Vec<Address> as StableAbi>::random(rng),
+                    recent_blockhash: StableAbi::random(rng),
+                    instructions: <Vec<CompiledInstruction> as StableAbi>::random(rng),
+                }),
+                <Vec<Signature> as StableAbi>::random(rng),
+            ),
+            1 => (
+                VersionedMessage::V0(v0::Message {
+                    header,
+                    account_keys: <Vec<Address> as StableAbi>::random(rng),
+                    recent_blockhash: StableAbi::random(rng),
+                    instructions: <Vec<CompiledInstruction> as StableAbi>::random(rng),
+                    address_table_lookups:
+                        <Vec<v0::MessageAddressTableLookup> as StableAbi>::random(rng),
+                }),
+                <Vec<Signature> as StableAbi>::random(rng),
+            ),
+            _ => {
+                let signatures = (0..header.num_required_signatures)
+                    .map(|_| Signature::random(rng))
+                    .collect();
+                (
+                    VersionedMessage::V1(v1::Message {
+                        header,
+                        config: StableAbi::random(rng),
+                        lifetime_specifier: StableAbi::random(rng),
+                        account_keys: <Vec<Address> as StableAbi>::random(rng),
+                        instructions: <Vec<CompiledInstruction> as StableAbi>::random(rng),
+                    }),
+                    signatures,
+                )
+            }
+        };
+
+        VersionedTransaction {
+            signatures,
+            message,
+        }
+    }
 }
 
 impl From<Transaction> for VersionedTransaction {

--- a/transaction/src/versioned/mod.rs
+++ b/transaction/src/versioned/mod.rs
@@ -153,7 +153,7 @@ impl solana_frozen_abi::rand::prelude::Distribution<VersionedTransaction>
                 }),
                 <Vec<Signature> as StableAbi>::random(rng),
             ),
-            _ => {
+            2 => {
                 let signatures = (0..header.num_required_signatures)
                     .map(|_| Signature::random(rng))
                     .collect();
@@ -168,6 +168,7 @@ impl solana_frozen_abi::rand::prelude::Distribution<VersionedTransaction>
                     signatures,
                 )
             }
+            _ => unreachable!(),
         };
 
         VersionedTransaction {


### PR DESCRIPTION
VersionedTransaction` and `TransactionError` previously had only `AbiExample`, not `StableAbi`. This adds `StableAbi` to both, along with the supporting types in their field trees (the message components and `InstructionError`).

Most types use the `StableAbiSample` derive. `VersionedTransaction` instead uses a manual `Distribution` (like the legacy `Transaction`): the wire format couples fields together — the legacy message's first byte must stay below the versioned-message prefix, and V1 sizes its signature array from the header — so a random sample has to be built consistently to survive a roundtrip. It still reuses the derived component samplers.

Each top-level type gains an `abi_digest` layout test. Types that support both encoders are digested under `["bincode", "wincode"]` (the two agree byte-for-byte); `VersionedTransaction` is wincode-only since V1 isn't bincode-compatible. All tests use `test_roundtrip = "eq_and_wire"`.

A `wincode`-enabling dev-dependency was added to a couple of crates so their wincode digest tests compile.