### PR TITLE
Bump solana-address to 2.7.0 and solana-slot-hashes to 3.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "solana-address"
-version = "2.6.1"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4639,7 +4639,7 @@ dependencies = [
 
 [[package]]
 name = "solana-slot-hashes"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,7 +231,7 @@ siphasher = "0.3.11"
 solana-account = { path = "account", version = "4.3.1" }
 solana-account-info = { path = "account-info", version = "3.0.0" }
 solana-account-view = { path = "account-view", version = "2.0.0" }
-solana-address = { path = "address", version = "2.6.1" }
+solana-address = { path = "address", version = "2.7.0" }
 solana-address-lookup-table-interface = { path = "address-lookup-table-interface", version = "3.1.0" }
 solana-atomic-u64 = { path = "atomic-u64", version = "3.0.0" }
 solana-big-mod-exp = { path = "big-mod-exp", version = "4.0.0" }
@@ -323,7 +323,7 @@ solana-shred-version = { path = "shred-version", version = "3.0.0" }
 solana-signature = { path = "signature", version = "3.4.1", default-features = false }
 solana-signer = { path = "signer", version = "3.0.1", default-features = false }
 solana-signer-store = { path = "signer-store", version = "0.1.0" }
-solana-slot-hashes = { path = "slot-hashes", version = "3.1.0" }
+solana-slot-hashes = { path = "slot-hashes", version = "3.2.0" }
 solana-slot-history = { path = "slot-history", version = "3.2.0" }
 solana-stable-layout = { path = "stable-layout", version = "3.0.0" }
 solana-stake-history = { path = "stake-history", version = "1.0.0" }

--- a/address/Cargo.toml
+++ b/address/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-address"
 description = "Solana account addresses"
 documentation = "https://docs.rs/solana-address"
-version = "2.6.1"
+version = "2.7.0"
 rust-version = { workspace = true }
 authors = { workspace = true }
 repository = { workspace = true }

--- a/slot-hashes/Cargo.toml
+++ b/slot-hashes/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-slot-hashes"
 description = "Types and utilities for the Solana SlotHashes sysvar."
 documentation = "https://docs.rs/solana-slot-hashes"
-version = "3.1.0"
+version = "3.2.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }


### PR DESCRIPTION
#### Problem
Manifests were not updated due to stale checkout during publish

#### Summary of Changes
Bump crates' manifests and main Cargo.toml file

#### Testing
CI