### PR TITLE
nonce: add frozen-abi traits to DurableNonce

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4034,6 +4034,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-fee-calculator",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
  "solana-hash",
  "solana-nonce",
  "solana-pubkey",

--- a/nonce/Cargo.toml
+++ b/nonce/Cargo.toml
@@ -30,11 +30,20 @@ wincode = [
     "solana-hash/wincode",
     "solana-pubkey/wincode",
 ]
+frozen-abi = [
+    "dep:solana-frozen-abi",
+    "dep:solana-frozen-abi-macro",
+    "solana-fee-calculator/frozen-abi",
+    "solana-hash/frozen-abi",
+    "solana-pubkey/frozen-abi",
+]
 
 [dependencies]
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 solana-fee-calculator = { workspace = true }
+solana-frozen-abi = { workspace = true, optional = true, features = ["frozen-abi"] }
+solana-frozen-abi-macro = { workspace = true, optional = true, features = ["frozen-abi"] }
 solana-hash = { workspace = true, features = ["copy", "decode"] }
 solana-pubkey = { workspace = true, default-features = false }
 solana-sha256-hasher = { workspace = true }
@@ -45,3 +54,6 @@ bincode = { workspace = true }
 solana-nonce = { path = ".", features = ["dev-context-only-utils", "wincode"] }
 solana-pubkey = { workspace = true, features = ["std"], default-features = false }
 solana-sha256-hasher = { workspace = true, features = ["sha2"] }
+
+[lints]
+workspace = true

--- a/nonce/src/lib.rs
+++ b/nonce/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 //! Durable transaction nonces.
 
 pub mod state;

--- a/nonce/src/state.rs
+++ b/nonce/src/state.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "serde")]
 use serde_derive::{Deserialize, Serialize};
+#[cfg(feature = "frozen-abi")]
+use solana_frozen_abi_macro::{AbiExample, StableAbi, StableAbiSample};
 #[cfg(feature = "wincode")]
 use wincode::{SchemaRead, SchemaWrite};
 use {
@@ -10,6 +12,7 @@ use {
 const DURABLE_NONCE_HASH_PREFIX: &[u8] = "DURABLE_NONCE".as_bytes();
 
 #[repr(transparent)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbiSample, StableAbi))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "wincode", derive(SchemaWrite, SchemaRead))]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -19,6 +22,7 @@ pub struct DurableNonce(Hash);
 ///
 /// This is stored within [`State`] for initialized nonce accounts.
 #[repr(C)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbiSample, StableAbi))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "wincode", derive(SchemaWrite, SchemaRead))]
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
@@ -73,6 +77,7 @@ impl DurableNonce {
 ///
 /// When created in memory with [`State::default`] or when deserialized from an
 /// uninitialized account, a nonce account will be [`State::Uninitialized`].
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbiSample, StableAbi))]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "wincode", derive(SchemaWrite, SchemaRead))]
 #[derive(Debug, Default, PartialEq, Eq, Clone)]

--- a/nonce/src/versions.rs
+++ b/nonce/src/versions.rs
@@ -1,5 +1,7 @@
 //! State for durable transaction nonces.
 
+#[cfg(feature = "frozen-abi")]
+use solana_frozen_abi_macro::{AbiExample, StableAbi, StableAbiSample};
 #[cfg(feature = "wincode")]
 use wincode::{SchemaRead, SchemaWrite};
 use {
@@ -9,6 +11,7 @@ use {
     std::collections::HashSet,
 };
 
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbiSample, StableAbi))]
 #[cfg_attr(
     feature = "serde",
     derive(serde_derive::Deserialize, serde_derive::Serialize)


### PR DESCRIPTION
to support https://github.com/anza-xyz/agave/issues/13909 id like to derive the abi traits for `DurableNonce` so that it can be (in a snapshot-format-safe manner) added to `BlockhashQueue`. my current idea is to not serialize/deserialize it, but to populate it from the deserialized `last_hash`. but to pass abi tests we need to either have these traits or hand-impl `AbiExample` for `BlockhashQueue`