### PR TITLE
fix(frozen-abi): bump versions accordingly to published crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3722,7 +3722,7 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "3.5.0"
+version = "3.6.0"
 dependencies = [
  "bincode",
  "bitflags",
@@ -3749,7 +3749,7 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "3.5.0"
+version = "3.6.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -259,8 +259,8 @@ solana-feature-gate-interface = { path = "feature-gate-interface", version = "4.
 solana-fee-calculator = { path = "fee-calculator", version = "3.2.1" }
 solana-fee-structure = { path = "fee-structure", version = "3.0.0" }
 solana-file-download = { path = "file-download", version = "3.0.0" }
-solana-frozen-abi = { path = "frozen-abi", version = "3.5.0" }
-solana-frozen-abi-macro = { path = "frozen-abi-macro", version = "3.5.0", default-features = false }
+solana-frozen-abi = { path = "frozen-abi", version = "3.6.0" }
+solana-frozen-abi-macro = { path = "frozen-abi-macro", version = "3.6.0", default-features = false }
 solana-genesis-config = { path = "genesis-config", version = "4.0.0" }
 solana-hard-forks = { path = "hard-forks", version = "3.1.0", default-features = false }
 solana-hash = { path = "hash", version = "4.4.0", default-features = false }

--- a/frozen-abi-macro/Cargo.toml
+++ b/frozen-abi-macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-frozen-abi-macro"
 description = "Solana Frozen ABI Macro"
 documentation = "https://docs.rs/solana-frozen-abi-macro"
-version = "3.5.0"
+version = "3.6.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/frozen-abi/Cargo.toml
+++ b/frozen-abi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-frozen-abi"
 description = "Solana Frozen ABI"
 documentation = "https://docs.rs/solana-frozen-abi"
-version = "3.5.0"
+version = "3.6.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }


### PR DESCRIPTION
Due to broken publish workflow (https://github.com/anza-xyz/solana-sdk/actions/runs/27373316711/job/80891254447 and https://github.com/anza-xyz/solana-sdk/actions/runs/27369584175/job/80878271722) the manifests and workspace dependency versions were not updated correctly.

Do it manually.