### PR TITLE
nonce-account: zero-copy get_system_account_kind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4045,6 +4045,7 @@ dependencies = [
 name = "solana-nonce-account"
 version = "4.1.0"
 dependencies = [
+ "bincode",
  "solana-account",
  "solana-fee-calculator",
  "solana-hash",

--- a/nonce-account/Cargo.toml
+++ b/nonce-account/Cargo.toml
@@ -25,5 +25,6 @@ solana-sdk-ids = { workspace = true }
 wincode = { workspace = true, optional = true }
 
 [dev-dependencies]
+bincode = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-pubkey = { workspace = true, features = ["std"] }

--- a/nonce-account/src/lib.rs
+++ b/nonce-account/src/lib.rs
@@ -58,17 +58,26 @@ pub enum SystemAccountKind {
 }
 
 pub fn get_system_account_kind(account: &AccountSharedData) -> Option<SystemAccountKind> {
-    if system_program::check_id(account.owner()) {
-        if account.data().is_empty() {
-            Some(SystemAccountKind::System)
-        } else if account.data().len() == State::size() {
-            let nonce_versions: Versions = account.state().ok()?;
-            match nonce_versions.state() {
-                State::Uninitialized => None,
-                State::Initialized(_) => Some(SystemAccountKind::Nonce),
-            }
-        } else {
-            None
+    if !system_program::check_id(account.owner()) {
+        return None;
+    }
+
+    let data = account.data();
+
+    if data.is_empty() {
+        Some(SystemAccountKind::System)
+    } else if data.len() == State::size() {
+        const NONCE_VERSIONS_LEGACY: u32 = 0;
+        const NONCE_VERSIONS_CURRENT: u32 = 1;
+        const NONCE_STATE_INITIALIZED: u32 = 1;
+
+        let versions_tag = u32::from_le_bytes(data.get(..4)?.try_into().ok()?);
+        let state_tag = u32::from_le_bytes(data.get(4..8)?.try_into().ok()?);
+
+        match (versions_tag, state_tag) {
+            (NONCE_VERSIONS_LEGACY, NONCE_STATE_INITIALIZED) => Some(SystemAccountKind::Nonce),
+            (NONCE_VERSIONS_CURRENT, NONCE_STATE_INITIALIZED) => Some(SystemAccountKind::Nonce),
+            _ => None,
         }
     } else {
         None
@@ -156,51 +165,94 @@ mod tests {
     }
 
     #[test]
-    fn test_get_system_account_kind_system_ok() {
-        let system_account = AccountSharedData::default();
-        assert_eq!(
-            get_system_account_kind(&system_account),
-            Some(SystemAccountKind::System)
-        );
-    }
+    fn test_get_system_account_kind() {
+        // protect `get_system_account_kind()` against the addition of new nonce variants.
+        // if anyone even attempts to add a new nonce variant however they should be punished
+        fn _assert_nonce_versions(v: Versions, s: State) {
+            match v {
+                Versions::Legacy(..) => {}
+                Versions::Current(..) => {}
+            }
+            match s {
+                State::Uninitialized => {}
+                State::Initialized(..) => {}
+            }
+        }
 
-    #[test]
-    fn test_get_system_account_kind_nonce_ok() {
-        let nonce_account = AccountSharedData::new_data(
-            42,
-            &Versions::new(State::Initialized(Data::default())),
-            &system_program::id(),
-        )
+        // assert our function produces the expected result
+        let assert_correct = |bytes: &[u8], kind: Option<SystemAccountKind>| {
+            let mut account = AccountSharedData::new(0, 0, &system_program::id());
+            account.set_data_from_slice(bytes);
+            assert_eq!(get_system_account_kind(&account), kind);
+        };
+
+        // the three (unfortunately rather than two) valid fee-payer types
+        let system_bytes = vec![];
+        let legacy_nonce_bytes = bincode::serialize(&Versions::Legacy(Box::new(
+            State::Initialized(Data::default()),
+        )))
         .unwrap();
-        assert_eq!(
-            get_system_account_kind(&nonce_account),
-            Some(SystemAccountKind::Nonce)
-        );
-    }
-
-    #[test]
-    fn test_get_system_account_kind_uninitialized_nonce_account_fail() {
-        assert_eq!(
-            get_system_account_kind(&crate::create_account(42).borrow()),
-            None
-        );
-    }
-
-    #[test]
-    fn test_get_system_account_kind_system_owner_nonzero_nonnonce_data_fail() {
-        let other_data_account =
-            AccountSharedData::new_data(42, b"other", &Pubkey::default()).unwrap();
-        assert_eq!(get_system_account_kind(&other_data_account), None);
-    }
-
-    #[test]
-    fn test_get_system_account_kind_nonsystem_owner_with_nonce_data_fail() {
-        let nonce_account = AccountSharedData::new_data(
-            42,
-            &Versions::new(State::Initialized(Data::default())),
-            &Pubkey::new_unique(),
-        )
+        let current_nonce_bytes = bincode::serialize(&Versions::Current(Box::new(
+            State::Initialized(Data::default()),
+        )))
         .unwrap();
-        assert_eq!(get_system_account_kind(&nonce_account), None);
+
+        // success
+        assert_correct(&system_bytes, Some(SystemAccountKind::System));
+        assert_correct(&legacy_nonce_bytes, Some(SystemAccountKind::Nonce));
+        assert_correct(&current_nonce_bytes, Some(SystemAccountKind::Nonce));
+
+        // non-system fails
+        for bytes in [&system_bytes, &legacy_nonce_bytes, &current_nonce_bytes] {
+            let mut non_system = AccountSharedData::new(0, 0, &Pubkey::new_unique());
+            non_system.set_data_from_slice(bytes);
+            assert_eq!(get_system_account_kind(&non_system), None);
+        }
+
+        // uninitialized nonce fails
+        for nonce in &[Versions::Legacy, Versions::Current] {
+            let mut bytes = bincode::serialize(&nonce(Box::new(State::Uninitialized))).unwrap();
+            bytes.resize(State::size(), 0);
+            assert_correct(&bytes, None);
+        }
+
+        for bytes in [&legacy_nonce_bytes, &current_nonce_bytes] {
+            // length too short fails
+            for len in 1..bytes.len() {
+                assert_correct(&bytes[..len], None);
+            }
+
+            // length too long fails
+            let mut extended = bytes.clone();
+            extended.push(0);
+            assert_correct(&extended, None);
+
+            // union tag variations fail
+            for byte in 0..=255 {
+                for i in 0..=7 {
+                    // bytes would not change
+                    if bytes[i] == byte {
+                        continue;
+                    }
+
+                    let mut corrupted = bytes.clone();
+                    corrupted[i] = byte;
+
+                    // legacy was changed to current or vice versa
+                    if corrupted == legacy_nonce_bytes || corrupted == current_nonce_bytes {
+                        continue;
+                    }
+
+                    assert_correct(&corrupted, None);
+                }
+            }
+
+            // data variation is ok
+            for i in 8..bytes.len() {
+                let mut with_data = bytes.clone();
+                with_data[i] = 255;
+                assert_correct(&with_data, Some(SystemAccountKind::Nonce));
+            }
+        }
     }
 }


### PR DESCRIPTION
port `fast_get_system_account_kind()` from https://github.com/anza-xyz/agave/pull/13709, a zero-copy impl of `get_system_account_kind()`. this function is called for every incoming transaction in the agave central scheduler