### PR TITLE
ci: pinning all gh actions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -77,56 +77,72 @@ runs:
 
     - name: Install stable toolchain
       if: ${{ inputs.stable-toolchain == 'true' }}
-      uses: dtolnay/rust-toolchain@master
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6  # v1.16.1
       with:
         toolchain: ${{ env.RUST_STABLE }}
+        cache: false
+        rustflags: ""
 
     - name: Install minimum toolchain
       if: ${{ inputs.minimum-toolchain == 'true' }}
-      uses: dtolnay/rust-toolchain@master
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6  # v1.16.1
       with:
         toolchain: ${{ env.RUST_MINIMUM }}
+        cache: false
+        rustflags: ""
 
     - name: Install nightly toolchain
       if: ${{ inputs.nightly-toolchain == 'true' }}
-      uses: dtolnay/rust-toolchain@master
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6  # v1.16.1
       with:
         toolchain: ${{ env.RUST_NIGHTLY }}
+        cache: false
+        rustflags: ""
 
     - name: Install Rustfmt
       if: ${{ inputs.rustfmt == 'true' }}
-      uses: dtolnay/rust-toolchain@master
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6  # v1.16.1
       with:
         toolchain: ${{ env.RUST_NIGHTLY }}
         components: rustfmt
+        cache: false
+        rustflags: ""
 
     - name: Install Clippy
       if: ${{ inputs.clippy == 'true' }}
-      uses: dtolnay/rust-toolchain@master
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6  # v1.16.1
       with:
         toolchain: ${{ env.RUST_NIGHTLY }}
         components: clippy
+        cache: false
+        rustflags: ""
 
     - name: Install Miri
       if: ${{ inputs.miri == 'true' }}
-      uses: dtolnay/rust-toolchain@master
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6  # v1.16.1
       with:
         toolchain: ${{ env.RUST_NIGHTLY }}
         components: miri
+        cache: false
+        rustflags: ""
 
     - name: Install llvm-tools-preview
       if: ${{ inputs.llvm-tools-preview == 'true' }}
-      uses: dtolnay/rust-toolchain@master
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6  # v1.16.1
       with:
         toolchain: ${{ env.RUST_NIGHTLY }}
         components: llvm-tools-preview
+        cache: false
+        rustflags: ""
 
     - name: Install rust-src
       if: ${{ inputs.rust-src == 'true' }}
-      uses: dtolnay/rust-toolchain@master
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6  # v1.16.1
       with:
         toolchain: ${{ env.RUST_NIGHTLY }}
         components: rust-src
+        cache: false
+        rustflags: ""
 
     - name: Install Agave build dependencies
       if: ${{ inputs.agave == 'true' }}
@@ -135,7 +151,7 @@ runs:
 
     - name: Cache Cargo Dependencies
       if: ${{ inputs.cargo-cache-key && !inputs.cargo-cache-fallback-key }}
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
       with:
         path: |
           ~/.cargo/bin/
@@ -148,7 +164,7 @@ runs:
 
     - name: Cache Cargo Dependencies With Fallback
       if: ${{ inputs.cargo-cache-key && inputs.cargo-cache-fallback-key }}
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
       with:
         path: |
           ~/.cargo/bin/
@@ -164,7 +180,7 @@ runs:
 
     - name: Cache Local Cargo Dependencies
       if: ${{ inputs.cargo-cache-local-key }}
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
       with:
         path: |
           .cargo/bin/

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,13 @@ updates:
     time: "08:00"
     timezone: UTC
   open-pull-requests-limit: 0
+
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "08:00"
+    timezone: UTC
+  open-pull-requests-limit: 3
+  cooldown:
+    default-days: 7

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -21,6 +21,6 @@ jobs:
         )
       )
     steps:
-      - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e
+      - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e  # v2.0.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 0 # full history to check for whitespace / conflict markers
 
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 0 # full history to check for diff
 
@@ -56,7 +56,7 @@ jobs:
           cargo-cache-fallback-key: cargo-stable
 
       - name: Install toml-cli
-        uses: taiki-e/cache-cargo-install-action@v2
+        uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7  # v2.3.1
         with:
           tool: toml-cli
 
@@ -79,7 +79,7 @@ jobs:
     needs: [sanity]
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -103,7 +103,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -146,7 +146,7 @@ jobs:
     needs: [sanity]
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -155,7 +155,7 @@ jobs:
           cargo-cache-key: cargo-audit
 
       - name: Install cargo-audit
-        uses: taiki-e/cache-cargo-install-action@v2
+        uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7  # v2.3.1
         with:
           tool: cargo-audit
 
@@ -168,7 +168,7 @@ jobs:
     needs: [sanity]
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -178,7 +178,7 @@ jobs:
           cargo-cache-fallback-key: cargo-nightly
 
       - name: Install cargo-hack
-        uses: taiki-e/cache-cargo-install-action@v2
+        uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7  # v2.3.1
         with:
           tool: cargo-hack
 
@@ -194,7 +194,7 @@ jobs:
         partition: [1, 2, 3, 4, 5, 6]
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -205,7 +205,7 @@ jobs:
           cargo-cache-fallback-key: cargo-nightly
 
       - name: Install cargo-hack
-        uses: taiki-e/cache-cargo-install-action@v2
+        uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7  # v2.3.1
         with:
           tool: cargo-hack
 
@@ -218,7 +218,7 @@ jobs:
     needs: [sanity]
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -243,7 +243,7 @@ jobs:
     needs: [sanity]
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -253,12 +253,12 @@ jobs:
           cargo-cache-fallback-key: cargo-nightly
 
       - name: Install cargo-hack
-        uses: taiki-e/cache-cargo-install-action@v2
+        uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7  # v2.3.1
         with:
           tool: cargo-hack
 
       - name: Install cargo-minimal-versions
-        uses: taiki-e/cache-cargo-install-action@v2
+        uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7  # v2.3.1
         with:
           tool: cargo-minimal-versions
 
@@ -271,7 +271,7 @@ jobs:
     needs: [sanity]
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Check crates for publishing
         run: ./scripts/order-crates-for-publishing.py
@@ -282,7 +282,7 @@ jobs:
     needs: [sanity]
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -292,7 +292,7 @@ jobs:
           cargo-cache-fallback-key: cargo-nightly
 
       - name: Install cargo-hack
-        uses: taiki-e/cache-cargo-install-action@v2
+        uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7  # v2.3.1
         with:
           tool: cargo-hack
 
@@ -305,7 +305,7 @@ jobs:
     needs: [sanity]
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -315,7 +315,7 @@ jobs:
           cargo-cache-fallback-key: cargo-nightly
 
       - name: Install cargo-sort
-        uses: taiki-e/cache-cargo-install-action@v2
+        uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7  # v2.3.1
         with:
           tool: cargo-sort@2.1.1
 
@@ -328,7 +328,7 @@ jobs:
     needs: [sanity]
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -346,7 +346,7 @@ jobs:
     needs: [sanity]
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -368,7 +368,7 @@ jobs:
           cache: true
 
       - name: Install cargo-hack
-        uses: taiki-e/cache-cargo-install-action@v2
+        uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7  # v2.3.1
         with:
           tool: cargo-hack
 
@@ -381,7 +381,7 @@ jobs:
     needs: [check]
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -391,7 +391,7 @@ jobs:
           cargo-cache-fallback-key: cargo-nightly
 
       - name: Install cargo-hack
-        uses: taiki-e/cache-cargo-install-action@v2
+        uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7  # v2.3.1
         with:
           tool: cargo-hack
 
@@ -404,7 +404,7 @@ jobs:
     needs: [check]
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -422,7 +422,7 @@ jobs:
     needs: [check]
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -432,7 +432,7 @@ jobs:
           cargo-cache-fallback-key: cargo-nightly
 
       - name: Install cargo-hack
-        uses: taiki-e/cache-cargo-install-action@v2
+        uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7  # v2.3.1
         with:
           tool: cargo-hack
 
@@ -445,10 +445,10 @@ jobs:
     needs: [check]
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: 20
 
@@ -459,7 +459,7 @@ jobs:
           cargo-cache-key: cargo-stable-wasm
 
       - name: Install wasm-pack
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595  # v2.81.11
         with:
           tool: wasm-pack
 
@@ -472,7 +472,7 @@ jobs:
     needs: [check]
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -482,7 +482,7 @@ jobs:
           cargo-cache-fallback-key: cargo-nightly
 
       - name: Install grcov
-        uses: taiki-e/cache-cargo-install-action@v2
+        uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7  # v2.3.1
         with:
           tool: grcov
 
@@ -495,7 +495,7 @@ jobs:
     needs: [check]
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -513,7 +513,7 @@ jobs:
     needs: [check]
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -531,7 +531,7 @@ jobs:
     needs: [sanity]
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -542,7 +542,7 @@ jobs:
           cargo-cache-fallback-key: cargo-nightly
 
       - name: Install cargo-hack
-        uses: taiki-e/cache-cargo-install-action@v2
+        uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7  # v2.3.1
         with:
           tool: cargo-hack
 

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 0 # full history to check for whitespace / conflict markers
 
@@ -80,7 +80,7 @@ jobs:
     needs: [sanity]
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -116,10 +116,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Install 'nightly' toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6  # v1.16.1
+        with:
+          toolchain: nightly
+          cache: false
+          rustflags: ""
 
       - name: Run docs.rs build
         run: |
@@ -134,7 +138,7 @@ jobs:
     needs: [sanity]
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -144,17 +148,17 @@ jobs:
           cargo-cache-fallback-key: cargo-nightly
 
       - name: Install cargo-hack
-        uses: taiki-e/cache-cargo-install-action@v2
+        uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7  # v2.3.1
         with:
           tool: cargo-hack
 
       - name: Install cargo-minimal-versions
-        uses: taiki-e/cache-cargo-install-action@v2
+        uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7  # v2.3.1
         with:
           tool: cargo-minimal-versions
 
       - name: Install toml-cli
-        uses: taiki-e/cache-cargo-install-action@v2
+        uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7  # v2.3.1
         with:
           tool: toml-cli
 
@@ -166,7 +170,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Environment
         uses: ./.github/actions/setup
@@ -175,7 +179,7 @@ jobs:
           cargo-cache-fallback-key: cargo-publish-semver
 
       - name: Install cargo-semver-checks
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595  # v2.81.11
         with:
           tool: toml-cli,cargo-semver-checks,cargo-release
 
@@ -228,7 +232,7 @@ jobs:
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           token: ${{ inputs.dry_run && github.token || steps.app-token.outputs.token }}
           fetch-depth: 0 # get the whole history for git-cliff
@@ -241,7 +245,7 @@ jobs:
           cargo-cache-fallback-key: cargo-stable
 
       - name: Install cargo-release
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595  # v2.81.11
         with:
           tool: cargo-release
 
@@ -287,7 +291,7 @@ jobs:
 
       - name: Generate a changelog
         if: github.event.inputs.create_release == 'true'
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5  # v4.8.0
         with:
           config: "scripts/cliff.toml"
           args: ${{ steps.publish.outputs.old_git_tag }}..HEAD --include-path "${{ inputs.package_path }}/**" --github-repo ${{ github.repository }}
@@ -297,7 +301,7 @@ jobs:
 
       - name: Create GitHub release
         if: github.event.inputs.create_release == 'true' && github.event.inputs.dry_run != 'true'
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd  # v1.21.0
         with:
           tag: ${{ steps.publish.outputs.new_git_tag }}
           bodyFile: TEMP_CHANGELOG.md

--- a/.github/workflows/sysvar-comment.yml
+++ b/.github/workflows/sysvar-comment.yml
@@ -25,7 +25,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: PR Comment
         run:


### PR DESCRIPTION
continuing my efforts to pin all of our deps/actions across all repos

- Pinned every external action to a SHA across the workflows and the `setup` composite action.
- Swapped `dtolnay/rust-toolchain` for `actions-rust-lang/setup-rust-toolchain`, so you can actually pin it. 
- Added `github-actions` to `dependabot.yml` (daily, max 3 open PRs, 7-day cooldown), mirroring agave.
