### PR TITLE
Add --levels flag to order-crates-for-publishing.py

### DIFF
--- a/scripts/order-crates-for-publishing.py
+++ b/scripts/order-crates-for-publishing.py
@@ -6,6 +6,22 @@
 #
 # On success an ordered list of Cargo.toml files is written to stdout
 #
+# With |--levels| each line is prefixed with the publishing "level" the crate
+# belongs to (|<level>\t<path>|). Crates sharing a level are independent of each
+# other and depend only on earlier levels, so a whole level can be published in
+# parallel once all earlier levels are published.
+#
+# Filtering to a subset of crates is left to standard tools. For example, to
+# group only the crates whose Cargo.toml mentions "wincode" into levels (the
+# leading tab pins the match to the path field so e.g. "sysvar" doesn't also
+# match "get-sysvar"):
+#
+#   ./scripts/order-crates-for-publishing.py --levels \
+#     | grep -Ff <(grep -l wincode $(./scripts/order-crates-for-publishing.py) | sed 's/^/\t/')
+#
+# Level numbers stay workspace-global (so a filtered view has gaps); to act per
+# level, group the output by its first column.
+#
 
 import os
 import json
@@ -125,8 +141,14 @@ def get_packages():
     if len(circular_dependencies) != 0 or len(wrong_self_dev_dependencies) != 0:
         sys.exit(1)
 
-    # Order dependencies
+    # Order dependencies.
+    #
+    # Each pass of the loop below removes every package whose dependencies have
+    # all already been removed. Such a batch forms a publishing "level": its
+    # members are mutually independent, so they can be published in parallel,
+    # and every level depends only on packages published in earlier levels.
     sorted_dependency_graph = []
+    level = 0
     max_iterations = pow(len(dependency_graph),2)
     while dependency_graph:
         deleted_packages = []
@@ -144,12 +166,23 @@ def get_packages():
                     break
             else:
                 deleted_packages.append(package)
-                sorted_dependency_graph.append((package, manifest_path[package]))
+                sorted_dependency_graph.append((package, manifest_path[package], level))
 
         dependency_graph = {p: d for p, d in dependency_graph.items() if not p in deleted_packages }
+        level += 1
 
 
     return sorted_dependency_graph
 
-for package, manifest in get_packages():
-    print(os.path.relpath(manifest))
+def main():
+    # `--levels` prefixes each line with the publishing level the crate belongs
+    # to (`<level>\t<path>`). Crates sharing a level are independent of each
+    # other and can be published in parallel once all earlier levels are
+    # published.
+    show_levels = '--levels' in sys.argv[1:]
+    for package, manifest, level in get_packages():
+        path = os.path.relpath(manifest)
+        print('{}\t{}'.format(level, path) if show_levels else path)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
#### Problem
The topological sort already removes packages in batches: each pass of the ordering loop drops every package whose dependencies have all been removed, so a batch is a set of mutually independent crates. This information isn't however exposed to the user of the script.

#### Summary of Changes
Record the batch number as a publishing "level".

Crates sharing a level are independent of each other and depend only on crates in earlier levels, so each level can be published in parallel once all earlier levels land.

The new --levels flag prints "<level>\t<path>"; without it the output is unchanged, so existing callers (including CI) are unaffected. The header comment documents the flag and a grep-based one-liner for grouping a subset of crates (e.g. those using wincode) into levels.
