### PR TITLE
svm-transaction: prep-work for ALT relaxation

### DIFF
--- a/svm-transaction/src/svm_message.rs
+++ b/svm-transaction/src/svm_message.rs
@@ -12,6 +12,7 @@ use {
 
 mod sanitized_message;
 mod sanitized_transaction;
+mod sanitized_versioned_transaction;
 // inlined to avoid solana-nonce dep
 #[cfg(test)]
 static_assertions::const_assert_eq!(
@@ -20,7 +21,8 @@ static_assertions::const_assert_eq!(
 );
 const NONCED_TX_MARKER_IX_INDEX: u8 = 0;
 
-pub trait SVMStaticMessage {
+// - Debug to support legacy logging
+pub trait SVMStaticMessage: Debug {
     /// Get the transaction version.
     fn version(&self) -> TransactionVersion;
 
@@ -42,6 +44,12 @@ pub trait SVMStaticMessage {
     /// Returns the number of requested write-locks in this message.
     /// This does not consider if write-locks are demoted.
     fn num_write_locks(&self) -> u64;
+
+    /// Return the number of readonly signed static account keys.
+    fn num_readonly_signed_static_accounts(&self) -> u8;
+
+    /// Return the number of readonly unsigned static account keys.
+    fn num_readonly_unsigned_static_accounts(&self) -> u8;
 
     /// Return the recent blockhash.
     fn recent_blockhash(&self) -> &Hash;
@@ -71,15 +79,30 @@ pub trait SVMStaticMessage {
     fn message_address_table_lookups(
         &self,
     ) -> impl Iterator<Item = SVMMessageAddressTableLookup<'_>>;
-}
 
-// - Debug to support legacy logging
-pub trait SVMMessage: Debug + SVMStaticMessage {
-    /// Return the account keys.
-    fn account_keys(&self) -> AccountKeys<'_>;
-
-    /// Returns `true` if the account at `index` is writable.
-    fn is_writable(&self, index: usize) -> bool;
+    /// Returns `true` if the account at `index` was requested writable.
+    /// This does not consider if write-locks are demoted.
+    fn is_requested_writable(&self, index: usize) -> bool {
+        let num_static_account_keys = self.static_account_keys().len();
+        if index >= num_static_account_keys {
+            let num_writable_loaded_addresses = self
+                .message_address_table_lookups()
+                .map(|lookup| lookup.writable_indexes.len())
+                .sum::<usize>();
+            let loaded_addresses_index = index.saturating_sub(num_static_account_keys);
+            loaded_addresses_index < num_writable_loaded_addresses
+        } else {
+            let num_signed_accounts = self.num_transaction_signatures() as usize;
+            index
+                < num_signed_accounts
+                    .saturating_sub(usize::from(self.num_readonly_signed_static_accounts()))
+                || (index >= num_signed_accounts
+                    && index
+                        < num_static_account_keys.saturating_sub(usize::from(
+                            self.num_readonly_unsigned_static_accounts(),
+                        )))
+        }
+    }
 
     /// Returns `true` if the account at `index` is signer.
     fn is_signer(&self, index: usize) -> bool;
@@ -98,6 +121,30 @@ pub trait SVMMessage: Debug + SVMStaticMessage {
             false
         }
     }
+
+    /// For the instruction at `index`, return an iterator over input accounts
+    /// that are signers.
+    fn get_ix_signers(&self, index: usize) -> impl Iterator<Item = &Pubkey> {
+        self.instructions_iter()
+            .nth(index)
+            .into_iter()
+            .flat_map(|ix| {
+                ix.accounts
+                    .iter()
+                    .copied()
+                    .map(usize::from)
+                    .filter(|index| self.is_signer(*index))
+                    .filter_map(|signer_index| self.static_account_keys().get(signer_index))
+            })
+    }
+}
+
+pub trait SVMMessage: SVMStaticMessage {
+    /// Return the account keys.
+    fn account_keys(&self) -> AccountKeys<'_>;
+
+    /// Returns `true` if the account at `index` is writable.
+    fn is_writable(&self, index: usize) -> bool;
 
     /// If the message uses a durable nonce, return the pubkey of the nonce account
     fn get_durable_nonce(&self) -> Option<&Pubkey> {
@@ -129,22 +176,6 @@ pub trait SVMMessage: Debug + SVMStaticMessage {
                         account_keys.get(index)
                     }
                 })
-            })
-    }
-
-    /// For the instruction at `index`, return an iterator over input accounts
-    /// that are signers.
-    fn get_ix_signers(&self, index: usize) -> impl Iterator<Item = &Pubkey> {
-        self.instructions_iter()
-            .nth(index)
-            .into_iter()
-            .flat_map(|ix| {
-                ix.accounts
-                    .iter()
-                    .copied()
-                    .map(usize::from)
-                    .filter(|index| self.is_signer(*index))
-                    .filter_map(|signer_index| self.account_keys().get(signer_index))
             })
     }
 }

--- a/svm-transaction/src/svm_message/sanitized_message.rs
+++ b/svm-transaction/src/svm_message/sanitized_message.rs
@@ -27,6 +27,14 @@ impl SVMStaticMessage for SanitizedMessage {
         SanitizedMessage::num_write_locks(self)
     }
 
+    fn num_readonly_signed_static_accounts(&self) -> u8 {
+        self.header().num_readonly_signed_accounts
+    }
+
+    fn num_readonly_unsigned_static_accounts(&self) -> u8 {
+        self.header().num_readonly_unsigned_accounts
+    }
+
     fn recent_blockhash(&self) -> &Hash {
         SanitizedMessage::recent_blockhash(self)
     }
@@ -67,6 +75,14 @@ impl SVMStaticMessage for SanitizedMessage {
             .iter()
             .map(SVMMessageAddressTableLookup::from)
     }
+
+    fn is_signer(&self, index: usize) -> bool {
+        SanitizedMessage::is_signer(self, index)
+    }
+
+    fn is_invoked(&self, key_index: usize) -> bool {
+        SanitizedMessage::is_invoked(self, key_index)
+    }
 }
 
 // Implement for the "reference" `SanitizedMessage` type.
@@ -77,13 +93,5 @@ impl SVMMessage for SanitizedMessage {
 
     fn is_writable(&self, index: usize) -> bool {
         SanitizedMessage::is_writable(self, index)
-    }
-
-    fn is_signer(&self, index: usize) -> bool {
-        SanitizedMessage::is_signer(self, index)
-    }
-
-    fn is_invoked(&self, key_index: usize) -> bool {
-        SanitizedMessage::is_invoked(self, key_index)
     }
 }

--- a/svm-transaction/src/svm_message/sanitized_transaction.rs
+++ b/svm-transaction/src/svm_message/sanitized_transaction.rs
@@ -23,6 +23,14 @@ impl SVMStaticMessage for SanitizedTransaction {
         SVMStaticMessage::num_write_locks(SanitizedTransaction::message(self))
     }
 
+    fn num_readonly_signed_static_accounts(&self) -> u8 {
+        SVMStaticMessage::num_readonly_signed_static_accounts(SanitizedTransaction::message(self))
+    }
+
+    fn num_readonly_unsigned_static_accounts(&self) -> u8 {
+        SVMStaticMessage::num_readonly_unsigned_static_accounts(SanitizedTransaction::message(self))
+    }
+
     fn recent_blockhash(&self) -> &Hash {
         SVMStaticMessage::recent_blockhash(SanitizedTransaction::message(self))
     }
@@ -58,6 +66,14 @@ impl SVMStaticMessage for SanitizedTransaction {
     ) -> impl Iterator<Item = SVMMessageAddressTableLookup<'_>> {
         SVMStaticMessage::message_address_table_lookups(SanitizedTransaction::message(self))
     }
+
+    fn is_signer(&self, index: usize) -> bool {
+        SVMStaticMessage::is_signer(SanitizedTransaction::message(self), index)
+    }
+
+    fn is_invoked(&self, key_index: usize) -> bool {
+        SVMStaticMessage::is_invoked(SanitizedTransaction::message(self), key_index)
+    }
 }
 
 impl SVMMessage for SanitizedTransaction {
@@ -67,13 +83,5 @@ impl SVMMessage for SanitizedTransaction {
 
     fn is_writable(&self, index: usize) -> bool {
         SVMMessage::is_writable(SanitizedTransaction::message(self), index)
-    }
-
-    fn is_signer(&self, index: usize) -> bool {
-        SVMMessage::is_signer(SanitizedTransaction::message(self), index)
-    }
-
-    fn is_invoked(&self, key_index: usize) -> bool {
-        SVMMessage::is_invoked(SanitizedTransaction::message(self), key_index)
     }
 }

--- a/svm-transaction/src/svm_message/sanitized_versioned_transaction.rs
+++ b/svm-transaction/src/svm_message/sanitized_versioned_transaction.rs
@@ -1,0 +1,113 @@
+use {
+    crate::{
+        instruction::SVMInstruction, message_address_table_lookup::SVMMessageAddressTableLookup,
+        svm_message::SVMStaticMessage,
+    },
+    solana_hash::Hash,
+    solana_message::VersionedMessage,
+    solana_pubkey::Pubkey,
+    solana_transaction::versioned::{sanitized::SanitizedVersionedTransaction, TransactionVersion},
+};
+
+impl SVMStaticMessage for SanitizedVersionedTransaction {
+    fn version(&self) -> TransactionVersion {
+        match &self.get_message().message {
+            VersionedMessage::Legacy(_) => TransactionVersion::LEGACY,
+            VersionedMessage::V0(_) => TransactionVersion::Number(0),
+            VersionedMessage::V1(_) => TransactionVersion::Number(1),
+        }
+    }
+
+    fn num_transaction_signatures(&self) -> u64 {
+        u64::from(self.get_message().message.header().num_required_signatures)
+    }
+
+    fn num_write_locks(&self) -> u64 {
+        let message = &self.get_message().message;
+        let header = message.header();
+        let num_writable_loaded_addresses = message
+            .address_table_lookups()
+            .unwrap_or_default()
+            .iter()
+            .map(|lookup| lookup.writable_indexes.len())
+            .sum::<usize>();
+        message
+            .static_account_keys()
+            .len()
+            .saturating_sub(usize::from(header.num_readonly_signed_accounts))
+            .saturating_sub(usize::from(header.num_readonly_unsigned_accounts))
+            .saturating_add(num_writable_loaded_addresses) as u64
+    }
+
+    fn num_readonly_signed_static_accounts(&self) -> u8 {
+        self.get_message()
+            .message
+            .header()
+            .num_readonly_signed_accounts
+    }
+
+    fn num_readonly_unsigned_static_accounts(&self) -> u8 {
+        self.get_message()
+            .message
+            .header()
+            .num_readonly_unsigned_accounts
+    }
+
+    fn recent_blockhash(&self) -> &Hash {
+        self.get_message().message.recent_blockhash()
+    }
+
+    fn num_instructions(&self) -> usize {
+        self.get_message().instructions().len()
+    }
+
+    fn instructions_iter(&self) -> impl Iterator<Item = SVMInstruction<'_>> {
+        self.get_message()
+            .instructions()
+            .iter()
+            .map(SVMInstruction::from)
+    }
+
+    fn program_instructions_iter(
+        &self,
+    ) -> impl Iterator<Item = (&Pubkey, SVMInstruction<'_>)> + Clone {
+        self.get_message()
+            .program_instructions_iter()
+            .map(|(pubkey, ix)| (pubkey, SVMInstruction::from(ix)))
+    }
+
+    fn static_account_keys(&self) -> &[Pubkey] {
+        self.get_message().message.static_account_keys()
+    }
+
+    fn fee_payer(&self) -> &Pubkey {
+        &self.get_message().message.static_account_keys()[0]
+    }
+
+    fn num_lookup_tables(&self) -> usize {
+        self.get_message()
+            .message
+            .address_table_lookups()
+            .unwrap_or_default()
+            .len()
+    }
+
+    fn message_address_table_lookups(
+        &self,
+    ) -> impl Iterator<Item = SVMMessageAddressTableLookup<'_>> {
+        self.get_message()
+            .message
+            .address_table_lookups()
+            .unwrap_or_default()
+            .iter()
+            .map(SVMMessageAddressTableLookup::from)
+    }
+
+    fn is_signer(&self, index: usize) -> bool {
+        self.get_message().message.is_signer(index)
+    }
+
+    fn is_invoked(&self, key_index: usize) -> bool {
+        self.get_message().message.is_invoked(key_index)
+    }
+}

--- a/svm-transaction/src/svm_transaction.rs
+++ b/svm-transaction/src/svm_transaction.rs
@@ -1,11 +1,18 @@
-use {crate::svm_message::SVMMessage, solana_signature::Signature};
+use {
+    crate::svm_message::{SVMMessage, SVMStaticMessage},
+    solana_signature::Signature,
+};
 
 mod sanitized_transaction;
+mod sanitized_versioned_transaction;
 
-pub trait SVMTransaction: SVMMessage {
+pub trait SVMStaticTransaction: SVMStaticMessage {
     /// Get the first signature of the message.
     fn signature(&self) -> &Signature;
 
     /// Get all the signatures of the message.
     fn signatures(&self) -> &[Signature];
 }
+
+pub trait SVMTransaction: SVMStaticTransaction + SVMMessage {}
+impl<T: SVMStaticTransaction + SVMMessage> SVMTransaction for T {}

--- a/svm-transaction/src/svm_transaction/sanitized_transaction.rs
+++ b/svm-transaction/src/svm_transaction/sanitized_transaction.rs
@@ -1,9 +1,9 @@
 use {
-    crate::svm_transaction::SVMTransaction, solana_signature::Signature,
+    crate::svm_transaction::SVMStaticTransaction, solana_signature::Signature,
     solana_transaction::sanitized::SanitizedTransaction,
 };
 
-impl SVMTransaction for SanitizedTransaction {
+impl SVMStaticTransaction for SanitizedTransaction {
     fn signature(&self) -> &Signature {
         SanitizedTransaction::signature(self)
     }

--- a/svm-transaction/src/svm_transaction/sanitized_versioned_transaction.rs
+++ b/svm-transaction/src/svm_transaction/sanitized_versioned_transaction.rs
@@ -1,0 +1,14 @@
+use {
+    crate::svm_transaction::SVMStaticTransaction, solana_signature::Signature,
+    solana_transaction::versioned::sanitized::SanitizedVersionedTransaction,
+};
+
+impl SVMStaticTransaction for SanitizedVersionedTransaction {
+    fn signature(&self) -> &Signature {
+        &SanitizedVersionedTransaction::signatures(self)[0]
+    }
+
+    fn signatures(&self) -> &[Signature] {
+        SanitizedVersionedTransaction::signatures(self)
+    }
+}

--- a/svm-transaction/src/tests.rs
+++ b/svm-transaction/src/tests.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 use {
-    crate::svm_message::SVMMessage,
+    crate::svm_message::{SVMMessage, SVMStaticMessage},
     solana_hash::Hash,
     solana_message::{
         compiled_instruction::CompiledInstruction,
@@ -274,19 +274,59 @@ fn test_get_ix_signers() {
     .unwrap();
 
     assert_eq!(
-        SVMMessage::get_ix_signers(&message, 0).collect::<HashSet<_>>(),
+        SVMStaticMessage::get_ix_signers(&message, 0).collect::<HashSet<_>>(),
         HashSet::from_iter([&signer0])
     );
     assert_eq!(
-        SVMMessage::get_ix_signers(&message, 1).collect::<HashSet<_>>(),
+        SVMStaticMessage::get_ix_signers(&message, 1).collect::<HashSet<_>>(),
         HashSet::from_iter([&signer0, &signer1])
     );
     assert_eq!(
-        SVMMessage::get_ix_signers(&message, 2).collect::<HashSet<_>>(),
+        SVMStaticMessage::get_ix_signers(&message, 2).collect::<HashSet<_>>(),
         HashSet::from_iter([&signer0])
     );
     assert_eq!(
-        SVMMessage::get_ix_signers(&message, 3).collect::<HashSet<_>>(),
+        SVMStaticMessage::get_ix_signers(&message, 3).collect::<HashSet<_>>(),
         HashSet::default()
     );
+}
+
+#[test]
+fn test_is_requested_writable() {
+    // 6 static keys: 3 signers, of which 1 readonly; 3 unsigned, of which 2
+    // readonly. Plus 2 loaded addresses: 1 writable, 1 readonly.
+    let message = SanitizedMessage::try_new(
+        SanitizedVersionedMessage::try_new(VersionedMessage::V0(v0::Message {
+            header: MessageHeader {
+                num_required_signatures: 3,
+                num_readonly_signed_accounts: 1,
+                num_readonly_unsigned_accounts: 2,
+            },
+            account_keys: (0..6).map(|_| Pubkey::new_unique()).collect(),
+            recent_blockhash: Hash::default(),
+            instructions: vec![CompiledInstruction::new_from_raw_parts(1, vec![], vec![])],
+            address_table_lookups: vec![MessageAddressTableLookup {
+                account_key: Pubkey::new_unique(),
+                writable_indexes: vec![0],
+                readonly_indexes: vec![1],
+            }],
+        }))
+        .unwrap(),
+        SimpleAddressLoader::Enabled(LoadedAddresses {
+            writable: vec![Pubkey::new_unique()],
+            readonly: vec![Pubkey::new_unique()],
+        }),
+        &HashSet::new(),
+    )
+    .unwrap();
+
+    assert!(SVMStaticMessage::is_requested_writable(&message, 0)); // writable signer
+    assert!(SVMStaticMessage::is_requested_writable(&message, 1)); // writable signer
+    assert!(!SVMStaticMessage::is_requested_writable(&message, 2)); // readonly signer
+    assert!(SVMStaticMessage::is_requested_writable(&message, 3)); // writable unsigned
+    assert!(!SVMStaticMessage::is_requested_writable(&message, 4)); // readonly unsigned
+    assert!(!SVMStaticMessage::is_requested_writable(&message, 5)); // readonly unsigned
+    assert!(SVMStaticMessage::is_requested_writable(&message, 6)); // writable loaded
+    assert!(!SVMStaticMessage::is_requested_writable(&message, 7)); // readonly loaded
+    assert!(!SVMStaticMessage::is_requested_writable(&message, 8)); // out of bounds
 }

--- a/transaction/src/versioned/sanitized.rs
+++ b/transaction/src/versioned/sanitized.rs
@@ -33,6 +33,10 @@ impl SanitizedVersionedTransaction {
         &self.message
     }
 
+    pub fn signatures(&self) -> &[Signature] {
+        &self.signatures
+    }
+
     /// Consumes the SanitizedVersionedTransaction, returning the fields individually.
     pub fn destruct(self) -> (Vec<Signature>, SanitizedVersionedMessage) {
         (self.signatures, self.message)


### PR DESCRIPTION
* move as much SVMMessage functionality as possible into SVMStaticMessage
* add signed/unsigned account counts to SVMStaticMessage
* add is_requested_writable() to SVMStaticMessage with blanket impl
* move SVMTransaction functions into new SVMStaticTransaction and make the former an automatic alias
* add static traits to SanitizedVersionedTransaction

in other words this reduces `SVMMessage` to nothing but `account_keys()`, `is_writable()`, and `get_durable_nonce()`

i cant promise this will be my _only_ sdk commit, since its honestly hard to keep track of all the different transaction wrapper types and which of them i might truly desire to use where, but as best i can tell this gives me what i need to start refactoring agave. other than `is_requested_writable()` and the two account counters (which are impled directly so that we can have one impl of of the more complex function) everything is just loosening constraints. `is_invoked()` and `is_signer()` are safe to be static because program ids and signers are not allowed to come from ALTs

`is_requested_writable()` is so that i can impl a static durable nonce helper in `runtime/`, which i am _not_ adding to any SVM traits because it could affect consensus if used in the wrong place. my basic idea is either:
1. i can put a slightly _looser_ nonce check in `check_transactions.rs` for leader and replay, by ignoring the fact that a nonce account may be demoted to read-only. the real check would be deferred to svm. this is consensus-safe as long as replay single-batches
2. i can put a slightly _tighter_ nonce check in the leader-only check function which discards a nonce transaction which uses a reserved key as a nonce or uses the nonce as a program id. the latter is not consensus-safe for replay because if LoaderV3 is present (which may be via ALT), the nonce would not be demoted, and if the nonce is valid it would become fee-only. in this case i would remove replay nonce checking from runtime entirely and again rely on svm, which is consensus-safe as long as replay single-batches

in both cases the goal is to allow all the check functions to be bounded by `Static` traits. then i would aim to be `Static` upstream of that on the leader side and use a list of loaded addresses produced in svm in all post-execution runtime work. this remains fairly speculative which is why im trying to land prs like this, ie that are nice refactors on their own even if ALT relaxation hits some major speedbumps later

the idea is land this, major release, bump version and rebase in https://github.com/anza-xyz/agave-sdk/pull/42, land that, major release, bump version and rebase in https://github.com/anza-xyz/agave/pull/14446, land that, then actually get to work. i feel like it is safer to speculatively land sdk changes first rather than to continuously rebase across three repos that may change out from under me, since the sdk/agave-sdk changes are straightforward improvements even if no agave pr besides the fixup for the interface change ever landed

the agave-sdk pr fails ci because it depends on this one. however, the _agave_ pr passes, because i pointed its sdk and agave-sdk deps to the other two prs' branches on github. this illustrates that everything compiles happily across the three repos