### PR TITLE
deps: Remove `memoffset`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2144,15 +2144,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "merlin"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4173,7 +4164,6 @@ dependencies = [
 name = "solana-program"
 version = "4.0.0"
 dependencies = [
- "memoffset",
  "solana-account-info",
  "solana-big-mod-exp",
  "solana-blake3-hasher",
@@ -4636,7 +4626,6 @@ dependencies = [
 name = "solana-stable-layout"
 version = "3.0.1"
 dependencies = [
- "memoffset",
  "solana-instruction",
  "solana-pubkey",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,7 +198,6 @@ libc = "0.2.170"
 light-poseidon = "0.4.0"
 log = "0.4.25"
 memmap2 = "0.5.10"
-memoffset = "0.9"
 num-bigint = "0.4.6"
 num-derive = "0.4"
 num-traits = { version = "0.2.18", default-features = false }

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -48,7 +48,6 @@ frozen-abi = [
 ]
 
 [dependencies]
-memoffset = { workspace = true }
 solana-account-info = { workspace = true, features = ["bincode"] }
 solana-big-mod-exp = { workspace = true }
 solana-blake3-hasher = { workspace = true, features = ["blake3"] }

--- a/program/src/program.rs
+++ b/program/src/program.rs
@@ -128,10 +128,9 @@ pub fn get_return_data() -> Option<(Pubkey, Vec<u8>)> {
 #[doc(hidden)]
 #[allow(clippy::arithmetic_side_effects)]
 pub fn check_type_assumptions() {
-    extern crate memoffset;
     use {
         crate::instruction::AccountMeta,
-        memoffset::offset_of,
+        core::mem::offset_of,
         std::{
             mem::{align_of, size_of},
             str::FromStr,

--- a/stable-layout/Cargo.toml
+++ b/stable-layout/Cargo.toml
@@ -8,6 +8,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/stable-layout/Cargo.toml
+++ b/stable-layout/Cargo.toml
@@ -19,5 +19,4 @@ solana-instruction = { workspace = true, default-features = false, features = ["
 solana-pubkey = { workspace = true, default-features = false }
 
 [dev-dependencies]
-memoffset = { workspace = true }
 solana-pubkey = { workspace = true, features = ["std"], default-features = false }

--- a/stable-layout/src/stable_instruction.rs
+++ b/stable-layout/src/stable_instruction.rs
@@ -50,8 +50,7 @@ impl From<Instruction> for StableInstruction {
 mod tests {
     use {
         super::*,
-        memoffset::offset_of,
-        std::mem::{align_of, size_of},
+        std::mem::{align_of, offset_of, size_of},
     };
 
     #[test]

--- a/stable-layout/src/stable_vec.rs
+++ b/stable-layout/src/stable_vec.rs
@@ -168,8 +168,7 @@ impl<T> Drop for StableVec<T> {
 mod tests {
     use {
         super::*,
-        memoffset::offset_of,
-        std::mem::{align_of, size_of},
+        std::mem::{align_of, offset_of, size_of},
     };
 
     #[test]


### PR DESCRIPTION
Hi, I may or may not have used your crate but I'd like to say a quick thank you for it anyway!
I'm going down the list of reverse dependencies on `memoffset`.

This PR aims to remove the `memoffset` crate from your dependencies.
[`core::mem::offset_of`](https://doc.rust-lang.org/core/mem/macro.offset_of.html) was stabilised in rustc 1.77 which I believe is at or below your MSRV.

The `memoffset` crate 0.9.1 says that

> If you're using a rustc version greater or equal to 1.77,
> this crate's offset_of!() macro simply forwards to core::mem::offset_of!().

I consider it very unlikely (see [here](https://github.com/rust-lang/rust/issues/111839)) for any usage of the `offset_of!` macro to break but please check anyway.
I hope we can all enjoy the benefits of one less dependency :)
