### PR TITLE
manifest: Enable `all-features` and docsrs config on all crates

### DIFF
--- a/atomic-u64/Cargo.toml
+++ b/atomic-u64/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [target.'cfg(not(target_pointer_width = "64"))'.dependencies]
 parking_lot = { workspace = true }

--- a/big-mod-exp/Cargo.toml
+++ b/big-mod-exp/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [dependencies]
 solana-define-syscall = { workspace = true }

--- a/bincode/Cargo.toml
+++ b/bincode/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [dependencies]
 bincode = { workspace = true }

--- a/borsh/Cargo.toml
+++ b/borsh/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [dependencies]
 borsh = { workspace = true }

--- a/client-traits/Cargo.toml
+++ b/client-traits/Cargo.toml
@@ -12,6 +12,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [dependencies]
 solana-account = { workspace = true }

--- a/commitment-config/Cargo.toml
+++ b/commitment-config/Cargo.toml
@@ -12,6 +12,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 serde = ["dep:serde", "dep:serde_derive"]

--- a/cpi/Cargo.toml
+++ b/cpi/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [dependencies]
 solana-account-info = { workspace = true }

--- a/define-syscall/Cargo.toml
+++ b/define-syscall/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 # static syscalls for eBPF are experimental and

--- a/derivation-path/Cargo.toml
+++ b/derivation-path/Cargo.toml
@@ -12,6 +12,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [dependencies]
 derivation-path = { workspace = true }

--- a/ed25519-program/Cargo.toml
+++ b/ed25519-program/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [dependencies]
 bytemuck = { workspace = true }

--- a/epoch-info/Cargo.toml
+++ b/epoch-info/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 serde = ["dep:serde", "dep:serde_derive"]

--- a/epoch-rewards-hasher/Cargo.toml
+++ b/epoch-rewards-hasher/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [dependencies]
 siphasher = { workspace = true }

--- a/epoch-schedule/Cargo.toml
+++ b/epoch-schedule/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]

--- a/feature-gate-interface/Cargo.toml
+++ b/feature-gate-interface/Cargo.toml
@@ -12,6 +12,8 @@ rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 bincode = [

--- a/file-download/Cargo.toml
+++ b/file-download/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 default = ["native-tls"]

--- a/get-sysvar/Cargo.toml
+++ b/get-sysvar/Cargo.toml
@@ -12,6 +12,7 @@ edition = { workspace = true }
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [dependencies]
 solana-address = { workspace = true }

--- a/hard-forks/Cargo.toml
+++ b/hard-forks/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]

--- a/inflation/Cargo.toml
+++ b/inflation/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]

--- a/msg/Cargo.toml
+++ b/msg/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 default = ["std"]

--- a/native-token/Cargo.toml
+++ b/native-token/Cargo.toml
@@ -11,3 +11,5 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]

--- a/nonce-account/Cargo.toml
+++ b/nonce-account/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 wincode = ["dep:wincode", "solana-nonce/wincode"]

--- a/package-metadata-macro/Cargo.toml
+++ b/package-metadata-macro/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [lib]
 proc-macro = true

--- a/package-metadata/Cargo.toml
+++ b/package-metadata/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [dependencies]
 solana-package-metadata-macro = { workspace = true }

--- a/precompile-error/Cargo.toml
+++ b/precompile-error/Cargo.toml
@@ -12,6 +12,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [dependencies]
 num-traits = { workspace = true }

--- a/presigner/Cargo.toml
+++ b/presigner/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [dependencies]
 solana-pubkey = { workspace = true }

--- a/program-entrypoint/Cargo.toml
+++ b/program-entrypoint/Cargo.toml
@@ -8,11 +8,12 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-
 rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [dependencies]
 solana-account-info = { workspace = true }

--- a/program-memory/Cargo.toml
+++ b/program-memory/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [target.'cfg(any(target_os = "solana", target_arch = "bpf"))'.dependencies]
 solana-define-syscall = { workspace = true }

--- a/program-option/Cargo.toml
+++ b/program-option/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 nullable = ["dep:solana-nullable"]

--- a/program-pack/Cargo.toml
+++ b/program-pack/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [dependencies]
 solana-program-error = { workspace = true }

--- a/rent/Cargo.toml
+++ b/rent/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]

--- a/reward-info/Cargo.toml
+++ b/reward-info/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro", "serde"]

--- a/sanitize/Cargo.toml
+++ b/sanitize/Cargo.toml
@@ -12,3 +12,5 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]

--- a/sdk-ids/Cargo.toml
+++ b/sdk-ids/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [dependencies]
 solana-address = { workspace = true, features = ["decode"] }

--- a/sdk-macro/Cargo.toml
+++ b/sdk-macro/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [lib]
 proc-macro = true

--- a/secp256k1-recover/Cargo.toml
+++ b/secp256k1-recover/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 borsh = ["dep:borsh"]

--- a/seed-derivable/Cargo.toml
+++ b/seed-derivable/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [dependencies]
 solana-derivation-path = { workspace = true }

--- a/seed-phrase/Cargo.toml
+++ b/seed-phrase/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [dependencies]
 hmac = { workspace = true }

--- a/serde-varint/Cargo.toml
+++ b/serde-varint/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [dependencies]
 serde = { workspace = true }

--- a/serde/Cargo.toml
+++ b/serde/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [dependencies]
 serde = { workspace = true }

--- a/serialize-utils/Cargo.toml
+++ b/serialize-utils/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 default = ["std"]

--- a/sha256-hasher/Cargo.toml
+++ b/sha256-hasher/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 sha2 = ["dep:sha2"]

--- a/short-vec/Cargo.toml
+++ b/short-vec/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 default = ["serde"]

--- a/shred-version/Cargo.toml
+++ b/shred-version/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [dependencies]
 solana-hard-forks = { workspace = true }

--- a/slot-hashes/Cargo.toml
+++ b/slot-hashes/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 serde = ["dep:serde", "dep:serde_derive", "serde/alloc", "solana-hash/serde"]

--- a/system-transaction/Cargo.toml
+++ b/system-transaction/Cargo.toml
@@ -12,6 +12,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [dependencies]
 solana-hash = { workspace = true }

--- a/time-utils/Cargo.toml
+++ b/time-utils/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [lints]
 workspace = true

--- a/validator-exit/Cargo.toml
+++ b/validator-exit/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [lints]
 workspace = true

--- a/wincode-varint/Cargo.toml
+++ b/wincode-varint/Cargo.toml
@@ -12,6 +12,8 @@ rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [dependencies]
 wincode = { workspace = true }


### PR DESCRIPTION
#### Problem

Some crates are missing all of the proper configuration for docs builds, which creates spurious errors when running `cargo-semver-checks`, since it's checking the output of docs builds.

#### Summary of changes

Add `all-features = true` and `rustdoc-args = ["--cfg=docsrs"]` where it isn't specified.