### PR TITLE
message: enforce transaction size limit in V1 deserialize

### DIFF
--- a/message/src/versions/v1/message.rs
+++ b/message/src/versions/v1/message.rs
@@ -60,7 +60,7 @@ use {
         compiled_keys::CompiledKeys,
         v1::{
             MessageError, TransactionConfig, TransactionConfigMask, MAX_ADDRESSES, MAX_HEAP_SIZE,
-            MAX_INSTRUCTIONS, MAX_SIGNATURES, MIN_HEAP_SIZE,
+            MAX_INSTRUCTIONS, MAX_SIGNATURES, MAX_TRANSACTION_SIZE, MIN_HEAP_SIZE,
         },
         AccountKeys, AddressSet, CompileError, MessageHeader,
     },
@@ -732,12 +732,18 @@ unsafe impl<'de, C: Config> SchemaRead<'de, C> for Message {
     }
 }
 
-/// Deserialize the message from the provided input buffer, returning the message and
-/// the number of bytes read.
+/// Deserialize a message from the provided input buffer.
+///
+/// Bounds preallocation to `MAX_TRANSACTION_SIZE` and rejects trailing bytes, so an
+/// oversized or padded buffer is refused instead of allocating for it.
 #[cfg(feature = "wincode")]
 #[inline]
 pub fn deserialize(input: &[u8]) -> wincode::ReadResult<Message> {
-    wincode::deserialize(input)
+    wincode::config::deserialize_exact(
+        input,
+        wincode::config::DefaultConfig::default()
+            .with_preallocation_size_limit::<MAX_TRANSACTION_SIZE>(),
+    )
 }
 
 #[cfg(test)]
@@ -1280,6 +1286,54 @@ mod tests {
         for message in &test_cases {
             assert_eq!(message.size(), wincode::serialize(message).unwrap().len());
         }
+    }
+
+    #[test]
+    fn deserialize_rejects_oversized_message() {
+        // `validate` bounds counts and indices but not total size, so wincode's 4 MiB
+        // default deserializes an over-limit message. `deserialize` pins the preallocation
+        // limit to `MAX_TRANSACTION_SIZE`, so the same bytes are refused before allocating.
+        const OVERSIZED_DATA_LEN: usize = MAX_TRANSACTION_SIZE + 1;
+        let message = MessageBuilder::new()
+            .required_signatures(1)
+            .lifetime_specifier(Hash::new_from_array([0u8; 32]))
+            .accounts(vec![
+                Address::new_from_array([1u8; 32]),
+                Address::new_from_array([2u8; 32]),
+            ])
+            .instruction(CompiledInstruction {
+                program_id_index: 1,
+                accounts: vec![0],
+                data: vec![0u8; OVERSIZED_DATA_LEN],
+            })
+            .build()
+            .unwrap();
+
+        let bytes = wincode::serialize(&message).unwrap();
+        assert!(deserialize(&bytes).is_err());
+        // The default-config path still accepts it, confirming the gap the limit closes.
+        assert!(wincode::deserialize::<Message>(&bytes).is_ok());
+    }
+
+    #[test]
+    fn deserialize_accepts_valid_message() {
+        let message = MessageBuilder::new()
+            .required_signatures(1)
+            .lifetime_specifier(Hash::new_from_array([0u8; 32]))
+            .accounts(vec![
+                Address::new_from_array([1u8; 32]),
+                Address::new_from_array([2u8; 32]),
+            ])
+            .instruction(CompiledInstruction {
+                program_id_index: 1,
+                accounts: vec![0],
+                data: vec![0xAB; 32],
+            })
+            .build()
+            .unwrap();
+
+        let bytes = wincode::serialize(&message).unwrap();
+        assert_eq!(deserialize(&bytes).unwrap(), message);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`v1::Message::deserialize` deserializes with wincode's default config, which permits preallocations up to 4 MiB and ignores trailing bytes. So the documented `MAX_TRANSACTION_SIZE` (`message/src/versions/v1/mod.rs`) is never enforced and the constant is unused outside tests. A buffer that declares an oversized instruction is allocated for before any check runs, and `sanitize()` bounds counts and indices but never total size (#831 has a message that passes `sanitize()` at roughly 4 MiB).

## Change

Bound preallocation to `MAX_TRANSACTION_SIZE` and reject trailing bytes with `deserialize_exact`:

```rust
pub fn deserialize(input: &[u8]) -> wincode::ReadResult<Message> {
    wincode::config::deserialize_exact(
        input,
        wincode::config::DefaultConfig::default()
            .with_preallocation_size_limit::<MAX_TRANSACTION_SIZE>(),
    )
}
```

Same two-part pattern agave uses for repair requests (`deserialize_exact` plus a config whose preallocation limit is the size cap). It also wires the previously dead `MAX_TRANSACTION_SIZE`.

This is hardening of the public `deserialize` helper, not a fix for a live remote DoS: agave already caps before the deserializer (RPC at `MAX_TRANSACTION_SIZE`, TPU/QUIC at `PACKET_DATA_SIZE`), and V1's length prefixes are `u8`/`u16` so there is no small-input preallocation amplification. The value is a self-defending public API for callers that decode untrusted bytes without pre-capping, plus strict framing.

One open point: the generic `VersionedMessage`/`VersionedTransaction` paths still decode with the default config, and a test there intentionally accepts an over-max transaction. I left those permissive since agave caps at ingress, but can thread the limit through them too if you'd prefer.

## Testing

`cargo test -p solana-message --features "wincode,serde"` passes (125 tests), including two new ones: an oversized message is rejected while the default-config `wincode::deserialize` still accepts it, and a valid message round-trips.

Addresses #831.
