### PR TITLE
Bump bytemuck and bytemuck_derive versions to 1.25 and 1.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,18 +618,18 @@ checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.10.2"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,8 +164,8 @@ borsh = { version = "1.5.5", default-features = false, features = ["derive", "un
 boxcar = "0.2.12"
 bs58 = { version = "0.5.1", default-features = false }
 bv = "0.11.1"
-bytemuck = "1.21.0"
-bytemuck_derive = "1.8.1"
+bytemuck = "1.25.2"
+bytemuck_derive = "1.11.0"
 bytes = "1.10.0"
 cfg_eval = "0.1.2"
 chrono = { version = "0.4.39", default-features = false }


### PR DESCRIPTION
#### Problem

There are some minimal version issue for `bytemuck` and `bytemuck_derive` crates as I was adding the syscall library for bls12-381 (https://github.com/anza-xyz/solana-sdk/pull/829).

The [cryptography](https://github.com/anza-xyz/cryptography) repo specifies  `bytemuck` v1.25 and `bytemuck_derive` v1.10` as the minimum versions while the solana-sdk is still on v1.21 and v1.8 respectively.

#### Summary of Changes

I bumped the `bytemuck` and `bytemuck_derive` versions in the solana-sdk. 

I looked at the change logs for [bytemuck](https://github.com/Lokathor/bytemuck/blob/main/changelog.md) and [bytemuck_derive](https://github.com/Lokathor/bytemuck/blob/main/derive/changelog.md) and it seems like the version bumps are minor updates that don't directly impact crates in the sdk. But if there are reasons we don't want to make this upgrade, then let me know and I can figure another way to resolve the CI in https://github.com/anza-xyz/solana-sdk/pull/829.