### PR TITLE
[bls12-381] Add library for bls12-381 syscalls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3308,7 +3308,6 @@ dependencies = [
  "bytemuck",
  "solana-bls12-381-syscall",
  "solana-define-syscall",
- "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3301,6 +3301,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-bls12-381"
+version = "0.1.0"
+dependencies = [
+ "array-bytes",
+ "bytemuck",
+ "solana-bls12-381-syscall",
+ "solana-define-syscall",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "solana-bls12-381-syscall"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e8256fda0542709fd1320a96d81c3c66e10ac5f680cca9b991d7d3b0e3fe86"
+dependencies = [
+ "blst",
+ "blstrs",
+ "bytemuck",
+ "bytemuck_derive",
+ "pairing",
+]
+
+[[package]]
 name = "solana-bn254"
 version = "3.2.1"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3306,6 +3306,7 @@ version = "0.1.0"
 dependencies = [
  "array-bytes",
  "bytemuck",
+ "bytemuck_derive",
  "solana-bls12-381-syscall",
  "solana-define-syscall",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "bincode",
     "blake3-hasher",
     "bls-signatures",
+    "bls12-381",
     "bn254",
     "borsh",
     "client-traits",
@@ -158,7 +159,7 @@ bincode = "1.3.3"
 bitflags = { version = "2.8.0" }
 bitvec = "1.0.1"
 blake3 = { version = "1.5.5", default-features = false }
-blst = "0.3.14"
+blst = "0.3.16"
 blstrs = "0.7.1"
 borsh = { version = "1.5.5", default-features = false, features = ["derive", "unstable__schema"] }
 boxcar = "0.2.12"
@@ -236,6 +237,8 @@ solana-big-mod-exp = { path = "big-mod-exp", version = "4.0.0" }
 solana-bincode = { path = "bincode", version = "3.0.0" }
 solana-blake3-hasher = { path = "blake3-hasher", version = "3.0.0" }
 solana-bls-signatures = { path = "bls-signatures", version = "3.4.0" }
+solana-bls12-381 = { path = "bls12-381", version = "0.1.0" }
+solana-bls12-381-syscall = "0.1.1"
 solana-bn254 = { path = "bn254", version = "3.0.0" }
 solana-borsh = { path = "borsh", version = "3.0.0" }
 solana-client-traits = { path = "client-traits", version = "4.1.0" }

--- a/bls12-381/Cargo.toml
+++ b/bls12-381/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "solana-bls12-381"
+description = "Solana BLS12-381"
+documentation = "https://docs.rs/solana-bls12-381"
+version = "0.1.0"
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+include = ["src/**/*"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[dependencies]
+bytemuck = { workspace = true, features = ["derive", "min_const_generics"] }
+solana-define-syscall = { workspace = true }
+thiserror = { workspace = true }
+
+[target.'cfg(not(target_os = "solana"))'.dependencies]
+solana-bls12-381-syscall = { workspace = true }
+
+[target.'cfg(target_os = "solana")'.dependencies]
+solana-define-syscall = { workspace = true }
+
+[dev-dependencies]
+array-bytes = { workspace = true }
+
+[lints]
+workspace = true

--- a/bls12-381/Cargo.toml
+++ b/bls12-381/Cargo.toml
@@ -17,8 +17,6 @@ rustdoc-args = ["--cfg=docsrs"]
 
 [dependencies]
 bytemuck = { workspace = true, features = ["derive", "min_const_generics"] }
-solana-define-syscall = { workspace = true }
-thiserror = { workspace = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 solana-bls12-381-syscall = { workspace = true }

--- a/bls12-381/Cargo.toml
+++ b/bls12-381/Cargo.toml
@@ -25,6 +25,7 @@ bytemuck_derive = { workspace = true, optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 bytemuck = { workspace = true, features = ["min_const_generics"] }
+bytemuck_derive = { workspace = true }
 solana-bls12-381-syscall = { workspace = true }
 
 [target.'cfg(target_os = "solana")'.dependencies]

--- a/bls12-381/Cargo.toml
+++ b/bls12-381/Cargo.toml
@@ -23,13 +23,13 @@ bytemuck = ["dep:bytemuck", "dep:bytemuck_derive"]
 bytemuck = { workspace = true, features = ["min_const_generics"], optional = true }
 bytemuck_derive = { workspace = true, optional = true }
 
-[target.'cfg(not(target_os = "solana"))'.dependencies]
+[target.'cfg(any(target_os = "solana", target_arch = "bpf"))'.dependencies]
+solana-define-syscall = { workspace = true }
+
+[target.'cfg(not(any(target_os = "solana", target_arch = "bpf")))'.dependencies]
 bytemuck = { workspace = true, features = ["min_const_generics"] }
 bytemuck_derive = { workspace = true }
 solana-bls12-381-syscall = { workspace = true }
-
-[target.'cfg(target_os = "solana")'.dependencies]
-solana-define-syscall = { workspace = true }
 
 [dev-dependencies]
 array-bytes = { workspace = true }

--- a/bls12-381/Cargo.toml
+++ b/bls12-381/Cargo.toml
@@ -15,10 +15,16 @@ targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
+[features]
+default = ["bytemuck"]
+bytemuck = ["dep:bytemuck", "dep:bytemuck_derive"]
+
 [dependencies]
-bytemuck = { workspace = true, features = ["derive", "min_const_generics"] }
+bytemuck = { workspace = true, features = ["min_const_generics"], optional = true }
+bytemuck_derive = { workspace = true, optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
+bytemuck = { workspace = true, features = ["min_const_generics"] }
 solana-bls12-381-syscall = { workspace = true }
 
 [target.'cfg(target_os = "solana")'.dependencies]
@@ -26,6 +32,7 @@ solana-define-syscall = { workspace = true }
 
 [dev-dependencies]
 array-bytes = { workspace = true }
+bytemuck = { workspace = true, features = ["min_const_generics"] }
 
 [lints]
 workspace = true

--- a/bls12-381/README.md
+++ b/bls12-381/README.md
@@ -14,10 +14,10 @@ verification and zero-knowledge proof (e.g., Groth16) validation.
   `bytemuck::Pod`. Developers can cast transaction instruction data directly
   into curve points without heap allocations.
 - **CU-Optimized Mutations:** Provides `_assign` variants for all group
-  operations (e.g., `add_assign`), allowing in-place memory mutations
-  to strictly control Compute Unit (CU) consumption.
-- **Safe & Unchecked APIs:** Exposes both fully validated group
-  operations and `_unchecked` variants that skip subgroup checks for cheaper
+  operations (e.g., `add_assign`), which write into a caller-supplied
+  `MaybeUninit` buffer to strictly control Compute Unit (CU) consumption.
+- **Validated & Unchecked APIs:** Group operations validate their operands by
+  default, with `_unchecked` variants that skip subgroup checks for cheaper
   point accumulation.
 - **Ergonomic Pairings:** Includes `pairing_check` for evaluating if the
   product of multiple pairings equals the identity element, avoiding costly
@@ -38,18 +38,51 @@ solana-bls12-381 = "0.1.0"
 
 ```rust
 use solana_bls12_381::{G1Point, Endianness};
+use core::mem::MaybeUninit;
 use bytemuck;
 
 // 1. Cast raw byte slices directly to G1Point references (Zero-Copy)
 let p1: &G1Point = bytemuck::cast_ref(raw_bytes_1);
 let p2: &G1Point = bytemuck::cast_ref(raw_bytes_2);
 
-// 2. Allocate output buffer
-let mut out = G1Point::infinity(Endianness::Little);
+// 2. Reserve an output buffer. It is never read before being written, so it
+//    does not need to be initialized.
+let mut out = MaybeUninit::uninit();
 
-// 3. Perform safe, in-place addition
+// 3. Perform validated, in-place addition
 let success = p1.add_assign(p2, &mut out, Endianness::Little);
 assert!(success);
+
+// SAFETY: `add_assign` returned `true`, so every byte of `out` was written.
+let sum = unsafe { out.assume_init() };
+```
+
+Every `_assign` method follows the same contract: on `true` the output buffer
+is fully initialized and may be `assume_init`ed; on `false` it is left
+untouched and must not be assumed initialized.
+
+To recycle buffers across a loop, keep the accumulator in a `MaybeUninit` and
+swap the two buffers each iteration:
+
+```rust
+use solana_bls12_381::{G1Point, Endianness};
+use core::mem::MaybeUninit;
+
+let e = Endianness::Little;
+let mut acc = MaybeUninit::new(G1Point::infinity(e));
+let mut scratch = MaybeUninit::uninit();
+
+for p in points {
+    // SAFETY: `acc` is initialized, by `new` above and by the swap below.
+    let lhs = unsafe { acc.assume_init_ref() };
+    if !lhs.add_assign_unchecked(p, &mut scratch, e) {
+        return Err(ProgramError::InvalidArgument);
+    }
+    core::mem::swap(&mut acc, &mut scratch);
+}
+
+// SAFETY: `acc` was initialized before the loop and stays initialized.
+let total = unsafe { acc.assume_init() };
 ```
 
 ### Multi-Pairing Check (e.g., BLS Signatures or ZK Proofs)
@@ -69,7 +102,7 @@ assert!(is_valid);
 
 ### Security & Validation
 
-All operations except the `_unchecked` variants
-inherently perform full point validation. This includes checking that the
-coordinates represent valid field elements, satisfy the curve equation, and
-exist within the correct prime-order subgroup.
+All group operations except the `_unchecked` variants, along with
+multiplication and decompression, inherently perform full point validation.
+This includes checking that the coordinates represent valid field elements,
+satisfy the curve equation, and exist within the correct prime-order subgroup.

--- a/bls12-381/README.md
+++ b/bls12-381/README.md
@@ -1,0 +1,75 @@
+# solana-bls12-381
+
+A Rust library for BLS12-381 elliptic curve operations
+on Solana, wrapping the native syscalls defined in
+[SIMD-0388](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0388-bls12-381-syscalls.md).
+
+This crate provides the standard interface for Solana program
+developers to perform pairing-based cryptography, such as BLS signature
+verification and zero-knowledge proof (e.g., Groth16) validation.
+
+## Features
+
+- **Zero-Copy Deserialization:** Types are `#[repr(transparent)]` and implement
+  `bytemuck::Pod`. Developers can cast transaction instruction data directly
+  into curve points without heap allocations.
+- **CU-Optimized Mutations:** Provides `_assign` variants for all group
+  operations (e.g., `checked_add_assign`), allowing in-place memory mutations
+  to strictly control Compute Unit (CU) consumption.
+- **Safe & Unchecked APIs:** Exposes both fully validated `checked_` group
+  operations and `_unchecked` variants that skip subgroup checks for cheaper
+  point accumulation.
+- **Ergonomic Pairings:** Includes `pairing_check` for evaluating if the
+  product of multiple pairings equals the identity element, avoiding costly
+  target group (`Gt`) allocations in ZK verifiers.
+- **Dual Endianness:** Full support for both Big-Endian (canonical Zcash/IETF
+  standard) and Little-Endian memory layouts.
+
+## Usage
+
+Add the following to your `Cargo.toml`:
+
+```toml
+[dependencies]
+solana-bls12-381 = "0.1.0"
+```
+
+### Zero-Copy Point Addition
+
+```rust
+use solana_bls12_381::{G1Point, Endianness};
+use bytemuck;
+
+// 1. Cast raw byte slices directly to G1Point references (Zero-Copy)
+let p1: &G1Point = bytemuck::cast_ref(raw_bytes_1);
+let p2: &G1Point = bytemuck::cast_ref(raw_bytes_2);
+
+// 2. Allocate output buffer
+let mut out = G1Point::infinity(Endianness::Little);
+
+// 3. Perform safe, in-place addition
+let success = p1.checked_add_assign(p2, &mut out, Endianness::Little);
+assert!(success);
+```
+
+### Multi-Pairing Check (e.g., BLS Signatures or ZK Proofs)
+
+```rust
+use solana_bls12_381::{G1Point, G2Point, pairing_check, Endianness};
+
+let g1_points: &[G1Point] = get_g1_batch();
+let g2_points: &[G2Point] = get_g2_batch();
+
+// Evaluates e(P_1, Q_1) * ... * e(P_n, Q_n) == 1
+let is_valid = pairing_check(g1_points, g2_points, Endianness::Big)
+    .expect("Pairing execution failed");
+
+assert!(is_valid);
+```
+
+### Security & Validation
+
+All `checked_` methods, multiplication operations, and decompression functions
+inherently perform full point validation. This includes checking that the
+coordinates represent valid field elements, satisfy the curve equation, and
+exist within the correct prime-order subgroup.

--- a/bls12-381/README.md
+++ b/bls12-381/README.md
@@ -34,6 +34,12 @@ Add the following to your `Cargo.toml`:
 solana-bls12-381 = "0.1.0"
 ```
 
+The `bytemuck` feature is enabled by default and provides the `Pod` and
+`Zeroable` implementations that make zero-copy casting possible. It can be
+turned off with `default-features = false` for on-chain builds that do not
+need them, but off-chain builds always include them, since the host
+implementation depends on them internally.
+
 ### Zero-Copy Point Addition
 
 ```rust

--- a/bls12-381/README.md
+++ b/bls12-381/README.md
@@ -14,9 +14,9 @@ verification and zero-knowledge proof (e.g., Groth16) validation.
   `bytemuck::Pod`. Developers can cast transaction instruction data directly
   into curve points without heap allocations.
 - **CU-Optimized Mutations:** Provides `_assign` variants for all group
-  operations (e.g., `checked_add_assign`), allowing in-place memory mutations
+  operations (e.g., `add_assign`), allowing in-place memory mutations
   to strictly control Compute Unit (CU) consumption.
-- **Safe & Unchecked APIs:** Exposes both fully validated `checked_` group
+- **Safe & Unchecked APIs:** Exposes both fully validated group
   operations and `_unchecked` variants that skip subgroup checks for cheaper
   point accumulation.
 - **Ergonomic Pairings:** Includes `pairing_check` for evaluating if the
@@ -48,7 +48,7 @@ let p2: &G1Point = bytemuck::cast_ref(raw_bytes_2);
 let mut out = G1Point::infinity(Endianness::Little);
 
 // 3. Perform safe, in-place addition
-let success = p1.checked_add_assign(p2, &mut out, Endianness::Little);
+let success = p1.add_assign(p2, &mut out, Endianness::Little);
 assert!(success);
 ```
 
@@ -69,7 +69,7 @@ assert!(is_valid);
 
 ### Security & Validation
 
-All `checked_` methods, multiplication operations, and decompression functions
+All operations except the `_unchecked` variants
 inherently perform full point validation. This includes checking that the
 coordinates represent valid field elements, satisfy the curve equation, and
 exist within the correct prime-order subgroup.

--- a/bls12-381/src/g1.rs
+++ b/bls12-381/src/g1.rs
@@ -1,4 +1,7 @@
-#[cfg(any(feature = "bytemuck", not(target_os = "solana")))]
+#[cfg(any(
+    feature = "bytemuck",
+    not(any(target_os = "solana", target_arch = "bpf"))
+))]
 use bytemuck_derive::{Pod, Zeroable};
 use {
     crate::{scalar::Scalar, Endianness},
@@ -15,7 +18,10 @@ pub const G1_UNCOMPRESSED_POINT_SIZE: usize = 96;
 /// Represents the `x` and `y` coordinates (96 bytes total).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    any(feature = "bytemuck", not(target_os = "solana")),
+    any(
+        feature = "bytemuck",
+        not(any(target_os = "solana", target_arch = "bpf"))
+    ),
     derive(Pod, Zeroable)
 )]
 #[repr(transparent)]
@@ -25,7 +31,10 @@ pub struct G1Point(pub [u8; G1_UNCOMPRESSED_POINT_SIZE]);
 /// Represents the `x` coordinate with control flags in the MSB (48 bytes).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    any(feature = "bytemuck", not(target_os = "solana")),
+    any(
+        feature = "bytemuck",
+        not(any(target_os = "solana", target_arch = "bpf"))
+    ),
     derive(Pod, Zeroable)
 )]
 #[repr(transparent)]
@@ -75,7 +84,7 @@ impl G1Point {
         out: &mut MaybeUninit<Self>,
         endianness: Endianness,
     ) -> bool {
-        #[cfg(target_os = "solana")]
+        #[cfg(any(target_os = "solana", target_arch = "bpf"))]
         {
             let curve_id = match endianness {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G1_LE,
@@ -97,7 +106,7 @@ impl G1Point {
             status == 0
         }
 
-        #[cfg(not(target_os = "solana"))]
+        #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
         {
             let left_pod: &solana_bls12_381_syscall::PodG1Point = bytemuck::cast_ref(&self.0);
             let right_pod: &solana_bls12_381_syscall::PodG1Point = bytemuck::cast_ref(&other.0);
@@ -178,7 +187,7 @@ impl G1Point {
         out: &mut MaybeUninit<Self>,
         endianness: Endianness,
     ) -> bool {
-        #[cfg(target_os = "solana")]
+        #[cfg(any(target_os = "solana", target_arch = "bpf"))]
         {
             let curve_id = match endianness {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G1_LE,
@@ -200,7 +209,7 @@ impl G1Point {
             status == 0
         }
 
-        #[cfg(not(target_os = "solana"))]
+        #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
         {
             let left_pod: &solana_bls12_381_syscall::PodG1Point = bytemuck::cast_ref(&self.0);
             let right_pod: &solana_bls12_381_syscall::PodG1Point = bytemuck::cast_ref(&other.0);
@@ -281,7 +290,7 @@ impl G1Point {
         out: &mut MaybeUninit<Self>,
         endianness: Endianness,
     ) -> bool {
-        #[cfg(target_os = "solana")]
+        #[cfg(any(target_os = "solana", target_arch = "bpf"))]
         {
             let curve_id = match endianness {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G1_LE,
@@ -303,7 +312,7 @@ impl G1Point {
             status == 0
         }
 
-        #[cfg(not(target_os = "solana"))]
+        #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
         {
             let point_pod: &solana_bls12_381_syscall::PodG1Point = bytemuck::cast_ref(&self.0);
             let scalar_pod: &solana_bls12_381_syscall::PodScalar = bytemuck::cast_ref(&scalar.0);
@@ -343,7 +352,7 @@ impl G1Point {
     /// Checks that coordinates represent a valid field element, satisfy the
     /// curve equation, and exist within the prime-order subgroup.
     pub fn validate(&self, endianness: Endianness) -> bool {
-        #[cfg(target_os = "solana")]
+        #[cfg(any(target_os = "solana", target_arch = "bpf"))]
         {
             let curve_id = match endianness {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G1_LE,
@@ -360,7 +369,7 @@ impl G1Point {
             status == 0
         }
 
-        #[cfg(not(target_os = "solana"))]
+        #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
         {
             let point_pod: &solana_bls12_381_syscall::PodG1Point = bytemuck::cast_ref(&self.0);
 
@@ -400,7 +409,7 @@ impl G1Compressed {
         out: &mut MaybeUninit<G1Point>,
         endianness: Endianness,
     ) -> bool {
-        #[cfg(target_os = "solana")]
+        #[cfg(any(target_os = "solana", target_arch = "bpf"))]
         {
             let curve_id = match endianness {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G1_LE,
@@ -420,7 +429,7 @@ impl G1Compressed {
             status == 0
         }
 
-        #[cfg(not(target_os = "solana"))]
+        #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
         {
             let pod: &solana_bls12_381_syscall::PodG1Compressed = bytemuck::cast_ref(&self.0);
 

--- a/bls12-381/src/g1.rs
+++ b/bls12-381/src/g1.rs
@@ -56,10 +56,14 @@ impl G1Point {
     ///
     /// WARNING: This operation skips the prime-order subgroup check
     /// for performance. Only use this if inputs are known to be valid.
+    ///
+    /// Returns `true` if and only if every byte of `out` was written, in
+    /// which case the caller may `assume_init` it. On `false`, `out` is
+    /// left untouched and must not be assumed initialized.
     pub fn add_assign_unchecked(
         &self,
         other: &Self,
-        out: &mut Self,
+        out: &mut MaybeUninit<Self>,
         endianness: Endianness,
     ) -> bool {
         #[cfg(target_os = "solana")]
@@ -68,13 +72,17 @@ impl G1Point {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G1_LE,
                 Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G1_BE,
             };
+            // SAFETY: the input pointers are valid for reads of their
+            // respective sizes and `out` is valid for writes of
+            // `G1_UNCOMPRESSED_POINT_SIZE` bytes. Per SIMD-0388 the syscall writes
+            // the full output buffer whenever it returns 0.
             let status = unsafe {
                 solana_define_syscall::definitions::sol_curve_group_op(
                     curve_id,
                     solana_define_syscall::curve_constants::GROUP_OP_ADD,
                     self.0.as_ptr(),
                     other.0.as_ptr(),
-                    out.0.as_mut_ptr(),
+                    out.as_mut_ptr().cast::<u8>(),
                 )
             };
             status == 0
@@ -96,7 +104,7 @@ impl G1Point {
                 right_pod,
                 end,
             ) {
-                out.0.copy_from_slice(&res.0);
+                out.write(Self(res.0));
                 true
             } else {
                 false
@@ -107,12 +115,11 @@ impl G1Point {
     /// Point addition returning a new allocated point.
     /// Skips subgroup checks.
     pub fn add_unchecked(&self, other: &Self, endianness: Endianness) -> Option<Self> {
-        let mut result = MaybeUninit::<Self>::uninit();
-        let success =
-            self.add_assign_unchecked(other, unsafe { result.assume_init_mut() }, endianness);
-
-        if success {
-            Some(unsafe { result.assume_init() })
+        let mut out = MaybeUninit::uninit();
+        if self.add_assign_unchecked(other, &mut out, endianness) {
+            // SAFETY: `add_assign_unchecked` returned `true`, so every byte of
+            // `out` has been written.
+            Some(unsafe { out.assume_init() })
         } else {
             None
         }
@@ -120,7 +127,16 @@ impl G1Point {
 
     /// Safe in-place point addition.
     /// Validates both operands (field, curve, subgroup) prior to addition.
-    pub fn add_assign(&self, other: &Self, out: &mut Self, endianness: Endianness) -> bool {
+    ///
+    /// Returns `true` if and only if every byte of `out` was written, in
+    /// which case the caller may `assume_init` it. On `false`, `out` is
+    /// left untouched and must not be assumed initialized.
+    pub fn add_assign(
+        &self,
+        other: &Self,
+        out: &mut MaybeUninit<Self>,
+        endianness: Endianness,
+    ) -> bool {
         if !self.validate(endianness) || !other.validate(endianness) {
             return false;
         }
@@ -129,11 +145,11 @@ impl G1Point {
 
     /// Safe point addition returning a new allocated point.
     pub fn add(&self, other: &Self, endianness: Endianness) -> Option<Self> {
-        let mut result = MaybeUninit::<Self>::uninit();
-        let success = self.add_assign(other, unsafe { result.assume_init_mut() }, endianness);
-
-        if success {
-            Some(unsafe { result.assume_init() })
+        let mut out = MaybeUninit::uninit();
+        if self.add_assign(other, &mut out, endianness) {
+            // SAFETY: `add_assign` returned `true`, so every byte of
+            // `out` has been written.
+            Some(unsafe { out.assume_init() })
         } else {
             None
         }
@@ -143,10 +159,14 @@ impl G1Point {
     ///
     /// WARNING: This operation skips the prime-order subgroup check
     /// for performance. Only use this if inputs are known to be valid.
+    ///
+    /// Returns `true` if and only if every byte of `out` was written, in
+    /// which case the caller may `assume_init` it. On `false`, `out` is
+    /// left untouched and must not be assumed initialized.
     pub fn sub_assign_unchecked(
         &self,
         other: &Self,
-        out: &mut Self,
+        out: &mut MaybeUninit<Self>,
         endianness: Endianness,
     ) -> bool {
         #[cfg(target_os = "solana")]
@@ -155,13 +175,17 @@ impl G1Point {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G1_LE,
                 Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G1_BE,
             };
+            // SAFETY: the input pointers are valid for reads of their
+            // respective sizes and `out` is valid for writes of
+            // `G1_UNCOMPRESSED_POINT_SIZE` bytes. Per SIMD-0388 the syscall writes
+            // the full output buffer whenever it returns 0.
             let status = unsafe {
                 solana_define_syscall::definitions::sol_curve_group_op(
                     curve_id,
                     solana_define_syscall::curve_constants::GROUP_OP_SUB,
                     self.0.as_ptr(),
                     other.0.as_ptr(),
-                    out.0.as_mut_ptr(),
+                    out.as_mut_ptr().cast::<u8>(),
                 )
             };
             status == 0
@@ -183,7 +207,7 @@ impl G1Point {
                 right_pod,
                 end,
             ) {
-                out.0.copy_from_slice(&res.0);
+                out.write(Self(res.0));
                 true
             } else {
                 false
@@ -194,12 +218,11 @@ impl G1Point {
     /// Point subtraction returning a new allocated point.
     /// Skips subgroup checks.
     pub fn sub_unchecked(&self, other: &Self, endianness: Endianness) -> Option<Self> {
-        let mut result = MaybeUninit::<Self>::uninit();
-        let success =
-            self.sub_assign_unchecked(other, unsafe { result.assume_init_mut() }, endianness);
-
-        if success {
-            Some(unsafe { result.assume_init() })
+        let mut out = MaybeUninit::uninit();
+        if self.sub_assign_unchecked(other, &mut out, endianness) {
+            // SAFETY: `sub_assign_unchecked` returned `true`, so every byte of
+            // `out` has been written.
+            Some(unsafe { out.assume_init() })
         } else {
             None
         }
@@ -207,7 +230,16 @@ impl G1Point {
 
     /// Safe in-place point subtraction.
     /// Validates both operands prior to subtraction.
-    pub fn sub_assign(&self, other: &Self, out: &mut Self, endianness: Endianness) -> bool {
+    ///
+    /// Returns `true` if and only if every byte of `out` was written, in
+    /// which case the caller may `assume_init` it. On `false`, `out` is
+    /// left untouched and must not be assumed initialized.
+    pub fn sub_assign(
+        &self,
+        other: &Self,
+        out: &mut MaybeUninit<Self>,
+        endianness: Endianness,
+    ) -> bool {
         if !self.validate(endianness) || !other.validate(endianness) {
             return false;
         }
@@ -216,11 +248,11 @@ impl G1Point {
 
     /// Safe point subtraction returning a new allocated point.
     pub fn sub(&self, other: &Self, endianness: Endianness) -> Option<Self> {
-        let mut result = MaybeUninit::<Self>::uninit();
-        let success = self.sub_assign(other, unsafe { result.assume_init_mut() }, endianness);
-
-        if success {
-            Some(unsafe { result.assume_init() })
+        let mut out = MaybeUninit::uninit();
+        if self.sub_assign(other, &mut out, endianness) {
+            // SAFETY: `sub_assign` returned `true`, so every byte of
+            // `out` has been written.
+            Some(unsafe { out.assume_init() })
         } else {
             None
         }
@@ -230,20 +262,33 @@ impl G1Point {
     ///
     /// Note: The underlying syscall inherently performs full validation
     /// (field, curve, and subgroup checks) on the input point.
-    pub fn mul_assign(&self, scalar: &Scalar, out: &mut Self, endianness: Endianness) -> bool {
+    ///
+    /// Returns `true` if and only if every byte of `out` was written, in
+    /// which case the caller may `assume_init` it. On `false`, `out` is
+    /// left untouched and must not be assumed initialized.
+    pub fn mul_assign(
+        &self,
+        scalar: &Scalar,
+        out: &mut MaybeUninit<Self>,
+        endianness: Endianness,
+    ) -> bool {
         #[cfg(target_os = "solana")]
         {
             let curve_id = match endianness {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G1_LE,
                 Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G1_BE,
             };
+            // SAFETY: the input pointers are valid for reads of their
+            // respective sizes and `out` is valid for writes of
+            // `G1_UNCOMPRESSED_POINT_SIZE` bytes. Per SIMD-0388 the syscall writes
+            // the full output buffer whenever it returns 0.
             let status = unsafe {
                 solana_define_syscall::definitions::sol_curve_group_op(
                     curve_id,
                     solana_define_syscall::curve_constants::GROUP_OP_MUL,
                     scalar.0.as_ptr(),
                     self.0.as_ptr(),
-                    out.0.as_mut_ptr(),
+                    out.as_mut_ptr().cast::<u8>(),
                 )
             };
             status == 0
@@ -265,7 +310,7 @@ impl G1Point {
                 scalar_pod,
                 end,
             ) {
-                out.0.copy_from_slice(&res.0);
+                out.write(Self(res.0));
                 true
             } else {
                 false
@@ -275,11 +320,11 @@ impl G1Point {
 
     /// Scalar multiplication returning a new allocated point.
     pub fn mul(&self, scalar: &Scalar, endianness: Endianness) -> Option<Self> {
-        let mut result = MaybeUninit::<Self>::uninit();
-        let success = self.mul_assign(scalar, unsafe { result.assume_init_mut() }, endianness);
-
-        if success {
-            Some(unsafe { result.assume_init() })
+        let mut out = MaybeUninit::uninit();
+        if self.mul_assign(scalar, &mut out, endianness) {
+            // SAFETY: `mul_assign` returned `true`, so every byte of
+            // `out` has been written.
+            Some(unsafe { out.assume_init() })
         } else {
             None
         }
@@ -337,18 +382,30 @@ impl G1Compressed {
 
     /// In-place decompression into an uncompressed affine point.
     /// Inherently performs format, field, curve, and subgroup validation.
-    pub fn decompress_assign(&self, out: &mut G1Point, endianness: Endianness) -> bool {
+    ///
+    /// Returns `true` if and only if every byte of `out` was written, in
+    /// which case the caller may `assume_init` it. On `false`, `out` is
+    /// left untouched and must not be assumed initialized.
+    pub fn decompress_assign(
+        &self,
+        out: &mut MaybeUninit<G1Point>,
+        endianness: Endianness,
+    ) -> bool {
         #[cfg(target_os = "solana")]
         {
             let curve_id = match endianness {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G1_LE,
                 Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G1_BE,
             };
+            // SAFETY: `self.0` is valid for reads of its size and `out`
+            // is valid for writes of `G1_UNCOMPRESSED_POINT_SIZE` bytes. Per
+            // SIMD-0388 the syscall writes the full output buffer
+            // whenever it returns 0.
             let status = unsafe {
                 solana_define_syscall::definitions::sol_curve_decompress(
                     curve_id,
                     self.0.as_ptr(),
-                    out.0.as_mut_ptr(),
+                    out.as_mut_ptr().cast::<u8>(),
                 )
             };
             status == 0
@@ -368,7 +425,7 @@ impl G1Compressed {
                 pod,
                 end,
             ) {
-                out.0.copy_from_slice(&res.0);
+                out.write(G1Point(res.0));
                 true
             } else {
                 false
@@ -378,11 +435,11 @@ impl G1Compressed {
 
     /// Decompresses into a new allocated affine point.
     pub fn decompress(&self, endianness: Endianness) -> Option<G1Point> {
-        let mut result = MaybeUninit::<G1Point>::uninit();
-        let success = self.decompress_assign(unsafe { result.assume_init_mut() }, endianness);
-
-        if success {
-            Some(unsafe { result.assume_init() })
+        let mut out = MaybeUninit::uninit();
+        if self.decompress_assign(&mut out, endianness) {
+            // SAFETY: `decompress_assign` returned `true`, so every byte of
+            // `out` has been written.
+            Some(unsafe { out.assume_init() })
         } else {
             None
         }

--- a/bls12-381/src/g1.rs
+++ b/bls12-381/src/g1.rs
@@ -49,14 +49,14 @@ impl G1Point {
 
     /// Safely negates the point by subtracting it from infinity.
     pub fn neg(&self, endianness: Endianness) -> Option<Self> {
-        Self::infinity(endianness).checked_sub(self, endianness)
+        Self::infinity(endianness).sub(self, endianness)
     }
 
     /// In-place point addition.
     ///
     /// WARNING: This operation skips the prime-order subgroup check
     /// for performance. Only use this if inputs are known to be valid.
-    pub fn add_unchecked_assign(
+    pub fn add_assign_unchecked(
         &self,
         other: &Self,
         out: &mut Self,
@@ -109,7 +109,7 @@ impl G1Point {
     pub fn add_unchecked(&self, other: &Self, endianness: Endianness) -> Option<Self> {
         let mut result = MaybeUninit::<Self>::uninit();
         let success =
-            self.add_unchecked_assign(other, unsafe { result.assume_init_mut() }, endianness);
+            self.add_assign_unchecked(other, unsafe { result.assume_init_mut() }, endianness);
 
         if success {
             Some(unsafe { result.assume_init() })
@@ -120,18 +120,17 @@ impl G1Point {
 
     /// Safe in-place point addition.
     /// Validates both operands (field, curve, subgroup) prior to addition.
-    pub fn checked_add_assign(&self, other: &Self, out: &mut Self, endianness: Endianness) -> bool {
+    pub fn add_assign(&self, other: &Self, out: &mut Self, endianness: Endianness) -> bool {
         if !self.validate(endianness) || !other.validate(endianness) {
             return false;
         }
-        self.add_unchecked_assign(other, out, endianness)
+        self.add_assign_unchecked(other, out, endianness)
     }
 
     /// Safe point addition returning a new allocated point.
-    pub fn checked_add(&self, other: &Self, endianness: Endianness) -> Option<Self> {
+    pub fn add(&self, other: &Self, endianness: Endianness) -> Option<Self> {
         let mut result = MaybeUninit::<Self>::uninit();
-        let success =
-            self.checked_add_assign(other, unsafe { result.assume_init_mut() }, endianness);
+        let success = self.add_assign(other, unsafe { result.assume_init_mut() }, endianness);
 
         if success {
             Some(unsafe { result.assume_init() })
@@ -144,7 +143,7 @@ impl G1Point {
     ///
     /// WARNING: This operation skips the prime-order subgroup check
     /// for performance. Only use this if inputs are known to be valid.
-    pub fn sub_unchecked_assign(
+    pub fn sub_assign_unchecked(
         &self,
         other: &Self,
         out: &mut Self,
@@ -197,7 +196,7 @@ impl G1Point {
     pub fn sub_unchecked(&self, other: &Self, endianness: Endianness) -> Option<Self> {
         let mut result = MaybeUninit::<Self>::uninit();
         let success =
-            self.sub_unchecked_assign(other, unsafe { result.assume_init_mut() }, endianness);
+            self.sub_assign_unchecked(other, unsafe { result.assume_init_mut() }, endianness);
 
         if success {
             Some(unsafe { result.assume_init() })
@@ -208,18 +207,17 @@ impl G1Point {
 
     /// Safe in-place point subtraction.
     /// Validates both operands prior to subtraction.
-    pub fn checked_sub_assign(&self, other: &Self, out: &mut Self, endianness: Endianness) -> bool {
+    pub fn sub_assign(&self, other: &Self, out: &mut Self, endianness: Endianness) -> bool {
         if !self.validate(endianness) || !other.validate(endianness) {
             return false;
         }
-        self.sub_unchecked_assign(other, out, endianness)
+        self.sub_assign_unchecked(other, out, endianness)
     }
 
     /// Safe point subtraction returning a new allocated point.
-    pub fn checked_sub(&self, other: &Self, endianness: Endianness) -> Option<Self> {
+    pub fn sub(&self, other: &Self, endianness: Endianness) -> Option<Self> {
         let mut result = MaybeUninit::<Self>::uninit();
-        let success =
-            self.checked_sub_assign(other, unsafe { result.assume_init_mut() }, endianness);
+        let success = self.sub_assign(other, unsafe { result.assume_init_mut() }, endianness);
 
         if success {
             Some(unsafe { result.assume_init() })

--- a/bls12-381/src/g1.rs
+++ b/bls12-381/src/g1.rs
@@ -1,0 +1,392 @@
+use {
+    crate::{scalar::Scalar, Endianness},
+    bytemuck::{Pod, Zeroable},
+    core::mem::MaybeUninit,
+};
+
+/// Size of a compressed BLS12-381 G1 point in bytes.
+pub const G1_COMPRESSED_POINT_SIZE: usize = 48;
+
+/// Size of an uncompressed BLS12-381 G1 affine point in bytes.
+pub const G1_UNCOMPRESSED_POINT_SIZE: usize = 96;
+
+/// Uncompressed BLS12-381 G1 affine point.
+/// Represents the `x` and `y` coordinates (96 bytes total).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct G1Point(pub [u8; G1_UNCOMPRESSED_POINT_SIZE]);
+
+/// Compressed BLS12-381 G1 point.
+/// Represents the `x` coordinate with control flags in the MSB (48 bytes).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct G1Compressed(pub [u8; G1_COMPRESSED_POINT_SIZE]);
+
+impl G1Point {
+    /// Returns the identity (infinity) element for the given endianness.
+    pub const fn infinity(endianness: Endianness) -> Self {
+        let mut bytes = [0u8; G1_UNCOMPRESSED_POINT_SIZE];
+        match endianness {
+            // Zcash standard sets the infinity flag on the highest byte.
+            Endianness::Big => bytes[0] = 0x40,
+            Endianness::Little => bytes[47] = 0x40,
+        }
+        Self(bytes)
+    }
+
+    /// Constructs a point from a byte array via a memory copy.
+    ///
+    /// Note: For zero-copy deserialization from instruction data, use
+    /// `bytemuck::cast_ref` directly on the byte slice.
+    pub const fn from_bytes(bytes: [u8; G1_UNCOMPRESSED_POINT_SIZE]) -> Self {
+        Self(bytes)
+    }
+
+    /// Returns the underlying byte array via a memory copy.
+    pub const fn to_bytes(&self) -> [u8; G1_UNCOMPRESSED_POINT_SIZE] {
+        self.0
+    }
+
+    /// Safely negates the point by subtracting it from infinity.
+    pub fn neg(&self, endianness: Endianness) -> Option<Self> {
+        Self::infinity(endianness).checked_sub(self, endianness)
+    }
+
+    /// In-place point addition.
+    ///
+    /// WARNING: This operation skips the prime-order subgroup check
+    /// for performance. Only use this if inputs are known to be valid.
+    pub fn add_unchecked_assign(
+        &self,
+        other: &Self,
+        out: &mut Self,
+        endianness: Endianness,
+    ) -> bool {
+        #[cfg(target_os = "solana")]
+        {
+            let curve_id = match endianness {
+                Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G1_LE,
+                Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G1_BE,
+            };
+            let status = unsafe {
+                solana_define_syscall::definitions::sol_curve_group_op(
+                    curve_id,
+                    solana_define_syscall::curve_constants::GROUP_OP_ADD,
+                    self.0.as_ptr(),
+                    other.0.as_ptr(),
+                    out.0.as_mut_ptr(),
+                )
+            };
+            status == 0
+        }
+
+        #[cfg(not(target_os = "solana"))]
+        {
+            let left_pod: &solana_bls12_381_syscall::PodG1Point = bytemuck::cast_ref(&self.0);
+            let right_pod: &solana_bls12_381_syscall::PodG1Point = bytemuck::cast_ref(&other.0);
+
+            let end = match endianness {
+                Endianness::Little => solana_bls12_381_syscall::Endianness::LE,
+                Endianness::Big => solana_bls12_381_syscall::Endianness::BE,
+            };
+
+            if let Some(res) = solana_bls12_381_syscall::bls12_381_g1_addition_unchecked(
+                solana_bls12_381_syscall::Version::V0,
+                left_pod,
+                right_pod,
+                end,
+            ) {
+                out.0.copy_from_slice(&res.0);
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    /// Point addition returning a new allocated point.
+    /// Skips subgroup checks.
+    pub fn add_unchecked(&self, other: &Self, endianness: Endianness) -> Option<Self> {
+        let mut result = MaybeUninit::<Self>::uninit();
+        let success =
+            self.add_unchecked_assign(other, unsafe { result.assume_init_mut() }, endianness);
+
+        if success {
+            Some(unsafe { result.assume_init() })
+        } else {
+            None
+        }
+    }
+
+    /// Safe in-place point addition.
+    /// Validates both operands (field, curve, subgroup) prior to addition.
+    pub fn checked_add_assign(&self, other: &Self, out: &mut Self, endianness: Endianness) -> bool {
+        if !self.validate(endianness) || !other.validate(endianness) {
+            return false;
+        }
+        self.add_unchecked_assign(other, out, endianness)
+    }
+
+    /// Safe point addition returning a new allocated point.
+    pub fn checked_add(&self, other: &Self, endianness: Endianness) -> Option<Self> {
+        let mut result = MaybeUninit::<Self>::uninit();
+        let success =
+            self.checked_add_assign(other, unsafe { result.assume_init_mut() }, endianness);
+
+        if success {
+            Some(unsafe { result.assume_init() })
+        } else {
+            None
+        }
+    }
+
+    /// In-place point subtraction.
+    ///
+    /// WARNING: This operation skips the prime-order subgroup check
+    /// for performance. Only use this if inputs are known to be valid.
+    pub fn sub_unchecked_assign(
+        &self,
+        other: &Self,
+        out: &mut Self,
+        endianness: Endianness,
+    ) -> bool {
+        #[cfg(target_os = "solana")]
+        {
+            let curve_id = match endianness {
+                Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G1_LE,
+                Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G1_BE,
+            };
+            let status = unsafe {
+                solana_define_syscall::definitions::sol_curve_group_op(
+                    curve_id,
+                    solana_define_syscall::curve_constants::GROUP_OP_SUB,
+                    self.0.as_ptr(),
+                    other.0.as_ptr(),
+                    out.0.as_mut_ptr(),
+                )
+            };
+            status == 0
+        }
+
+        #[cfg(not(target_os = "solana"))]
+        {
+            let left_pod: &solana_bls12_381_syscall::PodG1Point = bytemuck::cast_ref(&self.0);
+            let right_pod: &solana_bls12_381_syscall::PodG1Point = bytemuck::cast_ref(&other.0);
+
+            let end = match endianness {
+                Endianness::Little => solana_bls12_381_syscall::Endianness::LE,
+                Endianness::Big => solana_bls12_381_syscall::Endianness::BE,
+            };
+
+            if let Some(res) = solana_bls12_381_syscall::bls12_381_g1_subtraction_unchecked(
+                solana_bls12_381_syscall::Version::V0,
+                left_pod,
+                right_pod,
+                end,
+            ) {
+                out.0.copy_from_slice(&res.0);
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    /// Point subtraction returning a new allocated point.
+    /// Skips subgroup checks.
+    pub fn sub_unchecked(&self, other: &Self, endianness: Endianness) -> Option<Self> {
+        let mut result = MaybeUninit::<Self>::uninit();
+        let success =
+            self.sub_unchecked_assign(other, unsafe { result.assume_init_mut() }, endianness);
+
+        if success {
+            Some(unsafe { result.assume_init() })
+        } else {
+            None
+        }
+    }
+
+    /// Safe in-place point subtraction.
+    /// Validates both operands prior to subtraction.
+    pub fn checked_sub_assign(&self, other: &Self, out: &mut Self, endianness: Endianness) -> bool {
+        if !self.validate(endianness) || !other.validate(endianness) {
+            return false;
+        }
+        self.sub_unchecked_assign(other, out, endianness)
+    }
+
+    /// Safe point subtraction returning a new allocated point.
+    pub fn checked_sub(&self, other: &Self, endianness: Endianness) -> Option<Self> {
+        let mut result = MaybeUninit::<Self>::uninit();
+        let success =
+            self.checked_sub_assign(other, unsafe { result.assume_init_mut() }, endianness);
+
+        if success {
+            Some(unsafe { result.assume_init() })
+        } else {
+            None
+        }
+    }
+
+    /// In-place scalar multiplication.
+    ///
+    /// Note: The underlying syscall inherently performs full validation
+    /// (field, curve, and subgroup checks) on the input point.
+    pub fn mul_assign(&self, scalar: &Scalar, out: &mut Self, endianness: Endianness) -> bool {
+        #[cfg(target_os = "solana")]
+        {
+            let curve_id = match endianness {
+                Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G1_LE,
+                Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G1_BE,
+            };
+            let status = unsafe {
+                solana_define_syscall::definitions::sol_curve_group_op(
+                    curve_id,
+                    solana_define_syscall::curve_constants::GROUP_OP_MUL,
+                    scalar.0.as_ptr(),
+                    self.0.as_ptr(),
+                    out.0.as_mut_ptr(),
+                )
+            };
+            status == 0
+        }
+
+        #[cfg(not(target_os = "solana"))]
+        {
+            let point_pod: &solana_bls12_381_syscall::PodG1Point = bytemuck::cast_ref(&self.0);
+            let scalar_pod: &solana_bls12_381_syscall::PodScalar = bytemuck::cast_ref(&scalar.0);
+
+            let end = match endianness {
+                Endianness::Little => solana_bls12_381_syscall::Endianness::LE,
+                Endianness::Big => solana_bls12_381_syscall::Endianness::BE,
+            };
+
+            if let Some(res) = solana_bls12_381_syscall::bls12_381_g1_multiplication(
+                solana_bls12_381_syscall::Version::V0,
+                point_pod,
+                scalar_pod,
+                end,
+            ) {
+                out.0.copy_from_slice(&res.0);
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    /// Scalar multiplication returning a new allocated point.
+    pub fn mul(&self, scalar: &Scalar, endianness: Endianness) -> Option<Self> {
+        let mut result = MaybeUninit::<Self>::uninit();
+        let success = self.mul_assign(scalar, unsafe { result.assume_init_mut() }, endianness);
+
+        if success {
+            Some(unsafe { result.assume_init() })
+        } else {
+            None
+        }
+    }
+
+    /// Full point validation.
+    /// Checks that coordinates represent a valid field element, satisfy the
+    /// curve equation, and exist within the prime-order subgroup.
+    pub fn validate(&self, endianness: Endianness) -> bool {
+        #[cfg(target_os = "solana")]
+        {
+            let curve_id = match endianness {
+                Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G1_LE,
+                Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G1_BE,
+            };
+            let mut dummy = [0u8; 1];
+            let status = unsafe {
+                solana_define_syscall::definitions::sol_curve_validate_point(
+                    curve_id,
+                    self.0.as_ptr(),
+                    dummy.as_mut_ptr(),
+                )
+            };
+            status == 0
+        }
+
+        #[cfg(not(target_os = "solana"))]
+        {
+            let point_pod: &solana_bls12_381_syscall::PodG1Point = bytemuck::cast_ref(&self.0);
+
+            let end = match endianness {
+                Endianness::Little => solana_bls12_381_syscall::Endianness::LE,
+                Endianness::Big => solana_bls12_381_syscall::Endianness::BE,
+            };
+
+            solana_bls12_381_syscall::bls12_381_g1_point_validation(
+                solana_bls12_381_syscall::Version::V0,
+                point_pod,
+                end,
+            )
+        }
+    }
+}
+
+impl G1Compressed {
+    /// Constructs a compressed point from a byte array via a memory copy.
+    pub const fn from_bytes(bytes: [u8; G1_COMPRESSED_POINT_SIZE]) -> Self {
+        Self(bytes)
+    }
+
+    /// Returns the underlying compressed byte array via a memory copy.
+    pub const fn to_bytes(&self) -> [u8; G1_COMPRESSED_POINT_SIZE] {
+        self.0
+    }
+
+    /// In-place decompression into an uncompressed affine point.
+    /// Inherently performs format, field, curve, and subgroup validation.
+    pub fn decompress_assign(&self, out: &mut G1Point, endianness: Endianness) -> bool {
+        #[cfg(target_os = "solana")]
+        {
+            let curve_id = match endianness {
+                Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G1_LE,
+                Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G1_BE,
+            };
+            let status = unsafe {
+                solana_define_syscall::definitions::sol_curve_decompress(
+                    curve_id,
+                    self.0.as_ptr(),
+                    out.0.as_mut_ptr(),
+                )
+            };
+            status == 0
+        }
+
+        #[cfg(not(target_os = "solana"))]
+        {
+            let pod: &solana_bls12_381_syscall::PodG1Compressed = bytemuck::cast_ref(&self.0);
+
+            let end = match endianness {
+                Endianness::Little => solana_bls12_381_syscall::Endianness::LE,
+                Endianness::Big => solana_bls12_381_syscall::Endianness::BE,
+            };
+
+            if let Some(res) = solana_bls12_381_syscall::bls12_381_g1_decompress(
+                solana_bls12_381_syscall::Version::V0,
+                pod,
+                end,
+            ) {
+                out.0.copy_from_slice(&res.0);
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    /// Decompresses into a new allocated affine point.
+    pub fn decompress(&self, endianness: Endianness) -> Option<G1Point> {
+        let mut result = MaybeUninit::<G1Point>::uninit();
+        let success = self.decompress_assign(unsafe { result.assume_init_mut() }, endianness);
+
+        if success {
+            Some(unsafe { result.assume_init() })
+        } else {
+            None
+        }
+    }
+}

--- a/bls12-381/src/g1.rs
+++ b/bls12-381/src/g1.rs
@@ -1,10 +1,9 @@
+#[cfg(any(feature = "bytemuck", not(target_os = "solana")))]
+use bytemuck_derive::{Pod, Zeroable};
 use {
     crate::{scalar::Scalar, Endianness},
     core::mem::MaybeUninit,
 };
-
-#[cfg(any(feature = "bytemuck", not(target_os = "solana")))]
-use bytemuck_derive::{Pod, Zeroable};
 
 /// Size of a compressed BLS12-381 G1 point in bytes.
 pub const G1_COMPRESSED_POINT_SIZE: usize = 48;

--- a/bls12-381/src/g1.rs
+++ b/bls12-381/src/g1.rs
@@ -1,8 +1,10 @@
 use {
     crate::{scalar::Scalar, Endianness},
-    bytemuck::{Pod, Zeroable},
     core::mem::MaybeUninit,
 };
+
+#[cfg(any(feature = "bytemuck", not(target_os = "solana")))]
+use bytemuck_derive::{Pod, Zeroable};
 
 /// Size of a compressed BLS12-381 G1 point in bytes.
 pub const G1_COMPRESSED_POINT_SIZE: usize = 48;
@@ -12,13 +14,21 @@ pub const G1_UNCOMPRESSED_POINT_SIZE: usize = 96;
 
 /// Uncompressed BLS12-381 G1 affine point.
 /// Represents the `x` and `y` coordinates (96 bytes total).
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Pod, Zeroable)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    any(feature = "bytemuck", not(target_os = "solana")),
+    derive(Pod, Zeroable)
+)]
 #[repr(transparent)]
 pub struct G1Point(pub [u8; G1_UNCOMPRESSED_POINT_SIZE]);
 
 /// Compressed BLS12-381 G1 point.
 /// Represents the `x` coordinate with control flags in the MSB (48 bytes).
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Pod, Zeroable)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    any(feature = "bytemuck", not(target_os = "solana")),
+    derive(Pod, Zeroable)
+)]
 #[repr(transparent)]
 pub struct G1Compressed(pub [u8; G1_COMPRESSED_POINT_SIZE]);
 

--- a/bls12-381/src/g2.rs
+++ b/bls12-381/src/g2.rs
@@ -1,10 +1,9 @@
+#[cfg(any(feature = "bytemuck", not(target_os = "solana")))]
+use bytemuck_derive::{Pod, Zeroable};
 use {
     crate::{scalar::Scalar, Endianness},
     core::mem::MaybeUninit,
 };
-
-#[cfg(any(feature = "bytemuck", not(target_os = "solana")))]
-use bytemuck_derive::{Pod, Zeroable};
 
 /// Size of a compressed BLS12-381 G2 point in bytes.
 pub const G2_COMPRESSED_POINT_SIZE: usize = 96;

--- a/bls12-381/src/g2.rs
+++ b/bls12-381/src/g2.rs
@@ -1,8 +1,10 @@
 use {
     crate::{scalar::Scalar, Endianness},
-    bytemuck::{Pod, Zeroable},
     core::mem::MaybeUninit,
 };
+
+#[cfg(any(feature = "bytemuck", not(target_os = "solana")))]
+use bytemuck_derive::{Pod, Zeroable};
 
 /// Size of a compressed BLS12-381 G2 point in bytes.
 pub const G2_COMPRESSED_POINT_SIZE: usize = 96;
@@ -12,13 +14,21 @@ pub const G2_UNCOMPRESSED_POINT_SIZE: usize = 192;
 
 /// Uncompressed BLS12-381 G2 affine point.
 /// Represents the `x` and `y` coordinates in the extension field (192 bytes).
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Pod, Zeroable)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    any(feature = "bytemuck", not(target_os = "solana")),
+    derive(Pod, Zeroable)
+)]
 #[repr(transparent)]
 pub struct G2Point(pub [u8; G2_UNCOMPRESSED_POINT_SIZE]);
 
 /// Compressed BLS12-381 G2 point.
 /// Represents the `x` coordinate with control flags in the MSB (96 bytes).
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Pod, Zeroable)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    any(feature = "bytemuck", not(target_os = "solana")),
+    derive(Pod, Zeroable)
+)]
 #[repr(transparent)]
 pub struct G2Compressed(pub [u8; G2_COMPRESSED_POINT_SIZE]);
 

--- a/bls12-381/src/g2.rs
+++ b/bls12-381/src/g2.rs
@@ -56,10 +56,14 @@ impl G2Point {
     ///
     /// WARNING: This operation skips the prime-order subgroup check
     /// for performance. Only use this if inputs are known to be valid.
+    ///
+    /// Returns `true` if and only if every byte of `out` was written, in
+    /// which case the caller may `assume_init` it. On `false`, `out` is
+    /// left untouched and must not be assumed initialized.
     pub fn add_assign_unchecked(
         &self,
         other: &Self,
-        out: &mut Self,
+        out: &mut MaybeUninit<Self>,
         endianness: Endianness,
     ) -> bool {
         #[cfg(target_os = "solana")]
@@ -68,13 +72,17 @@ impl G2Point {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G2_LE,
                 Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G2_BE,
             };
+            // SAFETY: the input pointers are valid for reads of their
+            // respective sizes and `out` is valid for writes of
+            // `G2_UNCOMPRESSED_POINT_SIZE` bytes. Per SIMD-0388 the syscall writes
+            // the full output buffer whenever it returns 0.
             let status = unsafe {
                 solana_define_syscall::definitions::sol_curve_group_op(
                     curve_id,
                     solana_define_syscall::curve_constants::GROUP_OP_ADD,
                     self.0.as_ptr(),
                     other.0.as_ptr(),
-                    out.0.as_mut_ptr(),
+                    out.as_mut_ptr().cast::<u8>(),
                 )
             };
             status == 0
@@ -96,7 +104,7 @@ impl G2Point {
                 right_pod,
                 end,
             ) {
-                out.0.copy_from_slice(&res.0);
+                out.write(Self(res.0));
                 true
             } else {
                 false
@@ -107,12 +115,11 @@ impl G2Point {
     /// Point addition returning a new allocated point.
     /// Skips subgroup checks.
     pub fn add_unchecked(&self, other: &Self, endianness: Endianness) -> Option<Self> {
-        let mut result = MaybeUninit::<Self>::uninit();
-        let success =
-            self.add_assign_unchecked(other, unsafe { result.assume_init_mut() }, endianness);
-
-        if success {
-            Some(unsafe { result.assume_init() })
+        let mut out = MaybeUninit::uninit();
+        if self.add_assign_unchecked(other, &mut out, endianness) {
+            // SAFETY: `add_assign_unchecked` returned `true`, so every byte of
+            // `out` has been written.
+            Some(unsafe { out.assume_init() })
         } else {
             None
         }
@@ -120,7 +127,16 @@ impl G2Point {
 
     /// Safe in-place point addition.
     /// Validates both operands (field, curve, subgroup) prior to addition.
-    pub fn add_assign(&self, other: &Self, out: &mut Self, endianness: Endianness) -> bool {
+    ///
+    /// Returns `true` if and only if every byte of `out` was written, in
+    /// which case the caller may `assume_init` it. On `false`, `out` is
+    /// left untouched and must not be assumed initialized.
+    pub fn add_assign(
+        &self,
+        other: &Self,
+        out: &mut MaybeUninit<Self>,
+        endianness: Endianness,
+    ) -> bool {
         if !self.validate(endianness) || !other.validate(endianness) {
             return false;
         }
@@ -129,11 +145,11 @@ impl G2Point {
 
     /// Safe point addition returning a new allocated point.
     pub fn add(&self, other: &Self, endianness: Endianness) -> Option<Self> {
-        let mut result = MaybeUninit::<Self>::uninit();
-        let success = self.add_assign(other, unsafe { result.assume_init_mut() }, endianness);
-
-        if success {
-            Some(unsafe { result.assume_init() })
+        let mut out = MaybeUninit::uninit();
+        if self.add_assign(other, &mut out, endianness) {
+            // SAFETY: `add_assign` returned `true`, so every byte of
+            // `out` has been written.
+            Some(unsafe { out.assume_init() })
         } else {
             None
         }
@@ -143,10 +159,14 @@ impl G2Point {
     ///
     /// WARNING: This operation skips the prime-order subgroup check
     /// for performance. Only use this if inputs are known to be valid.
+    ///
+    /// Returns `true` if and only if every byte of `out` was written, in
+    /// which case the caller may `assume_init` it. On `false`, `out` is
+    /// left untouched and must not be assumed initialized.
     pub fn sub_assign_unchecked(
         &self,
         other: &Self,
-        out: &mut Self,
+        out: &mut MaybeUninit<Self>,
         endianness: Endianness,
     ) -> bool {
         #[cfg(target_os = "solana")]
@@ -155,13 +175,17 @@ impl G2Point {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G2_LE,
                 Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G2_BE,
             };
+            // SAFETY: the input pointers are valid for reads of their
+            // respective sizes and `out` is valid for writes of
+            // `G2_UNCOMPRESSED_POINT_SIZE` bytes. Per SIMD-0388 the syscall writes
+            // the full output buffer whenever it returns 0.
             let status = unsafe {
                 solana_define_syscall::definitions::sol_curve_group_op(
                     curve_id,
                     solana_define_syscall::curve_constants::GROUP_OP_SUB,
                     self.0.as_ptr(),
                     other.0.as_ptr(),
-                    out.0.as_mut_ptr(),
+                    out.as_mut_ptr().cast::<u8>(),
                 )
             };
             status == 0
@@ -183,7 +207,7 @@ impl G2Point {
                 right_pod,
                 end,
             ) {
-                out.0.copy_from_slice(&res.0);
+                out.write(Self(res.0));
                 true
             } else {
                 false
@@ -194,12 +218,11 @@ impl G2Point {
     /// Point subtraction returning a new allocated point.
     /// Skips subgroup checks.
     pub fn sub_unchecked(&self, other: &Self, endianness: Endianness) -> Option<Self> {
-        let mut result = MaybeUninit::<Self>::uninit();
-        let success =
-            self.sub_assign_unchecked(other, unsafe { result.assume_init_mut() }, endianness);
-
-        if success {
-            Some(unsafe { result.assume_init() })
+        let mut out = MaybeUninit::uninit();
+        if self.sub_assign_unchecked(other, &mut out, endianness) {
+            // SAFETY: `sub_assign_unchecked` returned `true`, so every byte of
+            // `out` has been written.
+            Some(unsafe { out.assume_init() })
         } else {
             None
         }
@@ -207,7 +230,16 @@ impl G2Point {
 
     /// Safe in-place point subtraction.
     /// Validates both operands prior to subtraction.
-    pub fn sub_assign(&self, other: &Self, out: &mut Self, endianness: Endianness) -> bool {
+    ///
+    /// Returns `true` if and only if every byte of `out` was written, in
+    /// which case the caller may `assume_init` it. On `false`, `out` is
+    /// left untouched and must not be assumed initialized.
+    pub fn sub_assign(
+        &self,
+        other: &Self,
+        out: &mut MaybeUninit<Self>,
+        endianness: Endianness,
+    ) -> bool {
         if !self.validate(endianness) || !other.validate(endianness) {
             return false;
         }
@@ -216,11 +248,11 @@ impl G2Point {
 
     /// Safe point subtraction returning a new allocated point.
     pub fn sub(&self, other: &Self, endianness: Endianness) -> Option<Self> {
-        let mut result = MaybeUninit::<Self>::uninit();
-        let success = self.sub_assign(other, unsafe { result.assume_init_mut() }, endianness);
-
-        if success {
-            Some(unsafe { result.assume_init() })
+        let mut out = MaybeUninit::uninit();
+        if self.sub_assign(other, &mut out, endianness) {
+            // SAFETY: `sub_assign` returned `true`, so every byte of
+            // `out` has been written.
+            Some(unsafe { out.assume_init() })
         } else {
             None
         }
@@ -230,20 +262,33 @@ impl G2Point {
     ///
     /// Note: The underlying syscall inherently performs full validation
     /// (field, curve, and subgroup checks) on the input point.
-    pub fn mul_assign(&self, scalar: &Scalar, out: &mut Self, endianness: Endianness) -> bool {
+    ///
+    /// Returns `true` if and only if every byte of `out` was written, in
+    /// which case the caller may `assume_init` it. On `false`, `out` is
+    /// left untouched and must not be assumed initialized.
+    pub fn mul_assign(
+        &self,
+        scalar: &Scalar,
+        out: &mut MaybeUninit<Self>,
+        endianness: Endianness,
+    ) -> bool {
         #[cfg(target_os = "solana")]
         {
             let curve_id = match endianness {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G2_LE,
                 Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G2_BE,
             };
+            // SAFETY: the input pointers are valid for reads of their
+            // respective sizes and `out` is valid for writes of
+            // `G2_UNCOMPRESSED_POINT_SIZE` bytes. Per SIMD-0388 the syscall writes
+            // the full output buffer whenever it returns 0.
             let status = unsafe {
                 solana_define_syscall::definitions::sol_curve_group_op(
                     curve_id,
                     solana_define_syscall::curve_constants::GROUP_OP_MUL,
                     scalar.0.as_ptr(),
                     self.0.as_ptr(),
-                    out.0.as_mut_ptr(),
+                    out.as_mut_ptr().cast::<u8>(),
                 )
             };
             status == 0
@@ -265,7 +310,7 @@ impl G2Point {
                 scalar_pod,
                 end,
             ) {
-                out.0.copy_from_slice(&res.0);
+                out.write(Self(res.0));
                 true
             } else {
                 false
@@ -275,11 +320,11 @@ impl G2Point {
 
     /// Scalar multiplication returning a new allocated point.
     pub fn mul(&self, scalar: &Scalar, endianness: Endianness) -> Option<Self> {
-        let mut result = MaybeUninit::<Self>::uninit();
-        let success = self.mul_assign(scalar, unsafe { result.assume_init_mut() }, endianness);
-
-        if success {
-            Some(unsafe { result.assume_init() })
+        let mut out = MaybeUninit::uninit();
+        if self.mul_assign(scalar, &mut out, endianness) {
+            // SAFETY: `mul_assign` returned `true`, so every byte of
+            // `out` has been written.
+            Some(unsafe { out.assume_init() })
         } else {
             None
         }
@@ -337,18 +382,30 @@ impl G2Compressed {
 
     /// In-place decompression into an uncompressed affine point.
     /// Inherently performs format, field, curve, and subgroup validation.
-    pub fn decompress_assign(&self, out: &mut G2Point, endianness: Endianness) -> bool {
+    ///
+    /// Returns `true` if and only if every byte of `out` was written, in
+    /// which case the caller may `assume_init` it. On `false`, `out` is
+    /// left untouched and must not be assumed initialized.
+    pub fn decompress_assign(
+        &self,
+        out: &mut MaybeUninit<G2Point>,
+        endianness: Endianness,
+    ) -> bool {
         #[cfg(target_os = "solana")]
         {
             let curve_id = match endianness {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G2_LE,
                 Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G2_BE,
             };
+            // SAFETY: `self.0` is valid for reads of its size and `out`
+            // is valid for writes of `G2_UNCOMPRESSED_POINT_SIZE` bytes. Per
+            // SIMD-0388 the syscall writes the full output buffer
+            // whenever it returns 0.
             let status = unsafe {
                 solana_define_syscall::definitions::sol_curve_decompress(
                     curve_id,
                     self.0.as_ptr(),
-                    out.0.as_mut_ptr(),
+                    out.as_mut_ptr().cast::<u8>(),
                 )
             };
             status == 0
@@ -368,7 +425,7 @@ impl G2Compressed {
                 pod,
                 end,
             ) {
-                out.0.copy_from_slice(&res.0);
+                out.write(G2Point(res.0));
                 true
             } else {
                 false
@@ -378,11 +435,11 @@ impl G2Compressed {
 
     /// Decompresses into a new allocated affine point.
     pub fn decompress(&self, endianness: Endianness) -> Option<G2Point> {
-        let mut result = MaybeUninit::<G2Point>::uninit();
-        let success = self.decompress_assign(unsafe { result.assume_init_mut() }, endianness);
-
-        if success {
-            Some(unsafe { result.assume_init() })
+        let mut out = MaybeUninit::uninit();
+        if self.decompress_assign(&mut out, endianness) {
+            // SAFETY: `decompress_assign` returned `true`, so every byte of
+            // `out` has been written.
+            Some(unsafe { out.assume_init() })
         } else {
             None
         }

--- a/bls12-381/src/g2.rs
+++ b/bls12-381/src/g2.rs
@@ -1,4 +1,7 @@
-#[cfg(any(feature = "bytemuck", not(target_os = "solana")))]
+#[cfg(any(
+    feature = "bytemuck",
+    not(any(target_os = "solana", target_arch = "bpf"))
+))]
 use bytemuck_derive::{Pod, Zeroable};
 use {
     crate::{scalar::Scalar, Endianness},
@@ -15,7 +18,10 @@ pub const G2_UNCOMPRESSED_POINT_SIZE: usize = 192;
 /// Represents the `x` and `y` coordinates in the extension field (192 bytes).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    any(feature = "bytemuck", not(target_os = "solana")),
+    any(
+        feature = "bytemuck",
+        not(any(target_os = "solana", target_arch = "bpf"))
+    ),
     derive(Pod, Zeroable)
 )]
 #[repr(transparent)]
@@ -25,7 +31,10 @@ pub struct G2Point(pub [u8; G2_UNCOMPRESSED_POINT_SIZE]);
 /// Represents the `x` coordinate with control flags in the MSB (96 bytes).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    any(feature = "bytemuck", not(target_os = "solana")),
+    any(
+        feature = "bytemuck",
+        not(any(target_os = "solana", target_arch = "bpf"))
+    ),
     derive(Pod, Zeroable)
 )]
 #[repr(transparent)]
@@ -75,7 +84,7 @@ impl G2Point {
         out: &mut MaybeUninit<Self>,
         endianness: Endianness,
     ) -> bool {
-        #[cfg(target_os = "solana")]
+        #[cfg(any(target_os = "solana", target_arch = "bpf"))]
         {
             let curve_id = match endianness {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G2_LE,
@@ -97,7 +106,7 @@ impl G2Point {
             status == 0
         }
 
-        #[cfg(not(target_os = "solana"))]
+        #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
         {
             let left_pod: &solana_bls12_381_syscall::PodG2Point = bytemuck::cast_ref(&self.0);
             let right_pod: &solana_bls12_381_syscall::PodG2Point = bytemuck::cast_ref(&other.0);
@@ -178,7 +187,7 @@ impl G2Point {
         out: &mut MaybeUninit<Self>,
         endianness: Endianness,
     ) -> bool {
-        #[cfg(target_os = "solana")]
+        #[cfg(any(target_os = "solana", target_arch = "bpf"))]
         {
             let curve_id = match endianness {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G2_LE,
@@ -200,7 +209,7 @@ impl G2Point {
             status == 0
         }
 
-        #[cfg(not(target_os = "solana"))]
+        #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
         {
             let left_pod: &solana_bls12_381_syscall::PodG2Point = bytemuck::cast_ref(&self.0);
             let right_pod: &solana_bls12_381_syscall::PodG2Point = bytemuck::cast_ref(&other.0);
@@ -281,7 +290,7 @@ impl G2Point {
         out: &mut MaybeUninit<Self>,
         endianness: Endianness,
     ) -> bool {
-        #[cfg(target_os = "solana")]
+        #[cfg(any(target_os = "solana", target_arch = "bpf"))]
         {
             let curve_id = match endianness {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G2_LE,
@@ -303,7 +312,7 @@ impl G2Point {
             status == 0
         }
 
-        #[cfg(not(target_os = "solana"))]
+        #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
         {
             let point_pod: &solana_bls12_381_syscall::PodG2Point = bytemuck::cast_ref(&self.0);
             let scalar_pod: &solana_bls12_381_syscall::PodScalar = bytemuck::cast_ref(&scalar.0);
@@ -343,7 +352,7 @@ impl G2Point {
     /// Checks that coordinates represent valid field elements, satisfy the
     /// curve equation, and exist within the prime-order subgroup.
     pub fn validate(&self, endianness: Endianness) -> bool {
-        #[cfg(target_os = "solana")]
+        #[cfg(any(target_os = "solana", target_arch = "bpf"))]
         {
             let curve_id = match endianness {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G2_LE,
@@ -360,7 +369,7 @@ impl G2Point {
             status == 0
         }
 
-        #[cfg(not(target_os = "solana"))]
+        #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
         {
             let point_pod: &solana_bls12_381_syscall::PodG2Point = bytemuck::cast_ref(&self.0);
 
@@ -400,7 +409,7 @@ impl G2Compressed {
         out: &mut MaybeUninit<G2Point>,
         endianness: Endianness,
     ) -> bool {
-        #[cfg(target_os = "solana")]
+        #[cfg(any(target_os = "solana", target_arch = "bpf"))]
         {
             let curve_id = match endianness {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G2_LE,
@@ -420,7 +429,7 @@ impl G2Compressed {
             status == 0
         }
 
-        #[cfg(not(target_os = "solana"))]
+        #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
         {
             let pod: &solana_bls12_381_syscall::PodG2Compressed = bytemuck::cast_ref(&self.0);
 

--- a/bls12-381/src/g2.rs
+++ b/bls12-381/src/g2.rs
@@ -1,0 +1,392 @@
+use {
+    crate::{scalar::Scalar, Endianness},
+    bytemuck::{Pod, Zeroable},
+    core::mem::MaybeUninit,
+};
+
+/// Size of a compressed BLS12-381 G2 point in bytes.
+pub const G2_COMPRESSED_POINT_SIZE: usize = 96;
+
+/// Size of an uncompressed BLS12-381 G2 affine point in bytes.
+pub const G2_UNCOMPRESSED_POINT_SIZE: usize = 192;
+
+/// Uncompressed BLS12-381 G2 affine point.
+/// Represents the `x` and `y` coordinates in the extension field (192 bytes).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct G2Point(pub [u8; G2_UNCOMPRESSED_POINT_SIZE]);
+
+/// Compressed BLS12-381 G2 point.
+/// Represents the `x` coordinate with control flags in the MSB (96 bytes).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct G2Compressed(pub [u8; G2_COMPRESSED_POINT_SIZE]);
+
+impl G2Point {
+    /// Returns the identity (infinity) element for the given endianness.
+    pub const fn infinity(endianness: Endianness) -> Self {
+        let mut bytes = [0u8; G2_UNCOMPRESSED_POINT_SIZE];
+        match endianness {
+            // Zcash standard sets the infinity flag on the highest byte.
+            Endianness::Big => bytes[0] = 0x40,
+            Endianness::Little => bytes[95] = 0x40,
+        }
+        Self(bytes)
+    }
+
+    /// Constructs a point from a byte array via a memory copy.
+    ///
+    /// Note: For zero-copy deserialization from instruction data, use
+    /// `bytemuck::cast_ref` directly on the byte slice.
+    pub const fn from_bytes(bytes: [u8; G2_UNCOMPRESSED_POINT_SIZE]) -> Self {
+        Self(bytes)
+    }
+
+    /// Returns the underlying byte array via a memory copy.
+    pub const fn to_bytes(&self) -> [u8; G2_UNCOMPRESSED_POINT_SIZE] {
+        self.0
+    }
+
+    /// Safely negates the point by subtracting it from infinity.
+    pub fn neg(&self, endianness: Endianness) -> Option<Self> {
+        Self::infinity(endianness).checked_sub(self, endianness)
+    }
+
+    /// In-place point addition.
+    ///
+    /// WARNING: This operation skips the prime-order subgroup check
+    /// for performance. Only use this if inputs are known to be valid.
+    pub fn add_unchecked_assign(
+        &self,
+        other: &Self,
+        out: &mut Self,
+        endianness: Endianness,
+    ) -> bool {
+        #[cfg(target_os = "solana")]
+        {
+            let curve_id = match endianness {
+                Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G2_LE,
+                Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G2_BE,
+            };
+            let status = unsafe {
+                solana_define_syscall::definitions::sol_curve_group_op(
+                    curve_id,
+                    solana_define_syscall::curve_constants::GROUP_OP_ADD,
+                    self.0.as_ptr(),
+                    other.0.as_ptr(),
+                    out.0.as_mut_ptr(),
+                )
+            };
+            status == 0
+        }
+
+        #[cfg(not(target_os = "solana"))]
+        {
+            let left_pod: &solana_bls12_381_syscall::PodG2Point = bytemuck::cast_ref(&self.0);
+            let right_pod: &solana_bls12_381_syscall::PodG2Point = bytemuck::cast_ref(&other.0);
+
+            let end = match endianness {
+                Endianness::Little => solana_bls12_381_syscall::Endianness::LE,
+                Endianness::Big => solana_bls12_381_syscall::Endianness::BE,
+            };
+
+            if let Some(res) = solana_bls12_381_syscall::bls12_381_g2_addition_unchecked(
+                solana_bls12_381_syscall::Version::V0,
+                left_pod,
+                right_pod,
+                end,
+            ) {
+                out.0.copy_from_slice(&res.0);
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    /// Point addition returning a new allocated point.
+    /// Skips subgroup checks.
+    pub fn add_unchecked(&self, other: &Self, endianness: Endianness) -> Option<Self> {
+        let mut result = MaybeUninit::<Self>::uninit();
+        let success =
+            self.add_unchecked_assign(other, unsafe { result.assume_init_mut() }, endianness);
+
+        if success {
+            Some(unsafe { result.assume_init() })
+        } else {
+            None
+        }
+    }
+
+    /// Safe in-place point addition.
+    /// Validates both operands (field, curve, subgroup) prior to addition.
+    pub fn checked_add_assign(&self, other: &Self, out: &mut Self, endianness: Endianness) -> bool {
+        if !self.validate(endianness) || !other.validate(endianness) {
+            return false;
+        }
+        self.add_unchecked_assign(other, out, endianness)
+    }
+
+    /// Safe point addition returning a new allocated point.
+    pub fn checked_add(&self, other: &Self, endianness: Endianness) -> Option<Self> {
+        let mut result = MaybeUninit::<Self>::uninit();
+        let success =
+            self.checked_add_assign(other, unsafe { result.assume_init_mut() }, endianness);
+
+        if success {
+            Some(unsafe { result.assume_init() })
+        } else {
+            None
+        }
+    }
+
+    /// In-place point subtraction.
+    ///
+    /// WARNING: This operation skips the prime-order subgroup check
+    /// for performance. Only use this if inputs are known to be valid.
+    pub fn sub_unchecked_assign(
+        &self,
+        other: &Self,
+        out: &mut Self,
+        endianness: Endianness,
+    ) -> bool {
+        #[cfg(target_os = "solana")]
+        {
+            let curve_id = match endianness {
+                Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G2_LE,
+                Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G2_BE,
+            };
+            let status = unsafe {
+                solana_define_syscall::definitions::sol_curve_group_op(
+                    curve_id,
+                    solana_define_syscall::curve_constants::GROUP_OP_SUB,
+                    self.0.as_ptr(),
+                    other.0.as_ptr(),
+                    out.0.as_mut_ptr(),
+                )
+            };
+            status == 0
+        }
+
+        #[cfg(not(target_os = "solana"))]
+        {
+            let left_pod: &solana_bls12_381_syscall::PodG2Point = bytemuck::cast_ref(&self.0);
+            let right_pod: &solana_bls12_381_syscall::PodG2Point = bytemuck::cast_ref(&other.0);
+
+            let end = match endianness {
+                Endianness::Little => solana_bls12_381_syscall::Endianness::LE,
+                Endianness::Big => solana_bls12_381_syscall::Endianness::BE,
+            };
+
+            if let Some(res) = solana_bls12_381_syscall::bls12_381_g2_subtraction_unchecked(
+                solana_bls12_381_syscall::Version::V0,
+                left_pod,
+                right_pod,
+                end,
+            ) {
+                out.0.copy_from_slice(&res.0);
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    /// Point subtraction returning a new allocated point.
+    /// Skips subgroup checks.
+    pub fn sub_unchecked(&self, other: &Self, endianness: Endianness) -> Option<Self> {
+        let mut result = MaybeUninit::<Self>::uninit();
+        let success =
+            self.sub_unchecked_assign(other, unsafe { result.assume_init_mut() }, endianness);
+
+        if success {
+            Some(unsafe { result.assume_init() })
+        } else {
+            None
+        }
+    }
+
+    /// Safe in-place point subtraction.
+    /// Validates both operands prior to subtraction.
+    pub fn checked_sub_assign(&self, other: &Self, out: &mut Self, endianness: Endianness) -> bool {
+        if !self.validate(endianness) || !other.validate(endianness) {
+            return false;
+        }
+        self.sub_unchecked_assign(other, out, endianness)
+    }
+
+    /// Safe point subtraction returning a new allocated point.
+    pub fn checked_sub(&self, other: &Self, endianness: Endianness) -> Option<Self> {
+        let mut result = MaybeUninit::<Self>::uninit();
+        let success =
+            self.checked_sub_assign(other, unsafe { result.assume_init_mut() }, endianness);
+
+        if success {
+            Some(unsafe { result.assume_init() })
+        } else {
+            None
+        }
+    }
+
+    /// In-place scalar multiplication.
+    ///
+    /// Note: The underlying syscall inherently performs full validation
+    /// (field, curve, and subgroup checks) on the input point.
+    pub fn mul_assign(&self, scalar: &Scalar, out: &mut Self, endianness: Endianness) -> bool {
+        #[cfg(target_os = "solana")]
+        {
+            let curve_id = match endianness {
+                Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G2_LE,
+                Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G2_BE,
+            };
+            let status = unsafe {
+                solana_define_syscall::definitions::sol_curve_group_op(
+                    curve_id,
+                    solana_define_syscall::curve_constants::GROUP_OP_MUL,
+                    scalar.0.as_ptr(),
+                    self.0.as_ptr(),
+                    out.0.as_mut_ptr(),
+                )
+            };
+            status == 0
+        }
+
+        #[cfg(not(target_os = "solana"))]
+        {
+            let point_pod: &solana_bls12_381_syscall::PodG2Point = bytemuck::cast_ref(&self.0);
+            let scalar_pod: &solana_bls12_381_syscall::PodScalar = bytemuck::cast_ref(&scalar.0);
+
+            let end = match endianness {
+                Endianness::Little => solana_bls12_381_syscall::Endianness::LE,
+                Endianness::Big => solana_bls12_381_syscall::Endianness::BE,
+            };
+
+            if let Some(res) = solana_bls12_381_syscall::bls12_381_g2_multiplication(
+                solana_bls12_381_syscall::Version::V0,
+                point_pod,
+                scalar_pod,
+                end,
+            ) {
+                out.0.copy_from_slice(&res.0);
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    /// Scalar multiplication returning a new allocated point.
+    pub fn mul(&self, scalar: &Scalar, endianness: Endianness) -> Option<Self> {
+        let mut result = MaybeUninit::<Self>::uninit();
+        let success = self.mul_assign(scalar, unsafe { result.assume_init_mut() }, endianness);
+
+        if success {
+            Some(unsafe { result.assume_init() })
+        } else {
+            None
+        }
+    }
+
+    /// Full point validation.
+    /// Checks that coordinates represent valid field elements, satisfy the
+    /// curve equation, and exist within the prime-order subgroup.
+    pub fn validate(&self, endianness: Endianness) -> bool {
+        #[cfg(target_os = "solana")]
+        {
+            let curve_id = match endianness {
+                Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G2_LE,
+                Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G2_BE,
+            };
+            let mut dummy = [0u8; 1];
+            let status = unsafe {
+                solana_define_syscall::definitions::sol_curve_validate_point(
+                    curve_id,
+                    self.0.as_ptr(),
+                    dummy.as_mut_ptr(),
+                )
+            };
+            status == 0
+        }
+
+        #[cfg(not(target_os = "solana"))]
+        {
+            let point_pod: &solana_bls12_381_syscall::PodG2Point = bytemuck::cast_ref(&self.0);
+
+            let end = match endianness {
+                Endianness::Little => solana_bls12_381_syscall::Endianness::LE,
+                Endianness::Big => solana_bls12_381_syscall::Endianness::BE,
+            };
+
+            solana_bls12_381_syscall::bls12_381_g2_point_validation(
+                solana_bls12_381_syscall::Version::V0,
+                point_pod,
+                end,
+            )
+        }
+    }
+}
+
+impl G2Compressed {
+    /// Constructs a compressed point from a byte array via a memory copy.
+    pub const fn from_bytes(bytes: [u8; G2_COMPRESSED_POINT_SIZE]) -> Self {
+        Self(bytes)
+    }
+
+    /// Returns the underlying compressed byte array via a memory copy.
+    pub const fn to_bytes(&self) -> [u8; G2_COMPRESSED_POINT_SIZE] {
+        self.0
+    }
+
+    /// In-place decompression into an uncompressed affine point.
+    /// Inherently performs format, field, curve, and subgroup validation.
+    pub fn decompress_assign(&self, out: &mut G2Point, endianness: Endianness) -> bool {
+        #[cfg(target_os = "solana")]
+        {
+            let curve_id = match endianness {
+                Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G2_LE,
+                Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G2_BE,
+            };
+            let status = unsafe {
+                solana_define_syscall::definitions::sol_curve_decompress(
+                    curve_id,
+                    self.0.as_ptr(),
+                    out.0.as_mut_ptr(),
+                )
+            };
+            status == 0
+        }
+
+        #[cfg(not(target_os = "solana"))]
+        {
+            let pod: &solana_bls12_381_syscall::PodG2Compressed = bytemuck::cast_ref(&self.0);
+
+            let end = match endianness {
+                Endianness::Little => solana_bls12_381_syscall::Endianness::LE,
+                Endianness::Big => solana_bls12_381_syscall::Endianness::BE,
+            };
+
+            if let Some(res) = solana_bls12_381_syscall::bls12_381_g2_decompress(
+                solana_bls12_381_syscall::Version::V0,
+                pod,
+                end,
+            ) {
+                out.0.copy_from_slice(&res.0);
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    /// Decompresses into a new allocated affine point.
+    pub fn decompress(&self, endianness: Endianness) -> Option<G2Point> {
+        let mut result = MaybeUninit::<G2Point>::uninit();
+        let success = self.decompress_assign(unsafe { result.assume_init_mut() }, endianness);
+
+        if success {
+            Some(unsafe { result.assume_init() })
+        } else {
+            None
+        }
+    }
+}

--- a/bls12-381/src/g2.rs
+++ b/bls12-381/src/g2.rs
@@ -49,14 +49,14 @@ impl G2Point {
 
     /// Safely negates the point by subtracting it from infinity.
     pub fn neg(&self, endianness: Endianness) -> Option<Self> {
-        Self::infinity(endianness).checked_sub(self, endianness)
+        Self::infinity(endianness).sub(self, endianness)
     }
 
     /// In-place point addition.
     ///
     /// WARNING: This operation skips the prime-order subgroup check
     /// for performance. Only use this if inputs are known to be valid.
-    pub fn add_unchecked_assign(
+    pub fn add_assign_unchecked(
         &self,
         other: &Self,
         out: &mut Self,
@@ -109,7 +109,7 @@ impl G2Point {
     pub fn add_unchecked(&self, other: &Self, endianness: Endianness) -> Option<Self> {
         let mut result = MaybeUninit::<Self>::uninit();
         let success =
-            self.add_unchecked_assign(other, unsafe { result.assume_init_mut() }, endianness);
+            self.add_assign_unchecked(other, unsafe { result.assume_init_mut() }, endianness);
 
         if success {
             Some(unsafe { result.assume_init() })
@@ -120,18 +120,17 @@ impl G2Point {
 
     /// Safe in-place point addition.
     /// Validates both operands (field, curve, subgroup) prior to addition.
-    pub fn checked_add_assign(&self, other: &Self, out: &mut Self, endianness: Endianness) -> bool {
+    pub fn add_assign(&self, other: &Self, out: &mut Self, endianness: Endianness) -> bool {
         if !self.validate(endianness) || !other.validate(endianness) {
             return false;
         }
-        self.add_unchecked_assign(other, out, endianness)
+        self.add_assign_unchecked(other, out, endianness)
     }
 
     /// Safe point addition returning a new allocated point.
-    pub fn checked_add(&self, other: &Self, endianness: Endianness) -> Option<Self> {
+    pub fn add(&self, other: &Self, endianness: Endianness) -> Option<Self> {
         let mut result = MaybeUninit::<Self>::uninit();
-        let success =
-            self.checked_add_assign(other, unsafe { result.assume_init_mut() }, endianness);
+        let success = self.add_assign(other, unsafe { result.assume_init_mut() }, endianness);
 
         if success {
             Some(unsafe { result.assume_init() })
@@ -144,7 +143,7 @@ impl G2Point {
     ///
     /// WARNING: This operation skips the prime-order subgroup check
     /// for performance. Only use this if inputs are known to be valid.
-    pub fn sub_unchecked_assign(
+    pub fn sub_assign_unchecked(
         &self,
         other: &Self,
         out: &mut Self,
@@ -197,7 +196,7 @@ impl G2Point {
     pub fn sub_unchecked(&self, other: &Self, endianness: Endianness) -> Option<Self> {
         let mut result = MaybeUninit::<Self>::uninit();
         let success =
-            self.sub_unchecked_assign(other, unsafe { result.assume_init_mut() }, endianness);
+            self.sub_assign_unchecked(other, unsafe { result.assume_init_mut() }, endianness);
 
         if success {
             Some(unsafe { result.assume_init() })
@@ -208,18 +207,17 @@ impl G2Point {
 
     /// Safe in-place point subtraction.
     /// Validates both operands prior to subtraction.
-    pub fn checked_sub_assign(&self, other: &Self, out: &mut Self, endianness: Endianness) -> bool {
+    pub fn sub_assign(&self, other: &Self, out: &mut Self, endianness: Endianness) -> bool {
         if !self.validate(endianness) || !other.validate(endianness) {
             return false;
         }
-        self.sub_unchecked_assign(other, out, endianness)
+        self.sub_assign_unchecked(other, out, endianness)
     }
 
     /// Safe point subtraction returning a new allocated point.
-    pub fn checked_sub(&self, other: &Self, endianness: Endianness) -> Option<Self> {
+    pub fn sub(&self, other: &Self, endianness: Endianness) -> Option<Self> {
         let mut result = MaybeUninit::<Self>::uninit();
-        let success =
-            self.checked_sub_assign(other, unsafe { result.assume_init_mut() }, endianness);
+        let success = self.sub_assign(other, unsafe { result.assume_init_mut() }, endianness);
 
         if success {
             Some(unsafe { result.assume_init() })

--- a/bls12-381/src/lib.rs
+++ b/bls12-381/src/lib.rs
@@ -1,0 +1,15 @@
+#![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+pub mod g1;
+pub mod g2;
+pub mod pairing;
+pub mod scalar;
+
+pub use {g1::*, g2::*, pairing::*, scalar::*};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Endianness {
+    Little,
+    Big,
+}

--- a/bls12-381/src/pairing.rs
+++ b/bls12-381/src/pairing.rs
@@ -1,8 +1,10 @@
 use {
     crate::{g1::G1Point, g2::G2Point, Endianness},
-    bytemuck::{Pod, Zeroable},
     core::mem::MaybeUninit,
 };
+
+#[cfg(any(feature = "bytemuck", not(target_os = "solana")))]
+use bytemuck_derive::{Pod, Zeroable};
 
 /// Size of a target group (Gt) element in bytes.
 pub const GT_ELEMENT_SIZE: usize = 576;
@@ -12,7 +14,11 @@ pub const MAX_PAIRING_LENGTH: usize = 8;
 
 /// An element in the target group (Gt).
 /// Represents an element in the extension field Fq12 (576 bytes).
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Pod, Zeroable)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    any(feature = "bytemuck", not(target_os = "solana")),
+    derive(Pod, Zeroable)
+)]
 #[repr(transparent)]
 pub struct GtElement(pub [u8; GT_ELEMENT_SIZE]);
 

--- a/bls12-381/src/pairing.rs
+++ b/bls12-381/src/pairing.rs
@@ -1,4 +1,7 @@
-#[cfg(any(feature = "bytemuck", not(target_os = "solana")))]
+#[cfg(any(
+    feature = "bytemuck",
+    not(any(target_os = "solana", target_arch = "bpf"))
+))]
 use bytemuck_derive::{Pod, Zeroable};
 use {
     crate::{g1::G1Point, g2::G2Point, Endianness},
@@ -15,7 +18,10 @@ pub const MAX_PAIRING_LENGTH: usize = 8;
 /// Represents an element in the extension field Fq12 (576 bytes).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    any(feature = "bytemuck", not(target_os = "solana")),
+    any(
+        feature = "bytemuck",
+        not(any(target_os = "solana", target_arch = "bpf"))
+    ),
     derive(Pod, Zeroable)
 )]
 #[repr(transparent)]
@@ -57,7 +63,7 @@ pub fn pairing_map_assign(
         return true;
     }
 
-    #[cfg(target_os = "solana")]
+    #[cfg(any(target_os = "solana", target_arch = "bpf"))]
     {
         let curve_id = match endianness {
             Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_LE,
@@ -80,7 +86,7 @@ pub fn pairing_map_assign(
         status == 0
     }
 
-    #[cfg(not(target_os = "solana"))]
+    #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
     {
         let g1_pods: &[solana_bls12_381_syscall::PodG1Point] = bytemuck::cast_slice(g1_points);
         let g2_pods: &[solana_bls12_381_syscall::PodG2Point] = bytemuck::cast_slice(g2_points);

--- a/bls12-381/src/pairing.rs
+++ b/bls12-381/src/pairing.rs
@@ -1,0 +1,167 @@
+use {
+    crate::{g1::G1Point, g2::G2Point, Endianness},
+    bytemuck::{Pod, Zeroable},
+    core::mem::MaybeUninit,
+};
+
+/// Size of a target group (Gt) element in bytes.
+pub const GT_ELEMENT_SIZE: usize = 576;
+
+/// Maximum number of pairs allowed in a single batch pairing operation.
+pub const MAX_PAIRING_LENGTH: usize = 8;
+
+/// An element in the target group (Gt).
+/// Represents an element in the extension field Fq12 (576 bytes).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct GtElement(pub [u8; GT_ELEMENT_SIZE]);
+
+/// In-place product of pairings for a batch of G1 and G2 points.
+///
+/// Computes `e(P_1, Q_1) * ... * e(P_n, Q_n)` and writes the resulting
+/// `GtElement` to the `out` reference.
+pub fn pairing_map_assign(
+    g1_points: &[G1Point],
+    g2_points: &[G2Point],
+    out: &mut GtElement,
+    endianness: Endianness,
+) -> bool {
+    if g1_points.len() != g2_points.len() || g1_points.len() > MAX_PAIRING_LENGTH {
+        return false;
+    }
+
+    if g1_points.is_empty() {
+        out.0.fill(0);
+        match endianness {
+            Endianness::Little => out.0[0] = 1,
+            Endianness::Big => out.0[575] = 1,
+        }
+        return true;
+    }
+
+    #[cfg(target_os = "solana")]
+    {
+        let curve_id = match endianness {
+            Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_LE,
+            Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_BE,
+        };
+
+        let status = unsafe {
+            solana_define_syscall::definitions::sol_curve_pairing_map(
+                curve_id,
+                g1_points.len() as u64,
+                g1_points.as_ptr() as *const u8,
+                g2_points.as_ptr() as *const u8,
+                out.0.as_mut_ptr(),
+            )
+        };
+        status == 0
+    }
+
+    #[cfg(not(target_os = "solana"))]
+    {
+        let g1_pods: &[solana_bls12_381_syscall::PodG1Point] = bytemuck::cast_slice(g1_points);
+        let g2_pods: &[solana_bls12_381_syscall::PodG2Point] = bytemuck::cast_slice(g2_points);
+
+        let end = match endianness {
+            Endianness::Little => solana_bls12_381_syscall::Endianness::LE,
+            Endianness::Big => solana_bls12_381_syscall::Endianness::BE,
+        };
+
+        if let Some(res) = solana_bls12_381_syscall::bls12_381_pairing_map(
+            solana_bls12_381_syscall::Version::V0,
+            g1_pods,
+            g2_pods,
+            end,
+        ) {
+            out.0.copy_from_slice(&res.0);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Product of pairings returning a new allocated target group element.
+pub fn pairing_map(
+    g1_points: &[G1Point],
+    g2_points: &[G2Point],
+    endianness: Endianness,
+) -> Option<GtElement> {
+    let mut result = MaybeUninit::<GtElement>::uninit();
+
+    let success = pairing_map_assign(
+        g1_points,
+        g2_points,
+        unsafe { result.assume_init_mut() },
+        endianness,
+    );
+
+    if success {
+        Some(unsafe { result.assume_init() })
+    } else {
+        None
+    }
+}
+
+/// In-place pairing for a single G1 and G2 point pair.
+/// Zero-allocation wrapper around `pairing_map_assign`.
+pub fn pairing_assign(
+    g1_point: &G1Point,
+    g2_point: &G2Point,
+    out: &mut GtElement,
+    endianness: Endianness,
+) -> bool {
+    pairing_map_assign(
+        core::slice::from_ref(g1_point),
+        core::slice::from_ref(g2_point),
+        out,
+        endianness,
+    )
+}
+
+/// Single pairing returning a new allocated target group element.
+pub fn pairing(
+    g1_point: &G1Point,
+    g2_point: &G2Point,
+    endianness: Endianness,
+) -> Option<GtElement> {
+    pairing_map(
+        core::slice::from_ref(g1_point),
+        core::slice::from_ref(g2_point),
+        endianness,
+    )
+}
+
+/// Evaluates if the product of pairings equals the identity element.
+///
+/// Highly efficient for ZK verifiers (e.g., Groth16) as it avoids returning
+/// the raw 576-byte `GtElement` to the caller.
+pub fn pairing_check(
+    g1_points: &[G1Point],
+    g2_points: &[G2Point],
+    endianness: Endianness,
+) -> Option<bool> {
+    let mut result = MaybeUninit::<GtElement>::uninit();
+
+    let success = pairing_map_assign(
+        g1_points,
+        g2_points,
+        unsafe { result.assume_init_mut() },
+        endianness,
+    );
+
+    if !success {
+        return None;
+    }
+
+    let gt = unsafe { result.assume_init() };
+    let mut identity = [0u8; GT_ELEMENT_SIZE];
+
+    match endianness {
+        Endianness::Little => identity[0] = 1,
+        Endianness::Big => identity[575] = 1,
+    }
+
+    Some(gt.0 == identity)
+}

--- a/bls12-381/src/pairing.rs
+++ b/bls12-381/src/pairing.rs
@@ -16,14 +16,31 @@ pub const MAX_PAIRING_LENGTH: usize = 8;
 #[repr(transparent)]
 pub struct GtElement(pub [u8; GT_ELEMENT_SIZE]);
 
+impl GtElement {
+    /// Returns the multiplicative identity of the target group for the given
+    /// endianness.
+    pub const fn identity(endianness: Endianness) -> Self {
+        let mut bytes = [0u8; GT_ELEMENT_SIZE];
+        match endianness {
+            Endianness::Little => bytes[0] = 1,
+            Endianness::Big => bytes[GT_ELEMENT_SIZE - 1] = 1,
+        }
+        Self(bytes)
+    }
+}
+
 /// In-place product of pairings for a batch of G1 and G2 points.
 ///
 /// Computes `e(P_1, Q_1) * ... * e(P_n, Q_n)` and writes the resulting
-/// `GtElement` to the `out` reference.
+/// `GtElement` into `out`.
+///
+/// Returns `true` if and only if every byte of `out` was written, in
+/// which case the caller may `assume_init` it. On `false`, `out` is
+/// left untouched and must not be assumed initialized.
 pub fn pairing_map_assign(
     g1_points: &[G1Point],
     g2_points: &[G2Point],
-    out: &mut GtElement,
+    out: &mut MaybeUninit<GtElement>,
     endianness: Endianness,
 ) -> bool {
     if g1_points.len() != g2_points.len() || g1_points.len() > MAX_PAIRING_LENGTH {
@@ -31,11 +48,7 @@ pub fn pairing_map_assign(
     }
 
     if g1_points.is_empty() {
-        out.0.fill(0);
-        match endianness {
-            Endianness::Little => out.0[0] = 1,
-            Endianness::Big => out.0[575] = 1,
-        }
+        out.write(GtElement::identity(endianness));
         return true;
     }
 
@@ -46,13 +59,17 @@ pub fn pairing_map_assign(
             Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_BE,
         };
 
+        // SAFETY: the point slices are valid for reads of their respective
+        // sizes and `out` is valid for writes of `GT_ELEMENT_SIZE` bytes. Per
+        // SIMD-0388 the syscall writes the full output buffer whenever it
+        // returns 0.
         let status = unsafe {
             solana_define_syscall::definitions::sol_curve_pairing_map(
                 curve_id,
                 g1_points.len() as u64,
                 g1_points.as_ptr() as *const u8,
                 g2_points.as_ptr() as *const u8,
-                out.0.as_mut_ptr(),
+                out.as_mut_ptr().cast::<u8>(),
             )
         };
         status == 0
@@ -74,7 +91,7 @@ pub fn pairing_map_assign(
             g2_pods,
             end,
         ) {
-            out.0.copy_from_slice(&res.0);
+            out.write(GtElement(res.0));
             true
         } else {
             false
@@ -88,17 +105,12 @@ pub fn pairing_map(
     g2_points: &[G2Point],
     endianness: Endianness,
 ) -> Option<GtElement> {
-    let mut result = MaybeUninit::<GtElement>::uninit();
+    let mut out = MaybeUninit::uninit();
 
-    let success = pairing_map_assign(
-        g1_points,
-        g2_points,
-        unsafe { result.assume_init_mut() },
-        endianness,
-    );
-
-    if success {
-        Some(unsafe { result.assume_init() })
+    if pairing_map_assign(g1_points, g2_points, &mut out, endianness) {
+        // SAFETY: `pairing_map_assign` returned `true`, so every byte of `out`
+        // has been written.
+        Some(unsafe { out.assume_init() })
     } else {
         None
     }
@@ -106,10 +118,14 @@ pub fn pairing_map(
 
 /// In-place pairing for a single G1 and G2 point pair.
 /// Zero-allocation wrapper around `pairing_map_assign`.
+///
+/// Returns `true` if and only if every byte of `out` was written, in
+/// which case the caller may `assume_init` it. On `false`, `out` is
+/// left untouched and must not be assumed initialized.
 pub fn pairing_assign(
     g1_point: &G1Point,
     g2_point: &G2Point,
-    out: &mut GtElement,
+    out: &mut MaybeUninit<GtElement>,
     endianness: Endianness,
 ) -> bool {
     pairing_map_assign(
@@ -142,26 +158,15 @@ pub fn pairing_check(
     g2_points: &[G2Point],
     endianness: Endianness,
 ) -> Option<bool> {
-    let mut result = MaybeUninit::<GtElement>::uninit();
+    let mut out = MaybeUninit::uninit();
 
-    let success = pairing_map_assign(
-        g1_points,
-        g2_points,
-        unsafe { result.assume_init_mut() },
-        endianness,
-    );
-
-    if !success {
+    if !pairing_map_assign(g1_points, g2_points, &mut out, endianness) {
         return None;
     }
 
-    let gt = unsafe { result.assume_init() };
-    let mut identity = [0u8; GT_ELEMENT_SIZE];
+    // SAFETY: `pairing_map_assign` returned `true`, so every byte of `out` has
+    // been written.
+    let gt = unsafe { out.assume_init() };
 
-    match endianness {
-        Endianness::Little => identity[0] = 1,
-        Endianness::Big => identity[575] = 1,
-    }
-
-    Some(gt.0 == identity)
+    Some(gt == GtElement::identity(endianness))
 }

--- a/bls12-381/src/pairing.rs
+++ b/bls12-381/src/pairing.rs
@@ -1,10 +1,9 @@
+#[cfg(any(feature = "bytemuck", not(target_os = "solana")))]
+use bytemuck_derive::{Pod, Zeroable};
 use {
     crate::{g1::G1Point, g2::G2Point, Endianness},
     core::mem::MaybeUninit,
 };
-
-#[cfg(any(feature = "bytemuck", not(target_os = "solana")))]
-use bytemuck_derive::{Pod, Zeroable};
 
 /// Size of a target group (Gt) element in bytes.
 pub const GT_ELEMENT_SIZE: usize = 576;

--- a/bls12-381/src/scalar.rs
+++ b/bls12-381/src/scalar.rs
@@ -1,10 +1,15 @@
-use bytemuck::{Pod, Zeroable};
+#[cfg(any(feature = "bytemuck", not(target_os = "solana")))]
+use bytemuck_derive::{Pod, Zeroable};
 
 /// Size of a BLS12-381 scalar field element in bytes.
 pub const SCALAR_SIZE: usize = 32;
 
 /// A BLS12-381 scalar field element.
 /// Represents a 256-bit integer used for scalar multiplication.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Pod, Zeroable)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    any(feature = "bytemuck", not(target_os = "solana")),
+    derive(Pod, Zeroable)
+)]
 #[repr(transparent)]
 pub struct Scalar(pub [u8; SCALAR_SIZE]);

--- a/bls12-381/src/scalar.rs
+++ b/bls12-381/src/scalar.rs
@@ -1,4 +1,7 @@
-#[cfg(any(feature = "bytemuck", not(target_os = "solana")))]
+#[cfg(any(
+    feature = "bytemuck",
+    not(any(target_os = "solana", target_arch = "bpf"))
+))]
 use bytemuck_derive::{Pod, Zeroable};
 
 /// Size of a BLS12-381 scalar field element in bytes.
@@ -8,7 +11,10 @@ pub const SCALAR_SIZE: usize = 32;
 /// Represents a 256-bit integer used for scalar multiplication.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(
-    any(feature = "bytemuck", not(target_os = "solana")),
+    any(
+        feature = "bytemuck",
+        not(any(target_os = "solana", target_arch = "bpf"))
+    ),
     derive(Pod, Zeroable)
 )]
 #[repr(transparent)]

--- a/bls12-381/src/scalar.rs
+++ b/bls12-381/src/scalar.rs
@@ -1,0 +1,10 @@
+use bytemuck::{Pod, Zeroable};
+
+/// Size of a BLS12-381 scalar field element in bytes.
+pub const SCALAR_SIZE: usize = 32;
+
+/// A BLS12-381 scalar field element.
+/// Represents a 256-bit integer used for scalar multiplication.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct Scalar(pub [u8; SCALAR_SIZE]);

--- a/bls12-381/tests/bls12_381.rs
+++ b/bls12-381/tests/bls12_381.rs
@@ -1,5 +1,9 @@
-use solana_bls12_381::{
-    pairing, pairing_assign, pairing_check, Endianness, G1Point, G2Point, GtElement,
+use {
+    core::mem::MaybeUninit,
+    solana_bls12_381::{
+        pairing, pairing_assign, pairing_check, pairing_map, Endianness, G1Point, G2Point,
+        GtElement, G1_UNCOMPRESSED_POINT_SIZE,
+    },
 };
 
 #[test]
@@ -19,17 +23,38 @@ fn test_validated_arithmetic_routing() {
     let p1 = G1Point::infinity(Endianness::Little);
     let p2 = G1Point::infinity(Endianness::Little);
 
-    // Test the returning safe wrapper.
+    // Test the returning validated wrapper.
     let sum = p1.add(&p2, Endianness::Little);
     assert!(sum.is_some());
 
-    // Test the in-place safe wrapper to save CUs.
-    let mut out = G1Point::infinity(Endianness::Little);
+    // Test the in-place validated wrapper to save CUs.
+    let mut out = MaybeUninit::uninit();
     let success = p1.add_assign(&p2, &mut out, Endianness::Little);
     assert!(success);
 
+    // SAFETY: `add_assign` returned `true`, so every byte of `out` was written.
+    let out = unsafe { out.assume_init() };
+
     // Verify both methods yielded the exact same underlying bytes.
     assert_eq!(sum.unwrap().to_bytes(), out.to_bytes());
+}
+
+#[test]
+fn test_assign_leaves_out_untouched_on_failure() {
+    let sentinel = G1Point::infinity(Endianness::Little);
+    let mut out = MaybeUninit::new(sentinel);
+
+    // An all-ones encoding is not a valid field element, so validation must
+    // reject it before the operation writes anything.
+    let valid = G1Point::infinity(Endianness::Little);
+    let invalid = G1Point::from_bytes([0xFF; G1_UNCOMPRESSED_POINT_SIZE]);
+
+    let success = valid.add_assign(&invalid, &mut out, Endianness::Little);
+    assert!(!success);
+
+    // SAFETY: `out` was initialized by `MaybeUninit::new`, and `add_assign`
+    // returned `false`, which guarantees it was left untouched.
+    assert_eq!(unsafe { out.assume_init() }, sentinel);
 }
 
 #[test]
@@ -42,9 +67,12 @@ fn test_pairing_ergonomics_and_limits() {
     assert!(gt_owned.is_some());
 
     // Test Single Pairing Wrapper (In-Place)
-    let mut gt_out = GtElement([0u8; 576]);
+    let mut gt_out = MaybeUninit::uninit();
     let success = pairing_assign(&g1, &g2, &mut gt_out, Endianness::Little);
     assert!(success);
+
+    // SAFETY: `pairing_assign` returned `true`, so `gt_out` is initialized.
+    let gt_out = unsafe { gt_out.assume_init() };
     assert_eq!(gt_owned.unwrap().0, gt_out.0);
 
     // Test Max Pairing Limit (SIMD-0388 restricts batch to 8 pairs)
@@ -68,4 +96,14 @@ fn test_pairing_check_identity() {
         pairing_check(&[g1], &[g2], Endianness::Little).expect("Pairing execution failed");
 
     assert!(is_identity);
+}
+
+#[test]
+fn test_empty_batch_maps_to_identity() {
+    for endianness in [Endianness::Little, Endianness::Big] {
+        let gt = pairing_map(&[], &[], endianness).expect("empty batch must succeed");
+        assert_eq!(gt, GtElement::identity(endianness));
+
+        assert_eq!(pairing_check(&[], &[], endianness), Some(true));
+    }
 }

--- a/bls12-381/tests/bls12_381.rs
+++ b/bls12-381/tests/bls12_381.rs
@@ -1,0 +1,71 @@
+use solana_bls12_381::{
+    pairing, pairing_assign, pairing_check, Endianness, G1Point, G2Point, GtElement,
+};
+
+#[test]
+fn test_zero_copy_and_constructors() {
+    let raw_g1 = [0u8; 96];
+    let point_ref: &G1Point = bytemuck::cast_ref(&raw_g1);
+
+    // Verify it perfectly matches the owned 'from_bytes' constructor.
+    let point_owned = G1Point::from_bytes(raw_g1);
+    assert_eq!(point_ref, &point_owned);
+    assert_eq!(point_ref.to_bytes(), raw_g1);
+}
+
+#[test]
+fn test_checked_arithmetic_routing() {
+    // Generate valid infinity points for math operations.
+    let p1 = G1Point::infinity(Endianness::Little);
+    let p2 = G1Point::infinity(Endianness::Little);
+
+    // Test the returning safe wrapper.
+    let sum = p1.checked_add(&p2, Endianness::Little);
+    assert!(sum.is_some());
+
+    // Test the in-place safe wrapper to save CUs.
+    let mut out = G1Point::infinity(Endianness::Little);
+    let success = p1.checked_add_assign(&p2, &mut out, Endianness::Little);
+    assert!(success);
+
+    // Verify both methods yielded the exact same underlying bytes.
+    assert_eq!(sum.unwrap().to_bytes(), out.to_bytes());
+}
+
+#[test]
+fn test_pairing_ergonomics_and_limits() {
+    let g1 = G1Point::infinity(Endianness::Little);
+    let g2 = G2Point::infinity(Endianness::Little);
+
+    // Test Single Pairing Wrapper (Returning)
+    let gt_owned = pairing(&g1, &g2, Endianness::Little);
+    assert!(gt_owned.is_some());
+
+    // Test Single Pairing Wrapper (In-Place)
+    let mut gt_out = GtElement([0u8; 576]);
+    let success = pairing_assign(&g1, &g2, &mut gt_out, Endianness::Little);
+    assert!(success);
+    assert_eq!(gt_owned.unwrap().0, gt_out.0);
+
+    // Test Max Pairing Limit (SIMD-0388 restricts batch to 8 pairs)
+    let g1_batch_ok = vec![g1; 8];
+    let g2_batch_ok = vec![g2; 8];
+    assert!(pairing_check(&g1_batch_ok, &g2_batch_ok, Endianness::Little).is_some());
+
+    let g1_batch_fail = vec![g1; 9];
+    let g2_batch_fail = vec![g2; 9];
+    assert!(pairing_check(&g1_batch_fail, &g2_batch_fail, Endianness::Little).is_none());
+}
+
+#[test]
+fn test_pairing_check_identity() {
+    let g1 = G1Point::infinity(Endianness::Little);
+    let g2 = G2Point::infinity(Endianness::Little);
+
+    // Pairing two infinity points should result in the multiplicative identity.
+    // pairing_check safely evaluates this without exposing the GtElement.
+    let is_identity =
+        pairing_check(&[g1], &[g2], Endianness::Little).expect("Pairing execution failed");
+
+    assert!(is_identity);
+}

--- a/bls12-381/tests/bls12_381.rs
+++ b/bls12-381/tests/bls12_381.rs
@@ -14,18 +14,18 @@ fn test_zero_copy_and_constructors() {
 }
 
 #[test]
-fn test_checked_arithmetic_routing() {
+fn test_validated_arithmetic_routing() {
     // Generate valid infinity points for math operations.
     let p1 = G1Point::infinity(Endianness::Little);
     let p2 = G1Point::infinity(Endianness::Little);
 
     // Test the returning safe wrapper.
-    let sum = p1.checked_add(&p2, Endianness::Little);
+    let sum = p1.add(&p2, Endianness::Little);
     assert!(sum.is_some());
 
     // Test the in-place safe wrapper to save CUs.
     let mut out = G1Point::infinity(Endianness::Little);
-    let success = p1.checked_add_assign(&p2, &mut out, Endianness::Little);
+    let success = p1.add_assign(&p2, &mut out, Endianness::Little);
     assert!(success);
 
     // Verify both methods yielded the exact same underlying bytes.

--- a/scripts/check-no-std.sh
+++ b/scripts/check-no-std.sh
@@ -50,6 +50,7 @@ no_std_crates=(
 # These are only checked in the alloc+core pass, not the core-only pass.
 no_std_alloc_crates=(
   -p solana-account-info
+  -p solana-bls12-381
   -p solana-borsh
   -p solana-curve25519
   -p solana-instruction

--- a/scripts/patch-crates-functions.sh
+++ b/scripts/patch-crates-functions.sh
@@ -13,6 +13,7 @@ all_crate_dirs=(
   big-mod-exp
   bincode
   blake3-hasher
+  bls12-381
   bls-signatures
   bn254
   borsh


### PR DESCRIPTION
#### Problem

[SIMD-388](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0388-bls12-381-syscalls.md) is already activated on mb, but we don't yet have a library in the sdk that developers can use to easily invoke the syscall.

#### Summary of Changes

I added the `solana-bls12-381` library. I organized the library via structs (g1, g2, scalar, etc), which is different to how the `solana-bn254` library is organized where it is organized by syscall operations. I think organizing things by structs is more intuitive and inline with existing cryptographic libraries like dalek, blstrs, ark, etc.

There is a bit more work to be done on the testing side. This PR is already big, so I just added the sanity check tests. Let me add more comprehensive tests incrementally on follow-ups.