### PR TITLE
rent: Export `GetSysvar` trait

### DIFF
--- a/rent/src/sysvar.rs
+++ b/rent/src/sysvar.rs
@@ -1,8 +1,7 @@
-pub use solana_sdk_ids::sysvar::rent::{check_id, id, ID};
-use {
-    crate::Rent,
-    solana_get_sysvar::{impl_get_sysvar, GetSysvar},
-    solana_sysvar_id::impl_sysvar_id,
+use {crate::Rent, solana_get_sysvar::impl_get_sysvar, solana_sysvar_id::impl_sysvar_id};
+pub use {
+    solana_get_sysvar::GetSysvar,
+    solana_sdk_ids::sysvar::rent::{check_id, id, ID},
 };
 
 impl_sysvar_id!(Rent);


### PR DESCRIPTION
### Problem

Currently to use `Rent::get`, it is necessary to enable the `"sysvar"` feature on solana-rent and also add the solana-get-sysvar crate as a dependency. This can be simplified if solana-rent re-exports the `GetSysvar` trait.

### Solution

Add an export to `GetSysvar` from solana-rent.