### PR TITLE
get-sysvar: Optimize trait implementation

### DIFF
--- a/clock/src/sysvar.rs
+++ b/clock/src/sysvar.rs
@@ -8,5 +8,5 @@ use {
 impl_sysvar_id!(Clock);
 
 impl GetSysvar for Clock {
-    impl_get_sysvar!(id());
+    impl_get_sysvar!(ID);
 }

--- a/epoch-rewards/src/sysvar.rs
+++ b/epoch-rewards/src/sysvar.rs
@@ -12,5 +12,5 @@ impl GetSysvar for EpochRewards {
     // by the Solana runtime and serializes bool as 0x00 or 0x01, so the final
     // `bool` field of `EpochRewards` can be re-aligned with padding and read
     // directly without validation.
-    impl_get_sysvar!(id(), 15);
+    impl_get_sysvar!(ID, 15);
 }

--- a/get-sysvar/src/lib.rs
+++ b/get-sysvar/src/lib.rs
@@ -8,23 +8,50 @@ use {solana_address::Address, solana_program_error::ProgramError};
 // Stable `$crate` paths for `impl_get_sysvar!`, which expands downstream.
 #[doc(hidden)]
 pub mod __private {
-    pub use {crate::get_sysvar_unchecked, solana_program_error::ProgramError};
+    pub use solana_program_error::ProgramError;
+
+    /// Syscall success code.
+    //
+    // Defined in solana-program-entrypoint as [`SUCCESS`](https://github.com/anza-xyz/solana-sdk/blob/program-entrypoint@v2.2.1/program-entrypoint/src/lib.rs#L35).
+    pub const SUCCESS: u64 = 0;
+    /// Return value indicating that the  `offset + length` is greater than the length of
+    /// the sysvar data.
+    //
+    // Defined in the Agave syscalls crate as [`OFFSET_LENGTH_EXCEEDS_SYSVAR`](https://github.com/anza-xyz/agave/blob/v4.0.2/syscalls/src/sysvar.rs#L180).
+    pub const OFFSET_LENGTH_EXCEEDS_SYSVAR: u64 = 1;
+
+    /// Return value indicating that the sysvar was not found.
+    //
+    // Defined in the Agave syscalls crate as [`SYSVAR_NOT_FOUND`](https://github.com/anza-xyz/agave/blob/v4.0.2/syscalls/src/sysvar.rs#L179).
+    pub const SYSVAR_NOT_FOUND: u64 = 2;
+
+    /// Wrapper for the `sol_get_sysvar` syscall.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `sysvar_id` points to a valid sysvar address, and that `var_addr` points
+    /// to a writable buffer of at least `length` bytes.
+    #[inline(always)]
+    pub unsafe fn sol_get_sysvar(
+        sysvar_id: *const u8,
+        var_addr: *mut u8,
+        offset: u64,
+        length: u64,
+    ) -> u64 {
+        // On-chain programs call the runtime syscall directly
+        #[cfg(target_os = "solana")]
+        unsafe {
+            solana_define_syscall::definitions::sol_get_sysvar(sysvar_id, var_addr, offset, length)
+        }
+
+        // Off-chain builds have no solana runtime syscall to call
+        #[cfg(not(target_os = "solana"))]
+        {
+            let _ = (sysvar_id, var_addr, offset, length); // warning suppression
+            solana_program_error::UNSUPPORTED_SYSVAR
+        }
+    }
 }
-
-/// Syscall success code.
-//
-// Defined in solana-program-entrypoint as [`SUCCESS`](https://github.com/anza-xyz/solana-sdk/blob/program-entrypoint@v2.2.1/program-entrypoint/src/lib.rs#L35).
-const SUCCESS: u64 = 0;
-/// Return value indicating that the  `offset + length` is greater than the length of
-/// the sysvar data.
-//
-// Defined in the Agave syscalls crate as [`OFFSET_LENGTH_EXCEEDS_SYSVAR`](https://github.com/anza-xyz/agave/blob/v4.0.2/syscalls/src/sysvar.rs#L180).
-const OFFSET_LENGTH_EXCEEDS_SYSVAR: u64 = 1;
-
-/// Return value indicating that the sysvar was not found.
-//
-// Defined in the Agave syscalls crate as [`SYSVAR_NOT_FOUND`](https://github.com/anza-xyz/agave/blob/v4.0.2/syscalls/src/sysvar.rs#L179).
-const SYSVAR_NOT_FOUND: u64 = 2;
 
 /// Interface for loading a sysvar directly from the runtime.
 pub trait GetSysvar: Sized {
@@ -36,6 +63,7 @@ pub trait GetSysvar: Sized {
     ///
     /// Not all sysvars support this method. If not, it returns
     /// [`ProgramError::UnsupportedSysvar`].
+    #[inline(always)]
     fn get() -> Result<Self, ProgramError> {
         Err(ProgramError::UnsupportedSysvar)
     }
@@ -49,7 +77,8 @@ pub fn get_sysvar(
     offset: u64,
     length: u64,
 ) -> Result<(), ProgramError> {
-    // Check that the provided destination buffer is large enough to hold the requested data
+    // Check that the provided destination buffer is large enough to hold
+    // the requested data.
     if dst.len() < length as usize {
         return Err(ProgramError::InvalidArgument);
     }
@@ -57,14 +86,11 @@ pub fn get_sysvar(
     let sysvar_id = sysvar_id as *const _ as *const u8;
     let var_addr = dst as *mut _ as *mut u8;
 
-    match sol_get_sysvar(sysvar_id, var_addr, offset, length) {
-        SUCCESS => Ok(()),
-        OFFSET_LENGTH_EXCEEDS_SYSVAR => Err(ProgramError::InvalidArgument),
-        _ => Err(ProgramError::UnsupportedSysvar),
-    }
+    // SAFETY: `dst` is a valid buffer of at least `length` bytes.
+    unsafe { get_sysvar_unchecked(var_addr, sysvar_id, offset, length) }
 }
 
-/// Internal helper for retrieving sysvar data directly into a raw buffer.
+/// Helper for retrieving sysvar data directly into a raw buffer.
 ///
 /// # Safety
 ///
@@ -73,62 +99,59 @@ pub fn get_sysvar(
 /// least `length` bytes. This is typically used with `MaybeUninit` to load
 /// compact representations of sysvars.
 #[doc(hidden)]
+#[inline(always)]
 pub unsafe fn get_sysvar_unchecked(
     var_addr: *mut u8,
     sysvar_id: *const u8,
     offset: u64,
     length: u64,
 ) -> Result<(), ProgramError> {
-    match sol_get_sysvar(sysvar_id, var_addr, offset, length) {
-        SUCCESS => Ok(()),
-        OFFSET_LENGTH_EXCEEDS_SYSVAR => Err(ProgramError::InvalidArgument),
-        SYSVAR_NOT_FOUND => Err(ProgramError::UnsupportedSysvar),
+    match __private::sol_get_sysvar(sysvar_id, var_addr, offset, length) {
+        __private::SUCCESS => Ok(()),
+        __private::OFFSET_LENGTH_EXCEEDS_SYSVAR => Err(ProgramError::InvalidArgument),
+        __private::SYSVAR_NOT_FOUND => Err(ProgramError::UnsupportedSysvar),
         // Unexpected errors are folded into `UnsupportedSysvar`.
         _ => Err(ProgramError::UnsupportedSysvar),
-    }
-}
-
-fn sol_get_sysvar(sysvar_id: *const u8, var_addr: *mut u8, offset: u64, length: u64) -> u64 {
-    // On-chain programs call the runtime syscall directly
-    #[cfg(target_os = "solana")]
-    unsafe {
-        solana_define_syscall::definitions::sol_get_sysvar(sysvar_id, var_addr, offset, length)
-    }
-
-    // Off-chain builds have no solana runtime syscall to call
-    #[cfg(not(target_os = "solana"))]
-    {
-        let _ = (sysvar_id, var_addr, offset, length); // warning suppression
-        solana_program_error::UNSUPPORTED_SYSVAR
     }
 }
 
 /// Implements [`GetSysvar::get`] for runtime-backed sysvars.
 #[macro_export]
 macro_rules! impl_get_sysvar {
-    // Variant for sysvars with padding at the end. Loads bincode-serialized data
-    // (size - padding bytes) and zeros the padding to avoid undefined behavior.
-    // Only supports sysvars where padding is at the end of the layout. Caller
-    // must supply the correct number of padding bytes.
+    // Variant for sysvars with trailing bytes (padding). Loads bincode-serialized
+    // data (size - padding bytes). Only supports sysvars where padding is at the end
+    // of the layout. Caller must supply the correct number of padding bytes.
     ($sysvar_id:expr, $padding:literal) => {
+        #[inline(always)]
         fn get() -> Result<Self, $crate::__private::ProgramError> {
             let mut var = core::mem::MaybeUninit::<Self>::uninit();
             let var_addr = var.as_mut_ptr() as *mut u8;
-            let length = core::mem::size_of::<Self>().saturating_sub($padding);
-            let sysvar_id_ptr = (&$sysvar_id) as *const _ as *const u8;
-            // SAFETY: The allocation is valid for `size_of::<Self>()`. We zero
-            // the padding bytes first, then load `(size - padding)` bytes from
-            // the syscall, which matches bincode serialization.
+            // SAFETY: The allocation is valid for `size_of::<Self>()` but it
+            // loads `(size - padding)` bytes from the syscall, which matches bincode
+            // serialization.
             let result = unsafe {
-                var_addr.add(length).write_bytes(0, $padding);
-                $crate::__private::get_sysvar_unchecked(var_addr, sysvar_id_ptr, 0, length as u64)
+                $crate::__private::sol_get_sysvar(
+                    &$sysvar_id as *const _ as *const u8,
+                    var_addr,
+                    0,
+                    core::mem::size_of::<Self>().saturating_sub($padding) as u64,
+                )
             };
+
             match result {
-                // SAFETY: All bytes initialized: padding was zeroed above,
-                // syscall filled the data bytes.
-                Ok(()) => Ok(unsafe { var.assume_init() }),
+                $crate::__private::SUCCESS => {
+                    // SAFETY: The syscall initialized all non-padding bytes of `Self`;
+                    // the remaining bytes are trailing padding.
+                    Ok(unsafe { var.assume_init() })
+                }
+                $crate::__private::OFFSET_LENGTH_EXCEEDS_SYSVAR => {
+                    Err($crate::__private::ProgramError::InvalidArgument)
+                }
+                $crate::__private::SYSVAR_NOT_FOUND => {
+                    Err($crate::__private::ProgramError::UnsupportedSysvar)
+                }
                 // Unexpected errors are folded into `UnsupportedSysvar`.
-                Err(_) => Err($crate::__private::ProgramError::UnsupportedSysvar),
+                _ => Err($crate::__private::ProgramError::UnsupportedSysvar),
             }
         }
     };

--- a/last-restart-slot/src/sysvar.rs
+++ b/last-restart-slot/src/sysvar.rs
@@ -8,5 +8,5 @@ use {
 impl_sysvar_id!(LastRestartSlot);
 
 impl GetSysvar for LastRestartSlot {
-    impl_get_sysvar!(id());
+    impl_get_sysvar!(ID);
 }

--- a/rent/src/sysvar.rs
+++ b/rent/src/sysvar.rs
@@ -7,5 +7,5 @@ pub use {
 impl_sysvar_id!(Rent);
 
 impl GetSysvar for Rent {
-    impl_get_sysvar!(id(), 7);
+    impl_get_sysvar!(ID, 7);
 }


### PR DESCRIPTION
### Problem

Currently, `get_sysvar` is not as performant as the one in pinocchio. It consumes about `48` CUs more, but it could have the same performance.


### Solution

This PR refactor the trait implementation by:

- Removing the double-error conversion
- Removing the unnecessary initialization of padding bytes (see [rustdocs](https://doc.rust-lang.org/std/mem/union.MaybeUninit.html#initialization-invariant))
- Use of `ID` constant instead of `id()` function