### PR TITLE
Fix `toml-cli` publish build

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -158,7 +158,7 @@ jobs:
           tool: cargo-minimal-versions
 
       - name: Install toml-cli
-        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7  # v3.0.7
+        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595  # v2.81.11
         with:
           tool: toml-cli
 


### PR DESCRIPTION
Publish job failing on master ([run#604](https://github.com/anza-xyz/solana-sdk/actions/runs/28020619429)) since https://github.com/anza-xyz/solana-sdk/pull/778.

Timeline:
- Before, the Install toml-cli step gets a cache hit and restores a prebuilt binary
- The publish run after #778 misses that cache and builds toml-cli from source, under nightly
- Failure due to a nightly feature rustc removed that toml-cli uses

This PR removes the cache setup:

```diff
name: Install toml-cli
-  uses: taiki-e/cache-cargo-install-action
+  uses: taiki-e/install-action
```

which fixes the problem as it doesn't compile toml-cli at all, but downloads a prebuilt binary. Validated with:

```
# old err
cargo +nightly-2026-01-22 install toml-cli --locked --version 0.2.3

# what `taiki-e/install-action` does
cargo binstall --no-confirm --dry-run --force --targets x86_64-unknown-linux-gnu toml-cli@0.2.3
# shows no compilation
```