### PR TITLE
feat(nonce-account)!: drop bincode from default features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3930,6 +3930,7 @@ dependencies = [
  "solana-fee-calculator",
  "solana-hash",
  "solana-nonce",
+ "solana-nonce-account",
  "solana-pubkey",
  "solana-sdk-ids",
 ]

--- a/nonce-account/Cargo.toml
+++ b/nonce-account/Cargo.toml
@@ -15,7 +15,6 @@ all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
 [features]
-default = ["bincode"]
 bincode = ["solana-account/bincode", "solana-nonce/serde"]
 wincode = ["solana-account/wincode", "solana-nonce/wincode"]
 
@@ -31,4 +30,5 @@ bincode = { workspace = true }
 solana-account = { workspace = true, features = ["bincode"] }
 solana-fee-calculator = { workspace = true }
 solana-nonce = { workspace = true, features = ["serde"] }
+solana-nonce-account = { path = ".", features = ["wincode"] }
 solana-pubkey = { workspace = true, features = ["std"] }


### PR DESCRIPTION
Follow-up to #863, which put both codecs behind features but kept `bincode` in `default` to avoid changing what existing consumers get. Nothing is enabled by default now, so a consumer picks its codec explicitly and a wincode-only one stops paying for `bincode`, `serde`, `serde_bytes`, `serde_derive` and `solana-sysvar`.

With no default features the unit tests would compile down to just `test_get_system_account_kind`, the one test that needs no codec, so the crate takes a dev-dependency on itself with `wincode` enabled. Test builds therefore exercise the wincode path while still constructing their fixtures with the bincode constructors, which the existing dev-dependencies keep available.

This is a breaking change: `default-features = false` was already a no-op after #863, but a consumer on plain defaults now loses the codec-dependent half of the API until it names a feature.