### PR TITLE
CI: Add summarize step to publishing

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -61,6 +61,9 @@ jobs:
         with:
           fetch-depth: 0 # full history to check for whitespace / conflict markers
 
+      - name: Summarise workflow inputs
+        uses: solana-program/actions/workflow-inputs@v1
+
       - name: Setup Environment
         uses: ./.github/actions/setup
         with:


### PR DESCRIPTION
#### Problem

The sdk repo doesn't provide a summary of publish jobs.

#### Summary of changes

Use the reusable workflow during the first step.