### PR TITLE
[poseidon] Use no-std when `target_os = "solana"` or `target_arch = "bpf"`

### DIFF
--- a/poseidon/Cargo.toml
+++ b/poseidon/Cargo.toml
@@ -17,12 +17,12 @@ rustdoc-args = ["--cfg=docsrs"]
 [dependencies]
 thiserror = { workspace = true }
 
-[target.'cfg(not(target_os = "solana"))'.dependencies]
+[target.'cfg(any(target_os = "solana", target_arch = "bpf"))'.dependencies]
+solana-define-syscall = { workspace = true }
+
+[target.'cfg(not(any(target_os = "solana", target_arch = "bpf")))'.dependencies]
 ark-bn254 = { workspace = true }
 light-poseidon = { workspace = true }
-
-[target.'cfg(target_os = "solana")'.dependencies]
-solana-define-syscall = { workspace = true }
 
 [lints]
 workspace = true

--- a/poseidon/src/lib.rs
+++ b/poseidon/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(target_os = "solana", no_std)]
+#![cfg_attr(any(target_os = "solana", target_arch = "bpf"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 //! Hashing with the [Poseidon] hash function.
 //!
@@ -171,7 +171,7 @@ impl PoseidonHash {
     }
 }
 
-#[cfg(target_os = "solana")]
+#[cfg(any(target_os = "solana", target_arch = "bpf"))]
 pub use solana_define_syscall::definitions::sol_poseidon;
 
 /// Return a Poseidon hash for the given data with the given elliptic curve and
@@ -215,7 +215,7 @@ pub fn hashv(
 ) -> Result<PoseidonHash, PoseidonSyscallError> {
     // Perform the calculation inline, calling this from within a program is
     // not supported.
-    #[cfg(not(target_os = "solana"))]
+    #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
     {
         use {
             ark_bn254::Fr,
@@ -260,7 +260,7 @@ pub fn hashv(
         Ok(PoseidonHash(res))
     }
     // Call via a system call to perform the calculation.
-    #[cfg(target_os = "solana")]
+    #[cfg(any(target_os = "solana", target_arch = "bpf"))]
     {
         let mut hash_result = [0; HASH_BYTES];
         let result = unsafe {

--- a/poseidon/src/lib.rs
+++ b/poseidon/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(target_os = "solana", no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 //! Hashing with the [Poseidon] hash function.
 //!

--- a/scripts/check-no-std.sh
+++ b/scripts/check-no-std.sh
@@ -26,6 +26,7 @@ no_std_crates=(
   -p solana-keccak-hasher
   -p solana-msg
   -p solana-nullable
+  -p solana-poseidon
   -p solana-program-error
   -p solana-program-log
   -p solana-program-log-macro


### PR DESCRIPTION
`solana-poseidon` already has a syscall-only implementation for Solana, but the crate does not declare `no_std`. 
Rust implicitly links `std`, which conflicts with panic handlers provided by strict `no-std` programs like `Quasar`
This change disables `std` only on `target_os = "solana";` host behavior is unchanged.

Fixes #858