### PR TITLE
[secp256k1-recover] Make secp256k1-recover no-std

### DIFF
--- a/scripts/check-no-std.sh
+++ b/scripts/check-no-std.sh
@@ -37,6 +37,7 @@ no_std_crates=(
   -p solana-sanitize
   -p solana-sdk-ids
   -p solana-secp256k1-program
+  -p solana-secp256k1-recover
   -p solana-sha256-hasher
   -p solana-signature
   -p solana-sysvar-id

--- a/secp256k1-recover/Cargo.toml
+++ b/secp256k1-recover/Cargo.toml
@@ -13,8 +13,10 @@ edition = { workspace = true }
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
+default = ["std"]
+std = ["borsh?/std", "thiserror/std", "k256/std"]
 borsh = ["dep:borsh"]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "std"]
 
 [dependencies]
 borsh = { workspace = true, optional = true }

--- a/secp256k1-recover/Cargo.toml
+++ b/secp256k1-recover/Cargo.toml
@@ -13,10 +13,8 @@ edition = { workspace = true }
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
-default = ["std"]
-std = ["borsh?/std", "thiserror/std", "k256/std"]
 borsh = ["dep:borsh"]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "std"]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 
 [dependencies]
 borsh = { workspace = true, optional = true }

--- a/secp256k1-recover/src/lib.rs
+++ b/secp256k1-recover/src/lib.rs
@@ -29,6 +29,8 @@
 
 #[cfg(feature = "borsh")]
 extern crate alloc;
+#[cfg(feature = "frozen-abi")]
+extern crate std;
 #[cfg(feature = "borsh")]
 use alloc::string::ToString;
 #[cfg(feature = "borsh")]

--- a/secp256k1-recover/src/lib.rs
+++ b/secp256k1-recover/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 //! Public key recovery from [secp256k1] ECDSA signatures.
@@ -26,6 +27,10 @@
 //! [sp]: https://docs.rs/solana-program/latest/solana_program/secp256k1_program/
 //! [`ecrecover`]: https://docs.soliditylang.org/en/v0.8.14/units-and-global-variables.html?highlight=ecrecover#mathematical-and-cryptographic-functions
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(all(not(feature = "std"), feature = "borsh"))]
+use alloc::string::ToString;
 #[cfg(feature = "borsh")]
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use {core::convert::TryFrom, thiserror::Error};

--- a/secp256k1-recover/src/lib.rs
+++ b/secp256k1-recover/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 //! Public key recovery from [secp256k1] ECDSA signatures.
@@ -27,9 +27,9 @@
 //! [sp]: https://docs.rs/solana-program/latest/solana_program/secp256k1_program/
 //! [`ecrecover`]: https://docs.soliditylang.org/en/v0.8.14/units-and-global-variables.html?highlight=ecrecover#mathematical-and-cryptographic-functions
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "borsh")]
 extern crate alloc;
-#[cfg(all(not(feature = "std"), feature = "borsh"))]
+#[cfg(feature = "borsh")]
 use alloc::string::ToString;
 #[cfg(feature = "borsh")]
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};


### PR DESCRIPTION
#### Problem

Currently, we can't invoke the secp256-recover syscall using `solana-secp256k1-recover` inside a no-std Solana program because the `solana-secp256k1-recover` crate does not support no-std.

#### Summary of Changes

Added `#![no_std]` support to the crate root, made `std` feature, and included the `std` feature as a default feature.