### PR TITLE
 feat(vote-interface): add StableAbi to more structs, fix lockouts sampling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4844,7 +4844,6 @@ dependencies = [
  "arbitrary",
  "bincode",
  "cfg_eval",
- "itertools 0.12.1",
  "num-derive",
  "num-traits",
  "rand 0.9.2",

--- a/vote-interface/Cargo.toml
+++ b/vote-interface/Cargo.toml
@@ -22,8 +22,14 @@ bincode = [
     "dep:solana-system-interface",
     "serde",
 ]
-dev-context-only-utils = ["bincode", "dep:arbitrary", "solana-pubkey/dev-context-only-utils"]
+dev-context-only-utils = [
+    "bincode",
+    "dep:arbitrary",
+    "dep:rand",
+    "solana-pubkey/dev-context-only-utils",
+]
 frozen-abi = [
+    "dep:rand",
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
     "serde",
@@ -59,6 +65,7 @@ bincode = { workspace = true, optional = true }
 cfg_eval = { workspace = true, optional = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
+rand = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 serde_with = { workspace = true, features = ["macros"], optional = true }
@@ -82,8 +89,6 @@ wincode = { workspace = true, optional = true }
 solana-serialize-utils = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
-itertools = { workspace = true }
-rand = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-pubkey = { workspace = true, features = ["dev-context-only-utils"] }
 solana-vote-interface = { path = ".", features = ["dev-context-only-utils", "wincode"] }

--- a/vote-interface/src/instruction.rs
+++ b/vote-interface/src/instruction.rs
@@ -1,5 +1,7 @@
 //! Vote program instructions
 
+#[cfg(feature = "frozen-abi")]
+use solana_frozen_abi_macro::{frozen_abi, StableAbi, StableAbiSample};
 use {
     super::state::TowerSync,
     crate::state::{
@@ -28,6 +30,7 @@ use {
 };
 
 #[repr(u8)]
+#[cfg_attr(feature = "frozen-abi", derive(StableAbi, StableAbiSample))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "wincode", derive(SchemaWrite, SchemaRead))]
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -36,6 +39,14 @@ pub enum CommissionKind {
     BlockRevenue = 1,
 }
 
+#[cfg_attr(
+    feature = "frozen-abi",
+    frozen_abi(
+        abi_digest = "9bqZ5L1KnMFnjQPMoRtfhdgUok3G5W2KKRGuw8uwbkuY",
+        abi_serializer = ["bincode", "wincode"]
+    ),
+    derive(StableAbi, StableAbiSample)
+)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "wincode", derive(SchemaWrite, SchemaRead))]
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -795,4 +806,32 @@ pub fn withdraw(
     ];
 
     Instruction::new_with_bincode(id(), &VoteInstruction::Withdraw(lamports), account_metas)
+}
+
+#[cfg(all(test, feature = "bincode"))]
+mod tests {
+    use {super::*, crate::state::Lockout, std::collections::VecDeque};
+
+    #[test]
+    fn test_compact_serialize_rejects_confirmation_count_above_u8() {
+        // The compact wire format stores `confirmation_count` as a `u8`, so a
+        // value that does not fit (> 255) must fail to serialize rather than be
+        // silently truncated.
+        let lockouts = VecDeque::from([Lockout::new_with_confirmation_count(1, 256)]);
+        let vote_state_update = VoteStateUpdate::new(lockouts.clone(), None, Hash::default());
+        let tower_sync = TowerSync::new(lockouts, None, Hash::default(), Hash::default());
+
+        for ix in [
+            VoteInstruction::CompactUpdateVoteState(vote_state_update),
+            VoteInstruction::TowerSync(tower_sync),
+        ] {
+            let err = bincode::serialize(&ix).unwrap_err();
+            assert!(
+                err.to_string().contains("Invalid confirmation count"),
+                "unexpected error: {err}"
+            );
+            #[cfg(feature = "wincode")]
+            assert!(wincode::serialize(&ix).is_err());
+        }
+    }
 }

--- a/vote-interface/src/state/mod.rs
+++ b/vote-interface/src/state/mod.rs
@@ -56,6 +56,12 @@ pub const VOTE_CREDITS_MAXIMUM_PER_SLOT: u8 = 16;
 #[cfg_attr(feature = "dev-context-only-utils", derive(Arbitrary))]
 pub struct Lockout {
     slot: Slot,
+    /// Effectively bounded by `MAX_LOCKOUT_HISTORY`, the cap applied to it as the
+    /// lockout exponent in [`Lockout::lockout`]; the ABI sample uses that range.
+    #[cfg_attr(
+        feature = "frozen-abi",
+        stable_abi_sample(with = "sampling::sample_confirmation_count(rng)")
+    )]
     confirmation_count: u32,
 }
 
@@ -100,6 +106,52 @@ impl Lockout {
 
     pub fn increase_confirmation_count(&mut self, by: u32) {
         self.confirmation_count = self.confirmation_count.saturating_add(by)
+    }
+}
+
+/// Sampling support for random lockout towers, shared by the `frozen-abi` ABI
+/// samplers and the round-trip tests.
+///
+/// The compact (offset-encoded) wire format used on the wire requires strictly
+/// increasing slots and a root at or below the first slot. Slots are sampled
+/// starting at `LOCKOUT_SAMPLE_SLOT_BASE` and grow by up to
+/// `LOCKOUT_SAMPLE_SLOT_STEP` per lockout; the (optional) root sits just below
+/// the base, so the first delta-encoded offset is always non-negative.
+#[cfg(any(feature = "frozen-abi", test))]
+mod sampling {
+    use {
+        super::{Lockout, MAX_LOCKOUT_HISTORY},
+        solana_clock::Slot,
+        std::collections::VecDeque,
+    };
+
+    const LOCKOUT_SAMPLE_SLOT_BASE: Slot = 149_303_885;
+    const LOCKOUT_SAMPLE_SLOT_STEP: Slot = 1_000;
+
+    /// A `confirmation_count` capped to `MAX_LOCKOUT_HISTORY`, the range usable
+    /// by the compact wire format (and the lockout exponent).
+    pub(super) fn sample_confirmation_count<R: rand::Rng + ?Sized>(rng: &mut R) -> u32 {
+        rng.random_range(0..=MAX_LOCKOUT_HISTORY as u32)
+    }
+
+    /// Build a tower with strictly increasing slots and in-range
+    /// `confirmation_count`s, so the sample survives the compact codec.
+    pub(super) fn sample_lockouts<R: rand::Rng + ?Sized>(rng: &mut R) -> VecDeque<Lockout> {
+        let mut slot = LOCKOUT_SAMPLE_SLOT_BASE;
+        (0..rng.random_range(0..=MAX_LOCKOUT_HISTORY))
+            .map(|_| {
+                slot = slot.saturating_add(rng.random_range(1..=LOCKOUT_SAMPLE_SLOT_STEP));
+                Lockout::new_with_confirmation_count(slot, sample_confirmation_count(rng))
+            })
+            .collect()
+    }
+
+    /// An optional root just below the first sampled slot, keeping the first
+    /// delta-encoded offset non-negative.
+    pub(super) fn sample_root<R: rand::Rng + ?Sized>(rng: &mut R) -> Option<Slot> {
+        rng.random_bool(0.5).then(|| {
+            LOCKOUT_SAMPLE_SLOT_BASE.saturating_sub(rng.random_range(0..=LOCKOUT_SAMPLE_SLOT_STEP))
+        })
     }
 }
 
@@ -503,33 +555,17 @@ pub mod wincode_compact {
 
 #[cfg(all(test, feature = "bincode"))]
 mod tests {
-    use {super::*, itertools::Itertools, rand::Rng, solana_hash::Hash};
+    use {super::*, rand::Rng, solana_hash::Hash};
 
     /// Build a random `VoteStateUpdate` with strictly increasing lockout slots
     /// and an optional root below the first slot, suitable for exercising the
     /// compact (offset-encoded) wire formats.
     fn random_vote_state_update<R: Rng>(rng: &mut R) -> VoteStateUpdate {
-        let lockouts: VecDeque<_> = std::iter::repeat_with(|| {
-            let slot = 149_303_885_u64.saturating_add(rng.random_range(0..10_000));
-            let confirmation_count = rng.random_range(0..33);
-            Lockout::new_with_confirmation_count(slot, confirmation_count)
-        })
-        .take(32)
-        .sorted_by_key(|lockout| lockout.slot())
-        .collect();
-        let root = rng.random_bool(0.5).then(|| {
-            lockouts[0]
-                .slot()
-                .checked_sub(rng.random_range(0..1_000))
-                .expect("All slots should be greater than 1_000")
-        });
-        let timestamp = rng.random_bool(0.5).then(|| rng.random());
-        let hash = Hash::from(rng.random::<[u8; 32]>());
         VoteStateUpdate {
-            lockouts,
-            root,
-            hash,
-            timestamp,
+            lockouts: sampling::sample_lockouts(rng),
+            root: sampling::sample_root(rng),
+            hash: Hash::from(rng.random::<[u8; 32]>()),
+            timestamp: rng.random_bool(0.5).then(|| rng.random()),
         }
     }
 

--- a/vote-interface/src/state/vote_instruction_data.rs
+++ b/vote-interface/src/state/vote_instruction_data.rs
@@ -55,7 +55,7 @@ impl Vote {
     feature = "frozen-abi",
     frozen_abi(
         api_digest = "CxyuwbaEdzP7jDCZyxjgQvLGXadBUZF3LoUvbSpQ6tYN",
-        abi_digest = "CAZasoggS6VYsJWdWf9tWUmqXjmCe1iCa1s1szSkcV3q",
+        abi_digest = "VRLZyFD5255zgCbMPBFExQyw2wyY41U6h4yCe5oT9tR",
         abi_serializer = ["bincode", "wincode"]
     ),
     derive(AbiExample, StableAbi, StableAbiSample)
@@ -65,8 +65,16 @@ impl Vote {
 #[derive(Default, Debug, PartialEq, Eq, Clone)]
 pub struct VoteStateUpdate {
     /// The proposed tower
+    #[cfg_attr(
+        feature = "frozen-abi",
+        stable_abi_sample(with = "super::sampling::sample_lockouts(rng)")
+    )]
     pub lockouts: VecDeque<Lockout>,
     /// The proposed root
+    #[cfg_attr(
+        feature = "frozen-abi",
+        stable_abi_sample(with = "super::sampling::sample_root(rng)")
+    )]
     pub root: Option<Slot>,
     /// signature of the bank's state at the last slot
     pub hash: Hash,
@@ -114,7 +122,7 @@ impl VoteStateUpdate {
     feature = "frozen-abi",
     frozen_abi(
         api_digest = "6UDiQMH4wbNwkMHosPMtekMYu2Qa6CHPZ2ymK4mc6FGu",
-        abi_digest = "AFc7BWoFERboQDSN7VmXqXu7MoV3TwksgKoabdarYycF",
+        abi_digest = "FUbrVcYe9LvPfr6PEk3E27YybVodHTfgZ7SnVzi3bR7",
         abi_serializer = ["bincode", "wincode"]
     ),
     derive(AbiExample, StableAbi, StableAbiSample)
@@ -124,8 +132,16 @@ impl VoteStateUpdate {
 #[derive(Default, Debug, PartialEq, Eq, Clone)]
 pub struct TowerSync {
     /// The proposed tower
+    #[cfg_attr(
+        feature = "frozen-abi",
+        stable_abi_sample(with = "super::sampling::sample_lockouts(rng)")
+    )]
     pub lockouts: VecDeque<Lockout>,
     /// The proposed root
+    #[cfg_attr(
+        feature = "frozen-abi",
+        stable_abi_sample(with = "super::sampling::sample_root(rng)")
+    )]
     pub root: Option<Slot>,
     /// signature of the bank's state at the last slot
     pub hash: Hash,
@@ -213,6 +229,7 @@ impl TowerSync {
     }
 }
 
+#[cfg_attr(feature = "frozen-abi", derive(StableAbi, StableAbiSample))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
@@ -226,6 +243,7 @@ pub struct VoteInit {
 #[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_as)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
+#[cfg_attr(feature = "frozen-abi", derive(StableAbi, StableAbiSample))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct VoteInitV2 {
     pub node_pubkey: Pubkey,
@@ -263,6 +281,7 @@ impl Default for VoteInitV2 {
 #[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_as)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
+#[cfg_attr(feature = "frozen-abi", derive(StableAbi, StableAbiSample))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct VoterWithBLSArgs {
     #[cfg_attr(
@@ -286,6 +305,7 @@ impl Default for VoterWithBLSArgs {
     }
 }
 
+#[cfg_attr(feature = "frozen-abi", derive(StableAbi, StableAbiSample))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -295,6 +315,7 @@ pub enum VoteAuthorize {
     VoterWithBLS(VoterWithBLSArgs),
 }
 
+#[cfg_attr(feature = "frozen-abi", derive(StableAbi, StableAbiSample))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -305,6 +326,7 @@ pub struct VoteAuthorizeWithSeedArgs {
     pub new_authority: Pubkey,
 }
 
+#[cfg_attr(feature = "frozen-abi", derive(StableAbi, StableAbiSample))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/vote-interface/src/state/vote_state_1_14_11.rs
+++ b/vote-interface/src/state/vote_state_1_14_11.rs
@@ -11,7 +11,7 @@ const DEFAULT_PRIOR_VOTERS_OFFSET: usize = 82;
     feature = "frozen-abi",
     frozen_abi(
         api_digest = "2rjXSWaNeAdoUNJDC5otC7NPR1qXHvLMuAs5faE4DPEt",
-        abi_digest = "AiZEyXQnygp5KQWY9godna9h8fZQ7nFPJvdvkuNkyAWc",
+        abi_digest = "3zLH9BFk2HeY4UTTWY82p6z4v9gNyyGkH3qZYWeGP2Fw",
         abi_serializer = ["bincode", "wincode"]
     ),
     derive(AbiExample, StableAbi, StableAbiSample)

--- a/vote-interface/src/state/vote_state_v3.rs
+++ b/vote-interface/src/state/vote_state_v3.rs
@@ -23,7 +23,7 @@ use {
     feature = "frozen-abi",
     frozen_abi(
         api_digest = "pZqasQc6duzMYzpzU7eriHH9cMXmubuUP4NmCrkWZjt",
-        abi_digest = "6xrS3B1cUyFYdPAwavAQ4DKpGTWsdoV4fkaGfiEBRmtQ",
+        abi_digest = "4VUwurjnJ96aMgYXaAmkDut56mMkC4uo6b5bm8iH7WzJ",
         abi_serializer = ["bincode", "wincode"]
     ),
     derive(AbiExample, StableAbi, StableAbiSample)

--- a/vote-interface/src/state/vote_state_v4.rs
+++ b/vote-interface/src/state/vote_state_v4.rs
@@ -22,7 +22,7 @@ use {
     feature = "frozen-abi",
     frozen_abi(
         api_digest = "ALZS4x22Ga8M6KkLVgdEJu3ZQUUSBkFHAkErmSvFLzUM",
-        abi_digest = "EhUJhYgvsX9T4hJPJovYbNLRiMR8irkT7K4BQQwZ797b",
+        abi_digest = "DqcDSgyayprZqMjBEHzUuB6afr3rGckVqHHBWdvVZefU",
         abi_serializer = ["bincode", "wincode"]
     ),
     derive(AbiExample, StableAbi, StableAbiSample)


### PR DESCRIPTION
#### Summary
Adds frozen-abi (`StableAbi`/`StableAbiSample` + `abi_digest`) coverage for `VoteInstruction`, including its compact (offset-encoded) wire format. Previously the compact codec couldn't be ABI-digested: `StableAbiSample` generated `Lockout`s with arbitrary `confirmation_count` (full `u32`) and out-of-order slots, which the compact encoder rejects (`u8::try_from` / non-monotonic offsets), so no stable digest existed.

#### Changes
- **Constrain lockout sampling** so generated towers are compact-serializable:
  - `Lockout::confirmation_count` is sampled in `0..=MAX_LOCKOUT_HISTORY` (the range it's effectively bounded to as the `lockout()` exponent, and which fits the compact `u8`).
  - `VoteStateUpdate`/`TowerSync` sample strictly-increasing slots with a root at/below the first slot, via a shared `sampling` submodule (also reused by the existing round-trip tests).
- **`StableAbi`/`StableAbiSample` + `abi_digest`** on `VoteInstruction` and its field types (`VoteInit`, `VoteInitV2`, `VoterWithBLSArgs`, `VoteAuthorize`, `VoteAuthorize{,Checked}WithSeedArgs`, `CommissionKind`). bincode and wincode agree on the shared digest.
- **Regenerated `abi_digest`** for `VoteStateUpdate`, `TowerSync`, `VoteState1_14_11`, `VoteStateV3`, `VoteStateV4` (sampling changed; wire layout did not).
- `rand` added as an optional dependency (enabled by `frozen-abi`/`dev-context-only-utils`) - the sampling of lockouts is shared by frozen-abi and regular tests with code extracted to shared module
- Negative test: serializing a compact `VoteInstruction` whose `confirmation_count` exceeds `u8` fails with `"Invalid confirmation count"` (bincode and wincode).