### PR TITLE
Reorder publish steps to first push tag and then publish to crates.io

### DIFF
--- a/scripts/publish-rust.sh
+++ b/scripts/publish-rust.sh
@@ -28,15 +28,14 @@ old_version=$(readCargoVariable version "Cargo.toml")
 package_name=$(readCargoVariable name "Cargo.toml")
 tag_name="${package_name//solana-/}"
 
-# Publish the new version and commit + tag the repo change locally.
-# The push is deliberately deferred (--no-push) so it can be retried against a
-# freshly synced master below; a concurrent publish of another crate may move
-# master forward between our rebase and our push, which would otherwise reject
-# the push non-fast-forward *after* the crate is already live on crates.io.
+# Publishing to crates.io is irreversible, so it is done last. If the tag push
+# loses a race with a concurrent release, the run fails before anything is
+# published and can simply be re-run; the worst residual state is a tag without
+# a crate, recoverable by re-publishing.
 if [[ -n ${DRY_RUN} ]]; then
   cargo release "${LEVEL}"
 else
-  cargo release "${LEVEL}" --tag-name "${tag_name}@v{{version}}" --no-confirm --execute --no-push --dependent-version "${DEPENDENT_VERSION}"
+  cargo release "${LEVEL}" --tag-name "${tag_name}@v{{version}}" --no-confirm --execute --no-publish --no-push --dependent-version "${DEPENDENT_VERSION}"
 fi
 
 # Stop here if this is a dry run.
@@ -49,24 +48,17 @@ new_version=$(readCargoVariable version "Cargo.toml")
 new_git_tag="${tag_name}@v${new_version}"
 old_git_tag="${tag_name}@v${old_version}"
 
-# The crate is already on crates.io; all that remains is landing the version
-# bump commit + tag in git. Retry the push, rebasing onto the latest master
-# between attempts so concurrent publishes of other crates don't fail us.
+# Verify the crate builds before we tag and publish it.
+cargo package
+
+# Push the tag first; a concurrent-release race is rejected non-fast-forward and
+# stops us here, before publishing.
 branch=$(git rev-parse --abbrev-ref HEAD)
-attempts=5
-for ((attempt = 1; attempt <= attempts; attempt++)); do
-  if git push --atomic origin "HEAD:${branch}" "refs/tags/${new_git_tag}"; then
-    break
-  fi
-  if [[ $attempt -eq $attempts ]]; then
-    echo "Failed to push ${branch} and tag ${new_git_tag} after ${attempts} attempts" >&2
-    exit 1
-  fi
-  echo "Push rejected (attempt ${attempt}/${attempts}); rebasing onto origin/${branch} and retrying"
-  git pull --rebase origin "${branch}"
-  # Re-point the tag onto the rebased commit so it stays on master's history.
-  git tag -f "${new_git_tag}" HEAD
-done
+git push --atomic origin "HEAD:${branch}" "refs/tags/${new_git_tag}"
+
+# Publish last, now that the tag is on master. cargo package already verified
+# this tree, so skip the redundant verify build.
+cargo publish --no-verify
 
 # Expose the new version to CI if needed.
 if [[ -n $CI ]]; then

--- a/scripts/publish-rust.sh
+++ b/scripts/publish-rust.sh
@@ -28,11 +28,15 @@ old_version=$(readCargoVariable version "Cargo.toml")
 package_name=$(readCargoVariable name "Cargo.toml")
 tag_name="${package_name//solana-/}"
 
-# Publish the new version, commit the repo change, tag it, and push it all.
+# Publish the new version and commit + tag the repo change locally.
+# The push is deliberately deferred (--no-push) so it can be retried against a
+# freshly synced master below; a concurrent publish of another crate may move
+# master forward between our rebase and our push, which would otherwise reject
+# the push non-fast-forward *after* the crate is already live on crates.io.
 if [[ -n ${DRY_RUN} ]]; then
   cargo release "${LEVEL}"
 else
-  cargo release "${LEVEL}" --tag-name "${tag_name}@v{{version}}" --no-confirm --execute --dependent-version "${DEPENDENT_VERSION}"
+  cargo release "${LEVEL}" --tag-name "${tag_name}@v{{version}}" --no-confirm --execute --no-push --dependent-version "${DEPENDENT_VERSION}"
 fi
 
 # Stop here if this is a dry run.
@@ -44,6 +48,25 @@ fi
 new_version=$(readCargoVariable version "Cargo.toml")
 new_git_tag="${tag_name}@v${new_version}"
 old_git_tag="${tag_name}@v${old_version}"
+
+# The crate is already on crates.io; all that remains is landing the version
+# bump commit + tag in git. Retry the push, rebasing onto the latest master
+# between attempts so concurrent publishes of other crates don't fail us.
+branch=$(git rev-parse --abbrev-ref HEAD)
+attempts=5
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+  if git push --atomic origin "HEAD:${branch}" "refs/tags/${new_git_tag}"; then
+    break
+  fi
+  if [[ $attempt -eq $attempts ]]; then
+    echo "Failed to push ${branch} and tag ${new_git_tag} after ${attempts} attempts" >&2
+    exit 1
+  fi
+  echo "Push rejected (attempt ${attempt}/${attempts}); rebasing onto origin/${branch} and retrying"
+  git pull --rebase origin "${branch}"
+  # Re-point the tag onto the rebased commit so it stays on master's history.
+  git tag -f "${new_git_tag}" HEAD
+done
 
 # Expose the new version to CI if needed.
 if [[ -n $CI ]]; then


### PR DESCRIPTION
#### Problem
`cargo release` publishes to crates.io and then pushes the version-bump commit + tag in a single non-atomic step, with no rebase/retry if that push is rejected non-fast-forward. When another release (or any commit) lands on `master` in that window, the crate ends up published on crates.io while its git commit and tag fail to push, leaving the repo inconsistent.

#### Summary of Changes
- Add `--no-push` to the `cargo release` call, so publishing + the local commit/tag still happen, but the git push is separated out.
- After release, push the branch and tag with `git push --atomic` in a retry loop (up to 5 attempts). On rejection, `git pull --rebase origin <branch>`, re-point the tag onto the rebased commit with `git tag -f`, and retry. Exit non-zero if all attempts are exhausted.
