### PR TITLE
Add sysvar size consts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3953,6 +3953,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-get-sysvar",
+ "solana-last-restart-slot",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
@@ -4296,6 +4297,7 @@ dependencies = [
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-get-sysvar",
+ "solana-rent",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
@@ -4612,6 +4614,7 @@ dependencies = [
  "solana-hash",
  "solana-sdk-ids",
  "solana-sha256-hasher",
+ "solana-slot-hashes",
  "solana-sysvar-id",
  "wincode",
 ]
@@ -4625,6 +4628,7 @@ dependencies = [
  "serde_derive",
  "solana-get-sysvar",
  "solana-sdk-ids",
+ "solana-slot-history",
  "solana-sysvar-id",
  "wincode",
 ]

--- a/clock/Cargo.toml
+++ b/clock/Cargo.toml
@@ -29,5 +29,5 @@ solana-sysvar-id = { workspace = true, optional = true }
 wincode = { workspace = true, optional = true }
 
 [dev-dependencies]
-solana-clock = { path = ".", features = ["sysvar"] }
+solana-clock = { path = ".", features = ["sysvar", "wincode"] }
 static_assertions = { workspace = true }

--- a/clock/src/lib.rs
+++ b/clock/src/lib.rs
@@ -171,9 +171,21 @@ pub struct Clock {
     pub unix_timestamp: UnixTimestamp,
 }
 
+/// Serialized size of the `Clock` sysvar account.
+pub const SIZE: usize = size_of::<Clock>();
+const _: () = assert!(SIZE == 40);
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_size_of() {
+        assert_eq!(
+            wincode::serialized_size(&Clock::default()).unwrap() as usize,
+            SIZE,
+        );
+    }
 
     #[test]
     fn test_clone() {

--- a/epoch-rewards/Cargo.toml
+++ b/epoch-rewards/Cargo.toml
@@ -39,7 +39,7 @@ solana-sysvar-id = { workspace = true, optional = true }
 wincode = { workspace = true, optional = true }
 
 [dev-dependencies]
-solana-epoch-rewards = { path = ".", features = ["sysvar"] }
+solana-epoch-rewards = { path = ".", features = ["sysvar", "wincode"] }
 
 [lints]
 workspace = true

--- a/epoch-rewards/src/lib.rs
+++ b/epoch-rewards/src/lib.rs
@@ -58,6 +58,16 @@ pub struct EpochRewards {
     pub active: bool,
 }
 
+/// Serialized size of the `EpochRewards` sysvar account.
+pub const SIZE: usize = size_of::<u64>() // distribution_starting_block_height
+    + size_of::<u64>() // num_partitions
+    + size_of::<Hash>() // parent_blockhash
+    + size_of::<u128>() // total_points
+    + size_of::<u64>() // total_rewards
+    + size_of::<u64>() // distributed_rewards
+    + size_of::<bool>(); // active
+const _: () = assert!(SIZE == 81);
+
 impl EpochRewards {
     pub fn distribute(&mut self, amount: u64) {
         let new_distributed_rewards = self.distributed_rewards.saturating_add(amount);
@@ -69,6 +79,14 @@ impl EpochRewards {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_size_of() {
+        assert_eq!(
+            wincode::serialized_size(&EpochRewards::default()).unwrap() as usize,
+            SIZE,
+        );
+    }
 
     impl EpochRewards {
         pub fn new(

--- a/epoch-schedule/Cargo.toml
+++ b/epoch-schedule/Cargo.toml
@@ -37,7 +37,7 @@ wincode = { workspace = true, optional = true }
 
 [dev-dependencies]
 solana-clock = { workspace = true }
-solana-epoch-schedule = { path = ".", features = ["sysvar"] }
+solana-epoch-schedule = { path = ".", features = ["sysvar", "wincode"] }
 static_assertions = { workspace = true }
 
 [lints]

--- a/epoch-schedule/src/lib.rs
+++ b/epoch-schedule/src/lib.rs
@@ -79,6 +79,14 @@ pub struct EpochSchedule {
     pub first_normal_slot: u64,
 }
 
+/// Serialized size of the `EpochSchedule` sysvar account.
+pub const SIZE: usize = size_of::<u64>() // slots_per_epoch
+    + size_of::<u64>() // leader_schedule_slot_offset
+    + size_of::<bool>() // warmup
+    + size_of::<u64>() // first_normal_epoch
+    + size_of::<u64>(); // first_normal_slot
+const _: () = assert!(SIZE == 33);
+
 impl Default for EpochSchedule {
     fn default() -> Self {
         Self::custom(
@@ -213,6 +221,14 @@ impl EpochSchedule {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_size_of() {
+        assert_eq!(
+            wincode::serialized_size(&EpochSchedule::default()).unwrap() as usize,
+            SIZE,
+        );
+    }
 
     #[test]
     fn test_epoch_schedule() {

--- a/last-restart-slot/Cargo.toml
+++ b/last-restart-slot/Cargo.toml
@@ -27,3 +27,6 @@ wincode = ["dep:wincode"]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
+
+[dev-dependencies]
+solana-last-restart-slot = { path = ".", features = ["wincode"] }

--- a/last-restart-slot/src/lib.rs
+++ b/last-restart-slot/src/lib.rs
@@ -17,3 +17,20 @@ pub struct LastRestartSlot {
     /// The last restart `Slot`.
     pub last_restart_slot: u64,
 }
+
+/// Serialized size of the `LastRestartSlot` sysvar account.
+pub const SIZE: usize = size_of::<LastRestartSlot>();
+const _: () = assert!(SIZE == 8);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_size_of() {
+        assert_eq!(
+            wincode::serialized_size(&LastRestartSlot::default()).unwrap() as usize,
+            SIZE,
+        );
+    }
+}

--- a/rent/Cargo.toml
+++ b/rent/Cargo.toml
@@ -32,6 +32,7 @@ wincode = { workspace = true, optional = true }
 [dev-dependencies]
 proptest = { workspace = true }
 solana-clock = { workspace = true }
+solana-rent = { path = ".", features = ["wincode"] }
 static_assertions = { workspace = true }
 
 [lints]

--- a/rent/src/lib.rs
+++ b/rent/src/lib.rs
@@ -39,6 +39,12 @@ pub struct Rent {
     pub burn_percent: u8,
 }
 
+/// Serialized size of the `Rent` sysvar account.
+pub const SIZE: usize = size_of::<u64>() // lamports_per_byte
+    + size_of::<[u8; 8]>() // exemption_threshold
+    + size_of::<u8>(); // burn_percent
+const _: () = assert!(SIZE == 17);
+
 /// Maximum permitted size of account data (10 MiB).
 const MAX_PERMITTED_DATA_LENGTH: u64 = 10 * 1024 * 1024;
 
@@ -225,6 +231,14 @@ impl Rent {
 #[cfg(test)]
 mod tests {
     use {super::*, proptest::proptest};
+
+    #[test]
+    fn test_size_of() {
+        assert_eq!(
+            wincode::serialized_size(&Rent::default()).unwrap() as usize,
+            SIZE,
+        );
+    }
 
     #[test]
     fn test_clone() {

--- a/slot-hashes/Cargo.toml
+++ b/slot-hashes/Cargo.toml
@@ -28,3 +28,4 @@ wincode = { workspace = true, optional = true }
 
 [dev-dependencies]
 solana-sha256-hasher = { workspace = true, features = ["sha2"] }
+solana-slot-hashes = { path = ".", features = ["wincode"] }

--- a/slot-hashes/src/lib.rs
+++ b/slot-hashes/src/lib.rs
@@ -35,6 +35,13 @@ pub fn set_entries_for_tests_only(entries: usize) {
 
 pub type SlotHash = (u64, Hash);
 
+const LEN_PREFIX: usize = size_of::<u64>();
+const SLOT_HASH_SERIALIZED_SIZE: usize = size_of::<u64>() + size_of::<Hash>();
+
+/// Serialized size of the `SlotHashes` sysvar account.
+pub const SIZE: usize = LEN_PREFIX + MAX_ENTRIES * SLOT_HASH_SERIALIZED_SIZE;
+const _: () = assert!(SIZE == 20_488);
+
 #[repr(C)]
 #[cfg_attr(
     feature = "serde",
@@ -87,6 +94,15 @@ impl Deref for SlotHashes {
 #[cfg(test)]
 mod tests {
     use {super::*, solana_sha256_hasher::hash};
+
+    #[test]
+    fn test_size_of() {
+        let slot_hashes = SlotHashes(vec![(0, Hash::default()); MAX_ENTRIES]);
+        assert_eq!(
+            wincode::serialized_size(&slot_hashes).unwrap() as usize,
+            SIZE,
+        );
+    }
 
     #[test]
     fn test() {

--- a/slot-history/Cargo.toml
+++ b/slot-history/Cargo.toml
@@ -27,3 +27,6 @@ solana-get-sysvar = { workspace = true, optional = true }
 solana-sdk-ids = { workspace = true, optional = true }
 solana-sysvar-id = { workspace = true, optional = true }
 wincode = { workspace = true, optional = true }
+
+[dev-dependencies]
+solana-slot-history = { path = ".", features = ["wincode"] }

--- a/slot-history/src/lib.rs
+++ b/slot-history/src/lib.rs
@@ -51,6 +51,9 @@ impl std::fmt::Debug for SlotHistory {
 
 pub const MAX_ENTRIES: u64 = 1024 * 1024; // 1 million slots is about 5 days
 
+/// Serialized size of the `SlotHistory` sysvar account.
+pub const SIZE: usize = 131_097;
+
 #[derive(PartialEq, Eq, Debug)]
 pub enum Check {
     Future,
@@ -101,6 +104,14 @@ impl SlotHistory {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_size_of() {
+        assert_eq!(
+            wincode::serialized_size(&SlotHistory::default()).unwrap() as usize,
+            SIZE,
+        );
+    }
 
     #[test]
     fn slot_history_test1() {

--- a/sysvar/Cargo.toml
+++ b/sysvar/Cargo.toml
@@ -93,7 +93,7 @@ solana-example-mocks = { path = "../example-mocks" }
 solana-hash = { workspace = true, features = ["atomic", "bytemuck"] }
 solana-msg = { workspace = true, features = ["std"] }
 solana-sha256-hasher = { workspace = true, features = ["sha2"] }
-solana-sysvar = { path = ".", features = ["dev-context-only-utils"] }
+solana-sysvar = { path = ".", features = ["dev-context-only-utils", "wincode"] }
 test-case = { workspace = true }
 
 [lints]

--- a/sysvar/src/clock.rs
+++ b/sysvar/src/clock.rs
@@ -124,7 +124,7 @@
 #[cfg(feature = "bincode")]
 use crate::SysvarSerialize;
 pub use {
-    solana_clock::Clock,
+    solana_clock::{Clock, SIZE},
     solana_sdk_ids::sysvar::clock::{check_id, id, ID},
 };
 
@@ -140,12 +140,11 @@ mod tests {
     fn test_clock_size_matches_bincode() {
         // Prove that Clock's in-memory layout matches its bincode serialization.
         let clock = Clock::default();
-        let in_memory_size = core::mem::size_of::<Clock>();
         let bincode_size = bincode::serialized_size(&clock).unwrap() as usize;
 
         assert_eq!(
-            in_memory_size, bincode_size,
-            "Clock in-memory size ({in_memory_size}) must match bincode size ({bincode_size})",
+            SIZE, bincode_size,
+            "Clock SIZE ({SIZE}) must match bincode size ({bincode_size})",
         );
     }
 }

--- a/sysvar/src/epoch_rewards.rs
+++ b/sysvar/src/epoch_rewards.rs
@@ -157,7 +157,7 @@
 #[cfg(feature = "bincode")]
 use crate::SysvarSerialize;
 pub use {
-    solana_epoch_rewards::EpochRewards,
+    solana_epoch_rewards::{EpochRewards, SIZE},
     solana_sdk_ids::sysvar::epoch_rewards::{check_id, id, ID},
 };
 

--- a/sysvar/src/epoch_schedule.rs
+++ b/sysvar/src/epoch_schedule.rs
@@ -122,7 +122,7 @@
 #[cfg(feature = "bincode")]
 use crate::SysvarSerialize;
 pub use {
-    solana_epoch_schedule::{sysvar::PodEpochSchedule, EpochSchedule},
+    solana_epoch_schedule::{sysvar::PodEpochSchedule, EpochSchedule, SIZE},
     solana_sdk_ids::sysvar::epoch_schedule::{check_id, id, ID},
 };
 

--- a/sysvar/src/fees.rs
+++ b/sysvar/src/fees.rs
@@ -47,6 +47,10 @@ pub struct Fees {
     pub fee_calculator: FeeCalculator,
 }
 
+/// Serialized size of `Fees` sysvar account.
+pub const SIZE: usize = size_of::<Fees>();
+const _: () = assert!(SIZE == 8);
+
 impl Fees {
     pub fn new(fee_calculator: &FeeCalculator) -> Self {
         #[allow(deprecated)]
@@ -86,6 +90,14 @@ impl SysvarSerialize for Fees {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_size_of() {
+        assert_eq!(
+            wincode::serialized_size(&Fees::default()).unwrap() as usize,
+            SIZE,
+        );
+    }
 
     #[test]
     fn test_clone() {

--- a/sysvar/src/last_restart_slot.rs
+++ b/sysvar/src/last_restart_slot.rs
@@ -39,7 +39,7 @@
 #[cfg(feature = "bincode")]
 use crate::SysvarSerialize;
 pub use {
-    solana_last_restart_slot::LastRestartSlot,
+    solana_last_restart_slot::{LastRestartSlot, SIZE},
     solana_sdk_ids::sysvar::last_restart_slot::{check_id, id, ID},
 };
 
@@ -55,12 +55,11 @@ mod tests {
     fn test_last_restart_slot_size_matches_bincode() {
         // Prove that LastRestartSlot's in-memory layout matches its bincode serialization.
         let slot = LastRestartSlot::default();
-        let in_memory_size = core::mem::size_of::<LastRestartSlot>();
         let bincode_size = bincode::serialized_size(&slot).unwrap() as usize;
 
         assert_eq!(
-            in_memory_size, bincode_size,
-            "LastRestartSlot in-memory size ({in_memory_size}) must match bincode size ({bincode_size})",
+            SIZE, bincode_size,
+            "LastRestartSlot SIZE ({SIZE}) must match bincode size ({bincode_size})",
         );
     }
 }

--- a/sysvar/src/recent_blockhashes.rs
+++ b/sysvar/src/recent_blockhashes.rs
@@ -37,6 +37,13 @@ use {
 )]
 pub const MAX_ENTRIES: usize = 150;
 
+const LEN_PREFIX: usize = size_of::<u64>();
+const ENTRY_SERIALIZED_SIZE: usize = size_of::<Hash>() + size_of::<FeeCalculator>();
+
+/// Serialized size of `RecentBlockhashes` sysvar account.
+pub const SIZE: usize = LEN_PREFIX + (MAX_ENTRIES * ENTRY_SERIALIZED_SIZE);
+const _: () = assert!(SIZE == 6_008);
+
 impl_sysvar_id!(RecentBlockhashes);
 
 #[deprecated(
@@ -158,8 +165,7 @@ impl Sysvar for RecentBlockhashes {}
 #[cfg(feature = "bincode")]
 impl SysvarSerialize for RecentBlockhashes {
     fn size_of() -> usize {
-        // hard-coded so that we don't have to construct an empty
-        6008 // golden, update if MAX_ENTRIES changes
+        SIZE
     }
 }
 

--- a/sysvar/src/rent.rs
+++ b/sysvar/src/rent.rs
@@ -124,7 +124,7 @@
 #[cfg(feature = "bincode")]
 use crate::SysvarSerialize;
 pub use {
-    solana_rent::Rent,
+    solana_rent::{Rent, SIZE},
     solana_sdk_ids::sysvar::rent::{check_id, id, ID},
 };
 

--- a/sysvar/src/rewards.rs
+++ b/sysvar/src/rewards.rs
@@ -16,6 +16,11 @@ pub struct Rewards {
     pub validator_point_value: f64,
     pub unused: f64,
 }
+
+/// Serialized size of `Rewards` sysvar account.
+pub const SIZE: usize = size_of::<Rewards>();
+const _: () = assert!(SIZE == 16);
+
 impl Rewards {
     pub fn new(validator_point_value: f64) -> Self {
         Self {
@@ -27,3 +32,16 @@ impl Rewards {
 impl Sysvar for Rewards {}
 #[cfg(feature = "bincode")]
 impl SysvarSerialize for Rewards {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_size_of() {
+        assert_eq!(
+            wincode::serialized_size(&Rewards::default()).unwrap() as usize,
+            SIZE,
+        );
+    }
+}

--- a/sysvar/src/slot_hashes.rs
+++ b/sysvar/src/slot_hashes.rs
@@ -53,12 +53,9 @@ use {solana_clock::Slot, solana_hash::Hash};
 #[cfg(feature = "bytemuck")]
 const U64_SIZE: usize = std::mem::size_of::<u64>();
 
-#[cfg(any(feature = "bytemuck", feature = "bincode"))]
-const SYSVAR_LEN: usize = 20_488; // golden, update if MAX_ENTRIES changes
-
 pub use {
     solana_sdk_ids::sysvar::slot_hashes::{check_id, id, ID},
-    solana_slot_hashes::SlotHashes,
+    solana_slot_hashes::{SlotHashes, SIZE},
     solana_sysvar_id::SysvarId,
 };
 
@@ -67,7 +64,7 @@ impl SysvarSerialize for SlotHashes {
     // override
     fn size_of() -> usize {
         // hard-coded so that we don't have to construct an empty
-        SYSVAR_LEN
+        SIZE
     }
     fn from_account_info(
         _account_info: &AccountInfo,
@@ -103,7 +100,7 @@ impl PodSlotHashes {
     /// Fetch all of the raw sysvar data using the `sol_get_sysvar` syscall.
     pub fn fetch() -> Result<Self, solana_program_error::ProgramError> {
         // Allocate an uninitialized buffer for the raw sysvar data.
-        let sysvar_len = SYSVAR_LEN;
+        let sysvar_len = SIZE;
         let mut data = vec![0; sysvar_len];
 
         // Ensure the created buffer is aligned to 8.

--- a/sysvar/src/slot_history.rs
+++ b/sysvar/src/slot_history.rs
@@ -53,15 +53,14 @@ pub use {
     solana_account_info::AccountInfo,
     solana_program_error::ProgramError,
     solana_sdk_ids::sysvar::slot_history::{check_id, id, ID},
-    solana_slot_history::SlotHistory,
+    solana_slot_history::{SlotHistory, SIZE},
 };
 
 #[cfg(feature = "bincode")]
 impl SysvarSerialize for SlotHistory {
     // override
     fn size_of() -> usize {
-        // hard-coded so that we don't have to construct an empty
-        131_097 // golden, update if MAX_ENTRIES changes
+        SIZE
     }
     fn from_account_info(_account_info: &AccountInfo) -> Result<Self, ProgramError> {
         // This sysvar is too large to bincode::deserialize in-program


### PR DESCRIPTION
Unblocks https://github.com/anza-xyz/agave/pull/12245
Continuation of https://github.com/solana-program/stake/pull/399 & https://github.com/anza-xyz/solana-sdk/pull/766

Adds `SIZE` consts to all sysvars. Considered adding a small `SysvarSize` crate/trait, but found it may be a premature abstraction as it doesn't make https://github.com/anza-xyz/agave/pull/12245 that much simpler and risks re-introducing a dep coupling issue we currently have with `SysvarSerialize`. 

All sysvars have a serializer test to backup the value.