### PR TITLE
feat(account): add wincode serialization with separate StateMutWincode trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3159,6 +3159,7 @@ dependencies = [
  "solana-instruction-error",
  "solana-pubkey",
  "solana-sdk-ids",
+ "solana-system-interface",
  "solana-sysvar",
  "wincode",
 ]

--- a/account/Cargo.toml
+++ b/account/Cargo.toml
@@ -44,3 +44,4 @@ wincode = { workspace = true, features = ["alloc"], optional = true }
 [dev-dependencies]
 solana-account = { path = ".", features = ["dev-context-only-utils"] }
 solana-pubkey = { workspace = true, features = ["std"] }
+solana-system-interface = { workspace = true }

--- a/account/Cargo.toml
+++ b/account/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--cfg=docsrs"]
 [features]
 bincode = ["dep:bincode", "dep:solana-sysvar", "serde"]
 wincode = ["dep:wincode", "solana-pubkey/wincode"]
-dev-context-only-utils = ["bincode", "dep:qualifier_attr"]
+dev-context-only-utils = ["bincode", "wincode", "dep:qualifier_attr"]
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",

--- a/account/src/account.rs
+++ b/account/src/account.rs
@@ -17,6 +17,10 @@ mod bincode;
 #[cfg(feature = "bincode")]
 pub use bincode::*;
 
+// NOTE: the wincode codec surface is not a peer of the bincode module above. Instead of
+// duplicating the inherent `new_data`/`serialize_data`/... methods, wincode is exposed
+// solely through the `state_traits::StateMutWincode` trait (read, write, and construct).
+
 // NOTE: `Account` and `AccountSharedData` are defined in the crate root (`lib.rs`)
 // rather than here. The frozen-abi digest of any downstream struct that holds an
 // `Account`/`AccountSharedData` field hashes that field's fully-qualified
@@ -229,6 +233,18 @@ impl Account {
         Account {
             lamports,
             data: vec![0; space],
+            owner: *owner,
+            executable: false,
+            rent_epoch: Epoch::default(),
+        }
+    }
+    /// Construct an `Account` from already-encoded `data`, taking ownership of the
+    /// buffer. Avoids the zero-fill allocation of [`Account::new`] followed by a
+    /// separate write when the caller already has the bytes.
+    pub fn new_with_data(lamports: u64, data: Vec<u8>, owner: &Pubkey) -> Self {
+        Account {
+            lamports,
+            data,
             owner: *owner,
             executable: false,
             rent_epoch: Epoch::default(),

--- a/account/src/lib.rs
+++ b/account/src/lib.rs
@@ -17,10 +17,16 @@ pub mod state_traits;
 
 // wincode config used by the `state_traits::wincode` trait. The wire format matches
 // bincode byte-for-byte; the only deliberate difference is raising the preallocation
-// guard to 10 MiB (Solana's max account data length) so valid accounts are never
-// rejected. This gates only the prealloc check, not the encoded bytes.
+// guard to the max account data length so valid accounts are never rejected. This gates
+// only the prealloc check, not the encoded bytes.
+//
+// Mirrors `solana_system_interface::MAX_PERMITTED_DATA_LENGTH` (kept in sync by the
+// assertion below) so `solana-system-interface` stays a dev-only dependency.
 #[cfg(feature = "wincode")]
 const WINCODE_PREALLOC_LIMIT: usize = 10 * 1024 * 1024;
+#[cfg(all(test, feature = "wincode"))]
+const _: () =
+    assert!(WINCODE_PREALLOC_LIMIT as u64 == solana_system_interface::MAX_PERMITTED_DATA_LENGTH);
 #[cfg(feature = "wincode")]
 pub(crate) type WincodeConfig = wincode::config::Configuration<true, WINCODE_PREALLOC_LIMIT>;
 #[cfg(feature = "wincode")]

--- a/account/src/lib.rs
+++ b/account/src/lib.rs
@@ -12,8 +12,21 @@ pub use account::*;
 #[cfg(feature = "serde")]
 mod serde;
 
-#[cfg(feature = "bincode")]
+#[cfg(any(feature = "bincode", feature = "wincode"))]
 pub mod state_traits;
+
+// wincode config used by the `state_traits::wincode` trait. The wire format matches
+// bincode byte-for-byte; the only deliberate difference is raising the preallocation
+// guard to 10 MiB (Solana's max account data length) so valid accounts are never
+// rejected. This gates only the prealloc check, not the encoded bytes.
+#[cfg(feature = "wincode")]
+const WINCODE_PREALLOC_LIMIT: usize = 10 * 1024 * 1024;
+#[cfg(feature = "wincode")]
+pub(crate) type WincodeConfig = wincode::config::Configuration<true, WINCODE_PREALLOC_LIMIT>;
+#[cfg(feature = "wincode")]
+pub(crate) const WINCODE_CONFIG: WincodeConfig = wincode::config::Configuration::default()
+    .with_preallocation_size_limit::<WINCODE_PREALLOC_LIMIT>(
+);
 
 // NOTE: `Account` and `AccountSharedData` are defined here, in the crate root, on
 // purpose. The frozen-abi digest of any downstream struct that has an

--- a/account/src/state_traits.rs
+++ b/account/src/state_traits.rs
@@ -4,6 +4,12 @@ use solana_instruction_error::InstructionError;
 
 #[cfg(feature = "bincode")]
 mod bincode;
+#[cfg(feature = "wincode")]
+mod wincode;
+// wincode uses its own trait (rather than `StateMut`/`State`) so the bincode and
+// wincode implementations can coexist when both features are enabled.
+#[cfg(feature = "wincode")]
+pub use wincode::*;
 
 /// Convenience trait to covert serialization errors to instruction errors.
 pub trait StateMut<T> {

--- a/account/src/state_traits/wincode.rs
+++ b/account/src/state_traits/wincode.rs
@@ -1,0 +1,193 @@
+//! wincode-based state trait for the account types.
+//!
+//! wincode gets its own [`StateMutWincode`] trait rather than reusing
+//! [`StateMut`](crate::state_traits::StateMut), so the bincode and wincode
+//! implementations can coexist when both features are enabled. It is the crate's
+//! entire wincode codec surface: reading (`state`), in-place writing (`set_state`),
+//! and construction (`new_data`/`new_data_with_space`).
+
+use {
+    crate::{
+        Account, AccountSharedData, ReadableAccount, WincodeConfig, WritableAccount, WINCODE_CONFIG,
+    },
+    solana_instruction_error::InstructionError,
+    solana_pubkey::Pubkey,
+    wincode::{SchemaRead, SchemaWrite, WriteResult},
+};
+
+/// wincode counterpart of [`StateMut`](crate::state_traits::StateMut) that also
+/// constructs accounts whose data is wincode-encoded.
+pub trait StateMutWincode<T>: Sized {
+    fn state(&self) -> Result<T, InstructionError>;
+    fn set_state(&mut self, state: &T) -> Result<(), InstructionError>;
+
+    /// Create an account sized to the wincode-serialized length of `state`.
+    fn new_data(lamports: u64, state: &T, owner: &Pubkey) -> WriteResult<Self>;
+
+    /// Create an account of `space` bytes with `state` serialized into the front and
+    /// the remainder zero-padded; fails with `WriteSizeLimit` if `state` does not fit.
+    fn new_data_with_space(
+        lamports: u64,
+        state: &T,
+        space: usize,
+        owner: &Pubkey,
+    ) -> WriteResult<Self>;
+}
+
+impl<T> StateMutWincode<T> for Account
+where
+    T: SchemaWrite<WincodeConfig, Src = T> + for<'de> SchemaRead<'de, WincodeConfig, Dst = T>,
+{
+    fn state(&self) -> Result<T, InstructionError> {
+        deserialize_state(self)
+    }
+    fn set_state(&mut self, state: &T) -> Result<(), InstructionError> {
+        serialize_state(self, state)
+    }
+    fn new_data(lamports: u64, state: &T, owner: &Pubkey) -> WriteResult<Self> {
+        let data = wincode::config::serialize(state, WINCODE_CONFIG)?;
+        Ok(Account::new_with_data(lamports, data, owner))
+    }
+    fn new_data_with_space(
+        lamports: u64,
+        state: &T,
+        space: usize,
+        owner: &Pubkey,
+    ) -> WriteResult<Self> {
+        let mut data = serialize_bounded(state, space)?;
+        data.resize(space, 0);
+        Ok(Account::new_with_data(lamports, data, owner))
+    }
+}
+
+impl<T> StateMutWincode<T> for AccountSharedData
+where
+    T: SchemaWrite<WincodeConfig, Src = T> + for<'de> SchemaRead<'de, WincodeConfig, Dst = T>,
+{
+    fn state(&self) -> Result<T, InstructionError> {
+        deserialize_state(self)
+    }
+    fn set_state(&mut self, state: &T) -> Result<(), InstructionError> {
+        serialize_state(self, state)
+    }
+    fn new_data(lamports: u64, state: &T, owner: &Pubkey) -> WriteResult<Self> {
+        <Account as StateMutWincode<T>>::new_data(lamports, state, owner)
+            .map(AccountSharedData::from)
+    }
+    fn new_data_with_space(
+        lamports: u64,
+        state: &T,
+        space: usize,
+        owner: &Pubkey,
+    ) -> WriteResult<Self> {
+        <Account as StateMutWincode<T>>::new_data_with_space(lamports, state, space, owner)
+            .map(AccountSharedData::from)
+    }
+}
+
+fn deserialize_state<T, U>(account: &U) -> Result<T, InstructionError>
+where
+    T: for<'de> SchemaRead<'de, WincodeConfig, Dst = T>,
+    U: ReadableAccount,
+{
+    wincode::config::deserialize(account.data(), WINCODE_CONFIG)
+        .map_err(|_| InstructionError::InvalidAccountData)
+}
+
+fn serialize_state<T, U>(account: &mut U, state: &T) -> Result<(), InstructionError>
+where
+    T: SchemaWrite<WincodeConfig, Src = T>,
+    U: WritableAccount,
+{
+    // The bounded slice writer fails with `WriteSizeLimit` when the value is too large
+    // for the account data, so no `serialized_size` pre-check is needed.
+    wincode::config::serialize_into(account.data_as_mut_slice(), state, WINCODE_CONFIG).map_err(
+        |err| match err {
+            wincode::WriteError::Io(wincode::io::WriteError::WriteSizeLimit(_)) => {
+                InstructionError::AccountDataTooSmall
+            }
+            _ => InstructionError::GenericError,
+        },
+    )
+}
+
+/// wincode-serialize `state` into a freshly allocated buffer capped at `limit` bytes,
+/// returning the exact-length encoded bytes or `WriteSizeLimit` if it does not fit.
+///
+/// Avoids both zero-filling bytes that are immediately overwritten and a separate
+/// `serialized_size` pass to enforce `limit`.
+fn serialize_bounded<T>(state: &T, limit: usize) -> WriteResult<Vec<u8>>
+where
+    T: SchemaWrite<WincodeConfig, Src = T>,
+{
+    let mut data = Vec::with_capacity(limit);
+    let mut uninit = &mut data.spare_capacity_mut()[..limit];
+    <T as SchemaWrite<WincodeConfig>>::write(&mut uninit, state)?;
+    // `write` only reslices `uninit` to a suffix of the original `limit`-length slice, so
+    // `uninit.len() <= limit` always holds and this never actually wraps.
+    let written = limit.wrapping_sub(uninit.len());
+    // SAFETY: `write` initialized exactly `written` bytes at the front of the buffer
+    // (advancing `uninit` past them), and `written <= limit == capacity`.
+    unsafe { data.set_len(written) };
+    Ok(data)
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::{StateMutWincode as StateMut, *},
+        solana_pubkey::Pubkey,
+    };
+
+    // Mirrors `state_traits::bincode`'s `test_account_state`, through the wincode trait.
+    #[test]
+    fn test_account_state() {
+        let state = 42u64;
+
+        assert!(AccountSharedData::default().set_state(&state).is_err());
+        let res = AccountSharedData::default().state() as Result<u64, InstructionError>;
+        assert!(res.is_err());
+
+        let mut account = AccountSharedData::new(0, std::mem::size_of::<u64>(), &Pubkey::default());
+        assert!(account.set_state(&state).is_ok());
+        let stored_state: u64 = account.state().unwrap();
+        assert_eq!(stored_state, state);
+    }
+
+    #[test]
+    fn test_new_data() {
+        let state = 42u64;
+        let owner = Pubkey::new_unique();
+
+        let account = <AccountSharedData as StateMut<u64>>::new_data(1, &state, &owner).unwrap();
+        assert_eq!(account.lamports(), 1);
+        assert_eq!(account.owner(), &owner);
+        assert_eq!(account.data().len(), std::mem::size_of::<u64>());
+        let stored: u64 = account.state().unwrap();
+        assert_eq!(stored, state);
+    }
+
+    #[test]
+    fn test_new_data_with_space() {
+        let state = 42u64;
+        let owner = Pubkey::new_unique();
+        let size = std::mem::size_of::<u64>();
+
+        // extra space is zero-padded, and the value still reads back
+        let account =
+            <AccountSharedData as StateMut<u64>>::new_data_with_space(1, &state, size + 4, &owner)
+                .unwrap();
+        assert_eq!(account.data().len(), size + 4);
+        let stored: u64 = account.state().unwrap();
+        assert_eq!(stored, state);
+
+        // a value that does not fit `space` fails
+        assert!(<AccountSharedData as StateMut<u64>>::new_data_with_space(
+            1,
+            &state,
+            size - 1,
+            &owner,
+        )
+        .is_err());
+    }
+}


### PR DESCRIPTION
#### Problem
Many `Account` functions rely on `SysvarSerialize` and bincode, we want to switch over from both to wincode / direct management of sysvar serialization and sizing.

#### Summary of Changes
Adds wincode-based (de)serialization for `Account`/`AccountSharedData` state, alongside bincode. The wire format matches bincode byte-for-byte; the only deliberate difference is raising the preallocation guard to 10 MiB (Solana's max account data length) so valid accounts are never rejected.

The whole wincode codec surface is a single `StateMutWincode<T>` trait: read (`state`), in-place write (`set_state`), and construction (`new_data` / `new_data_with_space`, as `Self`-returning associated fns). It is deliberately a
separate trait from the bincode `StateMut` so the two coexist when both features are enabled. Keeping construction on the trait lets a consumer migrating to wincode keep its `Type::new_data(..)` / `account.state()` call syntax — only the
trait import changes.

`set_state` and construction serialize into uninitialized capacity bounded to the target size, avoiding the allocate-zero-then-overwrite pattern and a redundant `serialized_size` pass.
