### PR TITLE
feat(vote-interface): support StableAbi for VoteStateVersions

### DIFF
--- a/vote-interface/src/state/vote_state_versions.rs
+++ b/vote-interface/src/state/vote_state_versions.rs
@@ -1,6 +1,8 @@
 use crate::state::{vote_state_1_14_11::VoteState1_14_11, VoteStateV3, VoteStateV4};
 #[cfg(test)]
 use arbitrary::{Arbitrary, Unstructured};
+#[cfg(feature = "frozen-abi")]
+use solana_frozen_abi_macro::{frozen_abi, StableAbi, StableAbiSample};
 #[cfg(any(target_os = "solana", feature = "bincode"))]
 use solana_instruction_error::InstructionError;
 #[cfg(test)]
@@ -10,6 +12,14 @@ use {
     std::collections::VecDeque,
 };
 
+#[cfg_attr(
+    feature = "frozen-abi",
+    frozen_abi(
+        abi_digest = "292pqhdmS6k7yrk5pUSQBpiQq1MLHb15pu6oM5WnWcug",
+        abi_serializer = ["bincode", "wincode"]
+    ),
+    derive(StableAbi, StableAbiSample)
+)]
 #[cfg_attr(
     feature = "serde",
     derive(serde_derive::Deserialize, serde_derive::Serialize)


### PR DESCRIPTION
The outer enum `VoteStateVersions` is still missing `StableAbi`, add it.