### PR TITLE
fix: SanitizedMessage::get_durable_nonce static account only

### DIFF
--- a/message/src/sanitized.rs
+++ b/message/src/sanitized.rs
@@ -347,7 +347,7 @@ impl SanitizedMessage {
                     if !self.is_writable(idx) {
                         None
                     } else {
-                        self.account_keys().get(idx)
+                        self.static_account_keys().get(idx)
                     }
                 })
             })

--- a/svm-transaction/src/tests.rs
+++ b/svm-transaction/src/tests.rs
@@ -243,7 +243,7 @@ fn test_get_durable_nonce() {
                 readonly: vec![],
             }),
         );
-        assert_eq!(SanitizedMessage::get_durable_nonce(&message), Some(&nonce));
+        assert_eq!(SanitizedMessage::get_durable_nonce(&message), None);
         assert_eq!(SVMMessage::get_durable_nonce(&message), None);
     }
 }


### PR DESCRIPTION
### Problem
- `SanitizedMessage::get_durable_nonce` is in inconsistent with `SVMMessage::get_durable_nonce` since we have activated `7VVhpg5oAjAmnmz1zCcSHb2Z9ecZB2FQqpnEwReka9Zm`
	- specifically it still returns Some for non-static acct index
	- this is only used in rpc in agave 

### Summary of Changes
- Only return Some if the nonce acct is a static acct index