### PR TITLE
Ensure InstructionHeader repr doesn't change

### DIFF
--- a/message/src/versions/v1/message.rs
+++ b/message/src/versions/v1/message.rs
@@ -23,7 +23,8 @@
 //! │                                                        │
 //! │ * ConfigValues ([[u8; 4] * variable based on mask])    │
 //! │                                                        │
-//! │ * InstructionHeaders [(u8, u8, u16) x NumInstructions] │
+//! │ * WireInstructionHeaders [WireInstructionHeader        │
+//! │                            x NumInstructions]          │
 //! │                                                        │
 //! │ * InstructionPayloads (variable based on headers)      │
 //! │    └─ Per NumInstructions:                             │
@@ -43,7 +44,7 @@ use solana_frozen_abi_macro::AbiExample;
 use std::collections::HashSet;
 #[cfg(feature = "wincode")]
 use {
-    crate::v1::{InstructionHeader, FIXED_HEADER_SIZE},
+    crate::v1::{WireInstructionHeader, FIXED_HEADER_SIZE},
     core::{mem::MaybeUninit, slice::from_raw_parts},
     wincode::{
         config::{Config, ConfigCore},
@@ -647,39 +648,26 @@ unsafe impl<'de, C: Config> SchemaRead<'de, C> for Message {
             config.heap_size = Some(u32::from_le_bytes(reader.take_array()?));
         }
 
-        // `InstructionHeader` is a tuple, whose layout Rust does not guarantee. The
-        // cast below reinterprets wire bytes as one, which is only sound if the
-        // fields sit at the offsets the wire format uses. Tuples have no invalid bit
-        // patterns and alignment 1 here, so the only risk is field reordering or
-        // padding; pin both at compile time so a future layout change fails the build
-        // rather than silently mis-parsing instructions.
-        const _: () = {
-            assert!(size_of::<InstructionHeader>() == 4);
-            assert!(core::mem::offset_of!(InstructionHeader, 0) == 0); // program_id_index
-            assert!(core::mem::offset_of!(InstructionHeader, 1) == 1); // num_accounts
-            assert!(core::mem::offset_of!(InstructionHeader, 2) == 2); // data_len (u16 LE)
-        };
-
         // SAFETY:
-        // - `take_borrowed(num_instructions * size_of::<InstructionHeader>())` returns
+        // - `take_borrowed(num_instructions * size_of::<WireInstructionHeader>())` returns
         //   exactly the requested number of bytes, or errors.
         // - `take_borrowed` returns a stable borrow from the backing buffer, so the
         //   resulting slice remains valid across subsequent reader operations.
-        // - The `const` block above pins `InstructionHeader`'s layout to a packed
+        // - The `const` block above pins `WireInstructionHeader`'s layout to a packed
         //   4 bytes with fields in wire order, so the reinterpretation is exact.
         let instruction_headers = unsafe {
             from_raw_parts(
                 reader
-                    .take_borrowed(num_instructions * size_of::<InstructionHeader>())?
-                    .as_ptr() as *const InstructionHeader,
+                    .take_borrowed(num_instructions * size_of::<WireInstructionHeader>())?
+                    .as_ptr() as *const WireInstructionHeader,
                 num_instructions,
             )
         };
         let mut instructions = Vec::with_capacity(num_instructions);
         for header in instruction_headers {
-            let program_id_index = header.0;
-            let num_accounts = header.1 as usize;
-            let data_len = u16::from_le_bytes(header.2) as usize;
+            let program_id_index = header.program_id_index;
+            let num_accounts = header.num_accounts as usize;
+            let data_len = u16::from_le_bytes(header.data_len) as usize;
 
             <C::LengthEncoding as SeqLen<C>>::prealloc_check::<u8>(num_accounts)?;
             let accounts = <Vec<u8> as SchemaReadContext<C, context::Len>>::get_with_context(

--- a/message/src/versions/v1/message.rs
+++ b/message/src/versions/v1/message.rs
@@ -647,13 +647,26 @@ unsafe impl<'de, C: Config> SchemaRead<'de, C> for Message {
             config.heap_size = Some(u32::from_le_bytes(reader.take_array()?));
         }
 
+        // `InstructionHeader` is a tuple, whose layout Rust does not guarantee. The
+        // cast below reinterprets wire bytes as one, which is only sound if the
+        // fields sit at the offsets the wire format uses. Tuples have no invalid bit
+        // patterns and alignment 1 here, so the only risk is field reordering or
+        // padding; pin both at compile time so a future layout change fails the build
+        // rather than silently mis-parsing instructions.
+        const _: () = {
+            assert!(size_of::<InstructionHeader>() == 4);
+            assert!(core::mem::offset_of!(InstructionHeader, 0) == 0); // program_id_index
+            assert!(core::mem::offset_of!(InstructionHeader, 1) == 1); // num_accounts
+            assert!(core::mem::offset_of!(InstructionHeader, 2) == 2); // data_len (u16 LE)
+        };
+
         // SAFETY:
         // - `take_borrowed(num_instructions * size_of::<InstructionHeader>())` returns
         //   exactly the requested number of bytes, or errors.
         // - `take_borrowed` returns a stable borrow from the backing buffer, so the
         //   resulting slice remains valid across subsequent reader operations.
-        // - `InstructionHeader` has alignment 1 and is encoded exactly as
-        //   4 bytes `(u8, u8, [u8; 2])`.
+        // - The `const` block above pins `InstructionHeader`'s layout to a packed
+        //   4 bytes with fields in wire order, so the reinterpretation is exact.
         let instruction_headers = unsafe {
             from_raw_parts(
                 reader

--- a/message/src/versions/v1/mod.rs
+++ b/message/src/versions/v1/mod.rs
@@ -20,6 +20,8 @@ pub use {config::*, error::*, message::*};
 #[deprecated(since = "4.3.0", note = "Use WireInstructionHeader instead")]
 pub type InstructionHeader = (u8, u8, [u8; 2]);
 
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaRead, wincode::SchemaWrite))]
+#[cfg_attr(feature = "wincode", wincode(assert_zero_copy))]
 #[repr(C)]
 pub struct WireInstructionHeader {
     pub program_id_index: u8,

--- a/message/src/versions/v1/mod.rs
+++ b/message/src/versions/v1/mod.rs
@@ -17,7 +17,15 @@ pub use {config::*, error::*, message::*};
 ///  - data_len
 ///
 /// This is used to parse the instruction portion of a V1 message.
+#[deprecated(since = "4.3.0", note = "Use WireInstructionHeader instead")]
 pub type InstructionHeader = (u8, u8, [u8; 2]);
+
+#[repr(C)]
+pub struct WireInstructionHeader {
+    pub program_id_index: u8,
+    pub num_accounts: u8,
+    pub data_len: [u8; 2],
+}
 
 /// Version byte for V1 messages (decimal 129).
 pub const V1_PREFIX: u8 = MESSAGE_VERSION_PREFIX | 1;

--- a/transaction/src/versioned/mod.rs
+++ b/transaction/src/versioned/mod.rs
@@ -475,7 +475,7 @@ mod tests {
             compiled_instruction::CompiledInstruction,
             v0::Message as MessageV0,
             v1::{
-                InstructionHeader, Message, TransactionConfig, FIXED_HEADER_SIZE,
+                Message, TransactionConfig, WireInstructionHeader, FIXED_HEADER_SIZE,
                 MAX_TRANSACTION_SIZE, SIGNATURE_SIZE,
             },
             Message as LegacyMessage, MessageHeader,
@@ -804,7 +804,7 @@ mod tests {
             + (NUM_SIGNATURES * SIGNATURE_SIZE)
             + FIXED_HEADER_SIZE
             + (NUM_ADDRESSES * ADDRESS_BYTES)
-            + size_of::<InstructionHeader>()
+            + size_of::<WireInstructionHeader>()
             + NUM_INSTRUCTION_ACCOUNTS;
 
         // adds `delta` bytes to the instruction data to test both at max size


### PR DESCRIPTION
### Problem
- tuple layout is technically not stable and future rust versions **could** change the order of fields 
- we take a slice of tuples during wincode deserialization of transaction

### Changes
- Add compile-time asserts on size & offsets for `InstructionHeader`