### PR TITLE
[define-syscall] Add `curve_constants` module for curve syscall constants

### DIFF
--- a/define-syscall/src/curve_constants.rs
+++ b/define-syscall/src/curve_constants.rs
@@ -1,0 +1,44 @@
+//! Constants and identifiers for Solana elliptic curve sycalls.
+//!
+//! This module defines the unique identifiers for supported elliptic curves,
+//! encoding formats, and algebraic group operations. These constants are used
+//! to dispatch syscalls such as `sol_curve_group_op` and `sol_curve_pairing_map`.
+
+/// Curve ID for Curve25519 Edwards representation (compressed).
+pub const CURVE25519_EDWARDS: u64 = 0;
+
+/// Curve ID for Curve25519 Ristretto representation (compressed).
+pub const CURVE25519_RISTRETTO: u64 = 1;
+
+// Indices 2 and 3 are reserved.
+// These slots are set aside for potential future support of affine
+// representations of Curve25519 points.
+//
+// Reserved constants for reference:
+// pub const CURVE25519_EDWARDS_AFFINE_LE: u64 = 2;
+// pub const CURVE25519_EDWARDS_AFFINE_BE: u64 = 2 | 0x80;
+// pub const CURVE25519_RISTRETTO_AFFINE_LE: u64 = 3;
+// pub const CURVE25519_RISTRETTO_AFFINE_BE: u64 = 3 | 0x80;
+
+/// Curve ID for BLS12-381 pairing operations
+pub const BLS12_381_LE: u64 = 4;
+pub const BLS12_381_BE: u64 = 4 | 0x80;
+
+/// Curve ID for BLS12-381 G1 group operations
+pub const BLS12_381_G1_LE: u64 = 5;
+pub const BLS12_381_G1_BE: u64 = 5 | 0x80;
+
+/// Curve ID for BLS12-381 G2 group operations
+pub const BLS12_381_G2_LE: u64 = 6;
+pub const BLS12_381_G2_BE: u64 = 6 | 0x80;
+
+/// Curve ID for the SECP256R1 curve
+pub const SECP256R1_LE: u64 = 7;
+pub const SECP256R1_BE: u64 = 7 | 0x80;
+
+/// Group operation identifier for Addition (P1 + P2).
+pub const GROUP_OP_ADD: u64 = 0;
+/// Group operation identifier for Subtraction (P1 - P2).
+pub const GROUP_OP_SUB: u64 = 1;
+/// Group operation identifier for Scalar Multiplication (S * P).
+pub const GROUP_OP_MUL: u64 = 2;

--- a/define-syscall/src/lib.rs
+++ b/define-syscall/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+pub mod curve_constants;
 pub mod definitions;
 
 #[cfg(any(


### PR DESCRIPTION
#### Problem

The syscall functions associated with elliptic curves takes in a curve ID and perform operations based on it. Some examples of curve ID constants are [here](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0565-secp256r1-syscalls.md#new-curve-id-constants).

Currently, these constants live in various places:
- The curve25519 curve ID live in the `solana-curve25519` crate
- The BLS12-381 curve ID live in the `solana-syscall` crate.

It would be nice to have these constants in one place in the `solana-define-syscall` crate as they are syscall-related constants that are validator-client-independent.

#### Summary of Changes

I added a `curve_constants` module inside the `solana-define-syscall` crate and added the curve IDs there.

If there is a better place to host these constants, please let me know.