### PR TITLE
perf(account): skip redundant memory init during sysvar account create

### DIFF
--- a/account/src/lib.rs
+++ b/account/src/lib.rs
@@ -357,6 +357,24 @@ fn shared_deserialize_data<T: serde::de::DeserializeOwned, U: ReadableAccount>(
     bincode::deserialize(account.data())
 }
 
+/// Serialize `state` into `writer`, failing with [`bincode::ErrorKind::SizeLimit`]
+/// once `limit` bytes have been written. The limit is enforced during
+/// serialization, so a `Serialize` impl that under-reports its size (or whose
+/// output varies between calls) cannot write past `limit`. Fixint encoding
+/// matches the default `bincode::serialize` byte format.
+#[cfg(feature = "bincode")]
+fn limited_serialize_into<W: std::io::Write, T: serde::Serialize>(
+    writer: W,
+    state: &T,
+    limit: u64,
+) -> Result<(), bincode::Error> {
+    use bincode::Options;
+    bincode::options()
+        .with_fixint_encoding()
+        .with_limit(limit)
+        .serialize_into(writer, state)
+}
+
 #[cfg(feature = "bincode")]
 fn shared_serialize_data<T: serde::Serialize, U: WritableAccount>(
     account: &mut U,
@@ -422,11 +440,10 @@ impl Account {
         space: usize,
         owner: &Pubkey,
     ) -> Result<Self, bincode::Error> {
-        if bincode::serialized_size(state)? > space as u64 {
-            return Err(Box::new(bincode::ErrorKind::SizeLimit));
-        }
+        // The byte limit prevents a misbehaving `Serialize` impl from growing
+        // `data` past `space` (which the `resize` below would then truncate).
         let mut data = Vec::with_capacity(space);
-        bincode::serialize_into(&mut data, state)?;
+        limited_serialize_into(&mut data, state, space as u64)?;
         data.resize(space, 0);
         Ok(Account::new_with_data(lamports, data, owner))
     }
@@ -583,11 +600,10 @@ impl AccountSharedData {
         space: usize,
         owner: &Pubkey,
     ) -> Result<Self, bincode::Error> {
-        if bincode::serialized_size(state)? > space as u64 {
-            return Err(Box::new(bincode::ErrorKind::SizeLimit));
-        }
+        // The byte limit prevents a misbehaving `Serialize` impl from growing
+        // `data` past `space` (which the `resize` below would then truncate).
         let mut data = Vec::with_capacity(space);
-        bincode::serialize_into(&mut data, state)?;
+        limited_serialize_into(&mut data, state, space as u64)?;
         data.resize(space, 0);
         Ok(Self::create_from_existing_shared_data(
             lamports,

--- a/account/src/lib.rs
+++ b/account/src/lib.rs
@@ -381,6 +381,17 @@ impl Account {
     pub fn new_ref(lamports: u64, space: usize, owner: &Pubkey) -> Rc<RefCell<Self>> {
         Rc::new(RefCell::new(Account::new(lamports, space, owner)))
     }
+    /// Create an `Account` from an already-built data buffer, taking ownership
+    /// of it without reallocating or zeroing.
+    pub fn new_with_data(lamports: u64, data: Vec<u8>, owner: &Pubkey) -> Self {
+        Account {
+            lamports,
+            data,
+            owner: *owner,
+            executable: false,
+            rent_epoch: Epoch::default(),
+        }
+    }
     #[cfg(feature = "bincode")]
     pub fn new_data<T: serde::Serialize>(
         lamports: u64,
@@ -411,9 +422,13 @@ impl Account {
         space: usize,
         owner: &Pubkey,
     ) -> Result<Self, bincode::Error> {
-        let mut account = Account::new(lamports, space, owner);
-        shared_serialize_data(&mut account, state)?;
-        Ok(account)
+        if bincode::serialized_size(state)? > space as u64 {
+            return Err(Box::new(bincode::ErrorKind::SizeLimit));
+        }
+        let mut data = Vec::with_capacity(space);
+        bincode::serialize_into(&mut data, state)?;
+        data.resize(space, 0);
+        Ok(Account::new_with_data(lamports, data, owner))
     }
     #[cfg(feature = "bincode")]
     pub fn new_ref_data_with_space<T: serde::Serialize>(
@@ -568,9 +583,19 @@ impl AccountSharedData {
         space: usize,
         owner: &Pubkey,
     ) -> Result<Self, bincode::Error> {
-        let mut account = AccountSharedData::new(lamports, space, owner);
-        shared_serialize_data(&mut account, state)?;
-        Ok(account)
+        if bincode::serialized_size(state)? > space as u64 {
+            return Err(Box::new(bincode::ErrorKind::SizeLimit));
+        }
+        let mut data = Vec::with_capacity(space);
+        bincode::serialize_into(&mut data, state)?;
+        data.resize(space, 0);
+        Ok(Self::create_from_existing_shared_data(
+            lamports,
+            Arc::new(data),
+            *owner,
+            false,
+            Epoch::default(),
+        ))
     }
     #[cfg(feature = "bincode")]
     pub fn new_ref_data_with_space<T: serde::Serialize>(
@@ -624,9 +649,12 @@ pub fn create_account_with_fields<S: SysvarSerialize>(
     sysvar: &S,
     (lamports, rent_epoch): InheritableAccountFields,
 ) -> Account {
-    let data_len = S::size_of().max(bincode::serialized_size(sysvar).unwrap() as usize);
-    let mut account = Account::new(lamports, data_len, &solana_sdk_ids::sysvar::id());
-    to_account::<S, Account>(sysvar, &mut account).unwrap();
+    // Size to the sysvar's full capacity (larger than the current serialized
+    // size for variable-length sysvars like SlotHashes/RecentBlockhashes).
+    let space = S::size_of().max(bincode::serialized_size(sysvar).unwrap() as usize);
+    let mut account =
+        Account::new_data_with_space(lamports, sysvar, space, &solana_sdk_ids::sysvar::id())
+            .unwrap();
     account.rent_epoch = rent_epoch;
     account
 }

--- a/feature-gate-interface/Cargo.toml
+++ b/feature-gate-interface/Cargo.toml
@@ -17,6 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 bincode = [
     "dep:bincode",
     "dep:solana-account",
+    "solana-account/bincode",
     "dep:solana-account-info",
     "dep:solana-instruction",
     "dep:solana-rent",

--- a/feature-gate-interface/src/state.rs
+++ b/feature-gate-interface/src/state.rs
@@ -50,9 +50,7 @@ pub fn to_account(feature: &Feature, account: &mut AccountSharedData) -> Option<
 #[cfg(feature = "bincode")]
 pub fn create_account(feature: &Feature, lamports: u64) -> AccountSharedData {
     let data_len = Feature::size_of().max(bincode::serialized_size(feature).unwrap() as usize);
-    let mut account = AccountSharedData::new(lamports, data_len, &id());
-    to_account(feature, &mut account).unwrap();
-    account
+    AccountSharedData::new_data_with_space(lamports, feature, data_len, &id()).unwrap()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem
When creating sysvar accounts we initialize a `vec![0; spaze]` and then overwrite it serializing the actual data. This came up in profiles and we can skip zeroing by using uninitialized Vec as serialize destination.

#### Changes
1. **New `Account::new_with_data(lamports, data, owner)`** — takes ownership of a pre-built `Vec` without reallocating or zeroing.
2. **`Account::new_data_with_space`** and **`AccountSharedData::new_data_with_space`** — rewritten to allocate once at `space` via `Vec::with_capacity`, `serialize_into` (no realloc), then `resize` to zero **only the trailing padding**. The explicit `serialized_size > space` check preserves the original `SizeLimit` error (which a bare `serialize_into` into a `Vec` would have silently lost by growing past `space`).
3. **`create_account_with_fields`** — delegate to the optimized `new_data_with_space`.