### PR TITLE
[signature] bump up solana-ed25519 to 0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3447,9 +3447,9 @@ dependencies = [
 
 [[package]]
 name = "solana-ed25519"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "277eebda58d900c9ded260368ad5d298bd5e10ca7c9934df1758013b24c87545"
+checksum = "e9eb363f7bce265f568551029efdff3f33752376fe8289cb628fe084503a925f"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -249,7 +249,7 @@ solana-cpi = { path = "cpi", version = "3.0.0" }
 solana-curve25519 = { path = "curve25519", version = "4.0.0" }
 solana-define-syscall = { path = "define-syscall", version = "5.1.0" }
 solana-derivation-path = { path = "derivation-path", version = "3.0.0" }
-solana-ed25519 = { version = "0.2.2", default-features = false, features = ["digest", "precomputed-tables", "rand_core", "zeroize"] }
+solana-ed25519 = { version = "0.2.3", default-features = false, features = ["digest", "precomputed-tables", "rand_core", "zeroize"] }
 solana-ed25519-program = { path = "ed25519-program", version = "3.0.0" }
 solana-epoch-info = { path = "epoch-info", version = "3.0.0" }
 solana-epoch-rewards = { path = "epoch-rewards", version = "3.2.0" }


### PR DESCRIPTION
bump up solana-ed25519 to 0.2.3

solana-ed25519 v0.2.3 allows for serial backend via a compiling flag.