### PR TITLE
packet: zero-initialize buffer in Packet::default

### DIFF
--- a/packet/src/lib.rs
+++ b/packet/src/lib.rs
@@ -315,12 +315,10 @@ impl fmt::Debug for Packet {
     }
 }
 
-#[allow(clippy::uninit_assumed_init)]
 impl Default for Packet {
     fn default() -> Self {
-        let buffer = std::mem::MaybeUninit::<[u8; PACKET_DATA_SIZE]>::uninit();
         Self {
-            buffer: unsafe { buffer.assume_init() },
+            buffer: [0; PACKET_DATA_SIZE],
             meta: Meta::default(),
         }
     }

--- a/scripts/test-miri.sh
+++ b/scripts/test-miri.sh
@@ -5,4 +5,4 @@ here="$(dirname "$0")"
 src_root="$(readlink -f "${here}/..")"
 cd "${src_root}"
 # miri is very slow; so only run very few of selective tests!
-./cargo nightly miri test -p solana-hash -p solana-account-info -p solana-account-view -p solana-instruction-view
+./cargo nightly miri test -p solana-hash -p solana-account-info -p solana-account-view -p solana-instruction-view -p solana-packet


### PR DESCRIPTION
`Packet::default` built its buffer with `MaybeUninit::uninit().assume_init()`, which is undefined behavior for `[u8; PACKET_DATA_SIZE]` (uninitialized integers). Miri flags it through the existing `test_deserialize_slice`:

```
error: Undefined Behavior: constructing invalid value of type [u8; 1232]: at [0], encountered uninitialized memory, but expected an integer
```

Switched to a zeroed buffer, which drops the unsafe block and the clippy allow. Zeroing 1232 bytes is a single memset, and callers overwrite the buffer anyway.

Also added `solana-packet` to `scripts/test-miri.sh` so the existing tests guard against a regression (verified locally: miri fails on the old code, passes on this branch).

Fixes #722