### PR TITLE
fix(signature): use ZIP-215 semantics in `batch_verify` single-item fast path

### DIFF
--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -515,6 +515,25 @@ mod tests {
         )));
     }
 
+    #[test]
+    fn test_batch_verify_single_item_rejects_zip215_valid_signature() {
+        let mut signature = [0; SIGNATURE_BYTES];
+        signature[0] = 1;
+        let signatures = [Signature::from(signature); 1];
+        let mut pubkey = [0; 32];
+        pubkey[0] = 1;
+        let pubkeys = [pubkey; 1];
+        let messages: [Vec<u8>; 1] = core::array::from_fn(|_| b"message".to_vec());
+
+        assert!(!signatures[0].verify(&pubkeys[0], &messages[0]));
+        assert!(signatures[0].verify_non_strict(&pubkeys[0], &messages[0]));
+        assert!(!Signature::batch_verify(batch_verify_items(
+            &signatures,
+            &pubkeys,
+            &messages,
+        )));
+    }
+
     #[cfg(feature = "parallel")]
     #[test]
     fn test_par_batch_verify() {

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -161,7 +161,7 @@ impl Signature {
         if signature_data.len() == 1 {
             let (signature, pubkey_bytes, message_bytes) =
                 signature_data.into_iter().next().unwrap();
-            return signature.verify(pubkey_bytes, message_bytes);
+            return signature.verify_non_strict(pubkey_bytes, message_bytes);
         }
 
         let mut batch = solana_ed25519::ed_sigs::batch::Verifier::new();
@@ -516,7 +516,7 @@ mod tests {
     }
 
     #[test]
-    fn test_batch_verify_single_item_rejects_zip215_valid_signature() {
+    fn test_batch_verify_single_item_accepts_zip215_valid_signature() {
         let mut signature = [0; SIGNATURE_BYTES];
         signature[0] = 1;
         let signatures = [Signature::from(signature); 1];
@@ -527,7 +527,7 @@ mod tests {
 
         assert!(!signatures[0].verify(&pubkeys[0], &messages[0]));
         assert!(signatures[0].verify_non_strict(&pubkeys[0], &messages[0]));
-        assert!(!Signature::batch_verify(batch_verify_items(
+        assert!(Signature::batch_verify(batch_verify_items(
             &signatures,
             &pubkeys,
             &messages,


### PR DESCRIPTION
- `Signature::batch_verify` documents ZIP-215-compatible semantics, matching `verify_non_strict` rather than strict `verify`.
- Its single-item fast path called strict `verify()` instead, so the same signature could pass or fail depending only on batch size.

## Context

- Introduced in 672ad60 (#724), which added `verify_non_strict` and the ZIP-215 docs but left the single-item fast path on the old strict `verify()` call.
- Related: anza-xyz/solana-sdk#819 (broader ZIP-215/verify_strict cleanup, also referenced in `verify_non_strict`'s doc comment).