### PR TITLE
packet: add StableAbi to public types

### DIFF
--- a/packet/Cargo.toml
+++ b/packet/Cargo.toml
@@ -25,7 +25,12 @@ serde = [
     "dep:serde_with",
     "solana-pubkey/serde",
 ]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "serde",
+    "solana-pubkey/frozen-abi",
+]
 
 [dependencies]
 bincode = { workspace = true, optional = true }

--- a/packet/src/lib.rs
+++ b/packet/src/lib.rs
@@ -3,7 +3,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "frozen-abi")]
-use solana_frozen_abi_macro::AbiExample;
+use solana_frozen_abi_macro::{frozen_abi, AbiExample, StableAbi, StableAbiSample};
 #[cfg(feature = "bincode")]
 use {
     bincode::{Options, Result},
@@ -64,7 +64,7 @@ bitflags! {
     }
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
@@ -89,6 +89,17 @@ impl ::solana_frozen_abi::abi_example::TransparentAsHelper for PacketFlags {}
 #[cfg(feature = "frozen-abi")]
 impl ::solana_frozen_abi::abi_example::EvenAsOpaque for PacketFlags {
     const TYPE_NAME_MATCHER: &'static str = "::_::InternalBitFlags";
+}
+
+#[cfg(feature = "frozen-abi")]
+impl ::solana_frozen_abi::stable_abi::StableAbi for PacketFlags {
+    fn random_with_context(
+        rng: &mut (impl ::solana_frozen_abi::rand::RngCore + ?Sized),
+        _ctx: (),
+    ) -> Self {
+        // All bits are defined, but truncate making it future-proof.
+        Self::from_bits_truncate(::solana_frozen_abi::rand::Rng::random(rng))
+    }
 }
 
 // serde_as is used as a work around because array isn't supported by serde
@@ -120,7 +131,15 @@ impl ::solana_frozen_abi::abi_example::EvenAsOpaque for PacketFlags {
 // We use the cfg_eval crate as advised by the serde_with guide:
 // https://docs.rs/serde_with/latest/serde_with/guide/serde_as/index.html#gating-serde_as-on-features
 #[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_as)]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, StableAbi, StableAbiSample),
+    frozen_abi(
+        abi_digest = "5MtHLJ3g6mJfsz9KfxnUgjksRUXSETinR9jZZiYuE7fh",
+        abi_serializer = "bincode",
+        test_roundtrip = "eq_and_wire"
+    )
+)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Clone, Eq)]
 #[repr(C)]


### PR DESCRIPTION
#### Problem
Another crate without `StableAbi` support

#### Summary of Changes
Derive `StableAbi/StableAbiSample` on `Meta` and `Packet`, add a manual impl for the bitflags `PacketFlags`, and freeze `Packet`'s bincode ABI digest.

`PacketFlags` truncates to defined bits: all are defined today, but this keeps sampling valid if a flag is ever removed.