### PR TITLE
maintenance/wincode-v0.5: Bound intra-repo deps to wincode v0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,20 +228,20 @@ sha2 = { version = "0.10.8", default-features = false }
 sha3 = "0.10.8"
 signal-hook = "0.3.17"
 siphasher = "0.3.11"
-solana-account = { path = "account", version = "4.3.1" }
+solana-account = { path = "account", version = ">=4.3.1,<4.4.0" }
 solana-account-info = { path = "account-info", version = "3.0.0" }
 solana-account-view = { path = "account-view", version = "2.0.0" }
-solana-address = { path = "address", version = "2.6.1" }
-solana-address-lookup-table-interface = { path = "address-lookup-table-interface", version = "3.1.0" }
+solana-address = { path = "address", version = ">=2.6.1,<2.7.0" }
+solana-address-lookup-table-interface = { path = "address-lookup-table-interface", version = ">=3.1.0,<3.2.0" }
 solana-atomic-u64 = { path = "atomic-u64", version = "3.0.0" }
 solana-big-mod-exp = { path = "big-mod-exp", version = "4.0.0" }
 solana-bincode = { path = "bincode", version = "3.0.0" }
 solana-blake3-hasher = { path = "blake3-hasher", version = "3.0.0" }
-solana-bls-signatures = { path = "bls-signatures", version = "3.0.0" }
+solana-bls-signatures = { path = "bls-signatures", version = ">=3.0.0,<3.4.0" }
 solana-bn254 = { path = "bn254", version = "3.0.0" }
 solana-borsh = { path = "borsh", version = "3.0.0" }
-solana-client-traits = { path = "client-traits", version = "4.0.0" }
-solana-clock = { path = "clock", version = "3.1.1" }
+solana-client-traits = { path = "client-traits", version = ">=4.0.0,<4.1.0" }
+solana-clock = { path = "clock", version = ">=3.1.1,<3.2.0" }
 solana-cluster-type = { path = "cluster-type", version = "3.0.0" }
 solana-commitment-config = { path = "commitment-config", version = "3.0.0" }
 solana-compute-budget-interface = { path = "compute-budget-interface", version = "3.0.0" }
@@ -252,42 +252,42 @@ solana-derivation-path = { path = "derivation-path", version = "3.0.0" }
 solana-ed25519 = { version = "0.2.2", default-features = false, features = ["digest", "precomputed-tables", "rand_core", "zeroize"] }
 solana-ed25519-program = { path = "ed25519-program", version = "3.0.0" }
 solana-epoch-info = { path = "epoch-info", version = "3.0.0" }
-solana-epoch-rewards = { path = "epoch-rewards", version = "3.1.0" }
+solana-epoch-rewards = { path = "epoch-rewards", version = ">=3.1.0,<3.2.0" }
 solana-epoch-rewards-hasher = { path = "epoch-rewards-hasher", version = "3.0.0" }
-solana-epoch-schedule = { path = "epoch-schedule", version = "3.2.0" }
+solana-epoch-schedule = { path = "epoch-schedule", version = ">=3.2.0,<3.3.0" }
 solana-epoch-stake = { path = "epoch-stake", version = "3.0.0" }
 solana-example-mocks = { path = "example-mocks", version = "4.0.0" }
 solana-feature-gate-interface = { path = "feature-gate-interface", version = "4.0.0" }
-solana-fee-calculator = { path = "fee-calculator", version = "3.2.2" }
+solana-fee-calculator = { path = "fee-calculator", version = ">=3.2.2,<3.3.0" }
 solana-fee-structure = { path = "fee-structure", version = "3.0.0" }
 solana-file-download = { path = "file-download", version = "3.0.0" }
-solana-frozen-abi = { path = "frozen-abi", version = "3.6.0" }
+solana-frozen-abi = { path = "frozen-abi", version = ">=3.6.0,<3.8.0" }
 solana-frozen-abi-macro = { path = "frozen-abi-macro", version = "3.6.0", default-features = false }
 solana-genesis-config = { path = "genesis-config", version = "4.0.0" }
 solana-get-sysvar = { path = "get-sysvar", version = "1.0.0" }
-solana-hard-forks = { path = "hard-forks", version = "3.1.1", default-features = false }
-solana-hash = { path = "hash", version = "4.4.0", default-features = false }
-solana-hash-512 = { path = "hash-512", version = "1.1.0", default-features = false }
-solana-inflation = { path = "inflation", version = "3.1.1" }
-solana-instruction = { path = "instruction", version = "3.4.0", default-features = false }
-solana-instruction-error = { path = "instruction-error", version = "2.4.0" }
+solana-hard-forks = { path = "hard-forks", version = ">=3.1.1,<3.2.0", default-features = false }
+solana-hash = { path = "hash", version = ">=4.4.0,<4.6.0", default-features = false }
+solana-hash-512 = { path = "hash-512", version = ">=1.1.0,<1.2.0", default-features = false }
+solana-inflation = { path = "inflation", version = ">=3.1.1,<3.2.0" }
+solana-instruction = { path = "instruction", version = ">=3.4.0,<3.5.0", default-features = false }
+solana-instruction-error = { path = "instruction-error", version = ">=2.4.0,<2.5.0" }
 solana-instruction-view = { path = "instruction-view", version = "2.1.0" }
 solana-instructions-sysvar = { path = "instructions-sysvar", version = "4.0.0" }
 solana-keccak-hasher = { path = "keccak-hasher", version = "3.0.0" }
 solana-keypair = { path = "keypair", version = "3.0.0" }
-solana-last-restart-slot = { path = "last-restart-slot", version = "3.1.0" }
+solana-last-restart-slot = { path = "last-restart-slot", version = ">=3.1.0,<3.2.0" }
 solana-loader-v2-interface = { path = "loader-v2-interface", version = "3.0.0" }
 solana-loader-v3-interface = { path = "loader-v3-interface", version = "8.0.0" }
-solana-message = { path = "message", version = "4.2.4", default-features = false }
+solana-message = { path = "message", version = ">=4.2.4,<4.5.0", default-features = false }
 solana-msg = { path = "msg", version = "3.0.0", default-features = false }
 solana-native-token = { path = "native-token", version = "3.0.0" }
-solana-nonce = { path = "nonce", version = "3.2.0" }
-solana-nonce-account = { path = "nonce-account", version = "4.1.0" }
+solana-nonce = { path = "nonce", version = ">=3.2.0,<3.3.0" }
+solana-nonce-account = { path = "nonce-account", version = ">=4.1.0,<4.2.0" }
 solana-nullable = { path = "nullable", version = "1.0.0", default-features = false }
 solana-offchain-message = { path = "offchain-message", version = "3.0.0" }
 solana-package-metadata = { path = "package-metadata", version = "3.0.0" }
 solana-package-metadata-macro = { path = "package-metadata-macro", version = "3.0.0" }
-solana-packet = { path = "packet", version = "4.2.0" }
+solana-packet = { path = "packet", version = ">=4.2.0,<4.3.0" }
 solana-poh-config = { path = "poh-config", version = "3.0.0" }
 solana-poseidon = { path = "poseidon", version = "4.0.0" }
 solana-precompile-error = { path = "precompile-error", version = "3.0.0" }
@@ -300,9 +300,9 @@ solana-program-log-macro = { path = "program-log-macro", version = "1.1.0" }
 solana-program-memory = { path = "program-memory", version = "3.0.0" }
 solana-program-option = { path = "program-option", version = "3.0.0" }
 solana-program-pack = { path = "program-pack", version = "3.0.0" }
-solana-pubkey = { path = "pubkey", version = "4.2.0", default-features = false }
-solana-rent = { path = "rent", version = "4.3.0", default-features = false }
-solana-reward-info = { path = "reward-info", version = "6.2.0" }
+solana-pubkey = { path = "pubkey", version = ">=4.2.0,<4.3.0", default-features = false }
+solana-rent = { path = "rent", version = ">=4.3.0,<4.4.0", default-features = false }
+solana-reward-info = { path = "reward-info", version = ">=6.2.0,<6.3.0" }
 solana-sanitize = { path = "sanitize", version = "3.0.0" }
 solana-sdk = { path = "sdk", version = "4.0.1" }
 solana-sdk-ids = { path = "sdk-ids", version = "3.0.0" }
@@ -318,27 +318,27 @@ solana-serde-varint = { path = "serde-varint", version = "3.0.1" }
 solana-serialize-utils = { path = "serialize-utils", version = "3.1.2", default-features = false }
 solana-sha256-hasher = { path = "sha256-hasher", version = "3.0.0" }
 solana-sha512-hasher = { path = "sha512-hasher", version = "1.0.1" }
-solana-short-vec = { path = "short-vec", version = "3.2.2", default-features = false }
+solana-short-vec = { path = "short-vec", version = ">=3.2.2,<3.3.0", default-features = false }
 solana-shred-version = { path = "shred-version", version = "3.0.0" }
-solana-signature = { path = "signature", version = "3.4.1", default-features = false }
+solana-signature = { path = "signature", version = ">=3.4.1,<3.5.0", default-features = false }
 solana-signer = { path = "signer", version = "3.0.1", default-features = false }
 solana-signer-store = { path = "signer-store", version = "0.1.0" }
-solana-slot-hashes = { path = "slot-hashes", version = "3.1.0" }
-solana-slot-history = { path = "slot-history", version = "3.1.0" }
+solana-slot-hashes = { path = "slot-hashes", version = ">=3.1.0,<3.2.0" }
+solana-slot-history = { path = "slot-history", version = ">=3.1.0,<3.2.0" }
 solana-stable-layout = { path = "stable-layout", version = "3.0.0" }
 solana-stake-history = { path = "stake-history", version = "1.0.0" }
-solana-svm-transaction = { path = "svm-transaction", version = "4.2.0" }
-solana-system-interface = { path = "system-interface", version = "3.2" }
-solana-system-transaction = { path = "system-transaction", version = "4.0.0" }
+solana-svm-transaction = { path = "svm-transaction", version = ">=4.2.0,<4.3.0" }
+solana-system-interface = { path = "system-interface", version = ">=3.2.0,<3.3.0" }
+solana-system-transaction = { path = "system-transaction", version = ">=4.0.0,<4.1.0" }
 solana-system-wasm-js = { path = "system-wasm-js", version = "1.0" }
-solana-sysvar = { path = "sysvar", version = "4.0.0" }
+solana-sysvar = { path = "sysvar", version = ">=4.0.0,<4.2.0" }
 solana-sysvar-id = { path = "sysvar-id", version = "3.0.0" }
 solana-time-utils = { path = "time-utils", version = "3.0.0" }
-solana-transaction = { path = "transaction", version = "4.1.5", default-features = false }
-solana-transaction-error = { path = "transaction-error", version = "3.3.1" }
+solana-transaction = { path = "transaction", version = ">=4.1.5,<4.2.0", default-features = false }
+solana-transaction-error = { path = "transaction-error", version = ">=3.3.1,<3.4.0" }
 solana-validator-exit = { path = "validator-exit", version = "3.0.0" }
-solana-vote-interface = { path = "vote-interface", version = "6.0.1" }
-solana-wincode-varint = { path = "wincode-varint", version = "1.0.0" }
+solana-vote-interface = { path = "vote-interface", version = ">=6.0.1,<6.1.0" }
+solana-wincode-varint = { path = "wincode-varint", version = ">=1.0.0,<1.1.0" }
 solana-zero-copy = { path = "zero-copy", version = "1.0.0", default-features = false }
 static_assertions = "1.1.0"
 strum = "0.24"


### PR DESCRIPTION
#### Problem

Currently, if you pull in Agave crates on their own in a project, it will fail to compile due to the breaking change between wincode v0.5 and v0.6.

Edit: to be clear, it will fail because newer versions get pulled in through transitive dependencies. For example, agave depends on solana-transaction-error, which brings in solana-instruction-error at version that only supports wincode v0.6.

#### Summary of changes

Rather than adding more dependencies in Agave and bounding there, the faster and easier solution is to bound all crates in the SDK directly.

After this change, we'll just need to publish a few crates as patch versions: instruction, message, pubkey, transaction, and transaction-error. That will fix the Agave issue. If any others are needed, we'll be able to publish them too.

Note: this follows the bounding done for Agave in https://github.com/anza-xyz/agave/pull/14178. Some of the lower bounds are different, because I didn't want to change the deps more than needed.

Also note: this PR is merging into a new maintenance branch called `maintenance/wincode-v0.5`, which was cut from *right* before the wincode bump landed.