### PR TITLE
Bump `quinn-proto`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2577,9 +2577,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
Fixes failing audit ci/cd check: https://github.com/anza-xyz/solana-sdk/actions/runs/27974540049/job/82788925921?pr=786