### PR TITLE
feat(feature-gate-interface): add wincode feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3557,6 +3557,7 @@ dependencies = [
  "solana-system-interface",
  "strum",
  "strum_macros",
+ "wincode",
 ]
 
 [[package]]

--- a/feature-gate-interface/Cargo.toml
+++ b/feature-gate-interface/Cargo.toml
@@ -24,9 +24,22 @@ bincode = [
     "dep:solana-rent",
     "dep:solana-system-interface",
     "serde",
+    "solana-account/bincode",
+    "solana-system-interface/bincode",
 ]
-dev-context-only-utils = ["bincode"]
+dev-context-only-utils = ["bincode", "wincode"]
 serde = ["dep:serde", "dep:serde_derive"]
+wincode = [
+    "dep:solana-account",
+    "dep:solana-account-info",
+    "dep:solana-instruction",
+    "dep:solana-rent",
+    "dep:solana-system-interface",
+    "dep:wincode",
+    "solana-account/wincode",
+    "solana-system-interface/wincode",
+    "wincode/alloc",
+]
 
 [dependencies]
 bincode = { workspace = true, optional = true }
@@ -39,9 +52,11 @@ solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true, optional = true }
 solana-sdk-ids = { workspace = true }
-solana-system-interface = { workspace = true, optional = true, features = ["bincode"] }
+solana-system-interface = { workspace = true, optional = true }
+wincode = { workspace = true, optional = true }
 
 [dev-dependencies]
+bincode = { workspace = true }
 solana-feature-gate-interface = { path = ".", features = ["dev-context-only-utils"] }
 solana-pubkey = { workspace = true, features = ["std"] }
 strum = { workspace = true }

--- a/feature-gate-interface/src/instruction.rs
+++ b/feature-gate-interface/src/instruction.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "bincode")]
+#[cfg(any(feature = "bincode", feature = "wincode"))]
 use {
     crate::state::Feature,
     solana_instruction::{AccountMeta, Instruction},
@@ -9,7 +9,7 @@ use {
 };
 
 /// Activate a feature
-#[cfg(feature = "bincode")]
+#[cfg(any(feature = "bincode", feature = "wincode"))]
 #[deprecated(
     since = "3.1.0",
     note = "Use `activate_with_lamports` with `rent.minimum_balance(Feature::size_of())` instead"
@@ -22,7 +22,7 @@ pub fn activate(feature_id: &Pubkey, funding_address: &Pubkey, rent: &Rent) -> V
     )
 }
 
-#[cfg(feature = "bincode")]
+#[cfg(any(feature = "bincode", feature = "wincode"))]
 pub fn activate_with_lamports(
     feature_id: &Pubkey,
     funding_address: &Pubkey,
@@ -36,7 +36,7 @@ pub fn activate_with_lamports(
 }
 
 /// Creates a 'RevokePendingActivation' instruction.
-#[cfg(feature = "bincode")]
+#[cfg(any(feature = "bincode", feature = "wincode"))]
 pub fn revoke_pending_activation(feature_id: &Pubkey) -> Instruction {
     let accounts = vec![
         AccountMeta::new(*feature_id, true),

--- a/feature-gate-interface/src/lib.rs
+++ b/feature-gate-interface/src/lib.rs
@@ -16,10 +16,10 @@ pub mod error;
 pub mod instruction;
 pub mod state;
 
-#[cfg(feature = "bincode")]
+#[cfg(any(feature = "bincode", feature = "wincode"))]
 #[allow(deprecated)]
 pub use crate::instruction::activate;
-#[cfg(feature = "bincode")]
+#[cfg(any(feature = "bincode", feature = "wincode"))]
 pub use crate::{
     instruction::activate_with_lamports,
     state::{create_account, from_account, to_account},

--- a/feature-gate-interface/src/state.rs
+++ b/feature-gate-interface/src/state.rs
@@ -1,6 +1,12 @@
-#[cfg(feature = "bincode")]
+// Imported anonymously: either name would be wrong under the other feature, and the two
+// traits share method names, so the account writers below stay codec-agnostic.
+#[cfg(all(feature = "bincode", not(feature = "wincode")))]
+use solana_account::state_traits::StateMut as _;
+#[cfg(feature = "wincode")]
+use solana_account::state_traits::StateMutWincode as _;
+#[cfg(any(feature = "bincode", feature = "wincode"))]
 use {
-    solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
+    solana_account::{AccountSharedData, ReadableAccount},
     solana_account_info::AccountInfo,
     solana_program_error::ProgramError,
     solana_sdk_ids::feature::id,
@@ -10,6 +16,7 @@ use {
     feature = "serde",
     derive(serde_derive::Deserialize, serde_derive::Serialize)
 )]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaRead, wincode::SchemaWrite))]
 #[derive(Default, Debug, PartialEq, Eq)]
 pub struct Feature {
     pub activated_at: Option<u64>,
@@ -20,7 +27,7 @@ impl Feature {
         9 // see test_feature_size_of.
     }
 
-    #[cfg(feature = "bincode")]
+    #[cfg(any(feature = "bincode", feature = "wincode"))]
     pub fn from_account_info(account_info: &AccountInfo) -> Result<Self, ProgramError> {
         if *account_info.owner != id() {
             return Err(ProgramError::InvalidAccountOwner);
@@ -28,31 +35,43 @@ impl Feature {
         if account_info.data_len() < Feature::size_of() {
             return Err(ProgramError::InvalidAccountData);
         }
-        bincode::deserialize(&account_info.data.borrow())
-            .map_err(|_| ProgramError::InvalidAccountData)
+        deserialize(&account_info.data.borrow()).ok_or(ProgramError::InvalidAccountData)
     }
 }
 
-#[cfg(feature = "bincode")]
+#[cfg(any(feature = "bincode", feature = "wincode"))]
 pub fn from_account<T: ReadableAccount>(account: &T) -> Option<Feature> {
     if account.owner() != &id() || account.data().len() < Feature::size_of() {
         None
     } else {
-        bincode::deserialize(account.data()).ok()
+        deserialize(account.data())
     }
 }
 
-#[cfg(feature = "bincode")]
+#[cfg(any(feature = "bincode", feature = "wincode"))]
 pub fn to_account(feature: &Feature, account: &mut AccountSharedData) -> Option<()> {
-    bincode::serialize_into(account.data_as_mut_slice(), feature).ok()
+    account.set_state(feature).ok()
 }
 
-#[cfg(feature = "bincode")]
+#[cfg(any(feature = "bincode", feature = "wincode"))]
 pub fn create_account(feature: &Feature, lamports: u64) -> AccountSharedData {
-    let data_len = Feature::size_of().max(bincode::serialized_size(feature).unwrap() as usize);
-    let mut account = AccountSharedData::new(lamports, data_len, &id());
-    to_account(feature, &mut account).unwrap();
-    account
+    // `size_of()` is the larger of the two encoded lengths (9 for `Some`, 1 for `None`),
+    // as `test_feature_size_of` asserts, so it is the account length for every `Feature`.
+    AccountSharedData::new_data_with_space(lamports, feature, Feature::size_of(), &id()).unwrap()
+}
+
+// The writers above go through `StateMut`/`StateMutWincode`, but those are only
+// implemented for `Account`/`AccountSharedData`: `from_account` is generic over
+// `ReadableAccount` and `from_account_info` takes an `AccountInfo`, so both read through
+// raw bytes here instead.
+#[cfg(feature = "wincode")]
+fn deserialize(data: &[u8]) -> Option<Feature> {
+    wincode::deserialize(data).ok()
+}
+
+#[cfg(all(not(feature = "wincode"), feature = "bincode"))]
+fn deserialize(data: &[u8]) -> Option<Feature> {
+    bincode::deserialize(data).ok()
 }
 
 #[cfg(test)]
@@ -84,6 +103,42 @@ mod test {
             assert_eq!(
                 Feature::size_of(),
                 bincode::serialized_size(feature).unwrap() as usize
+            );
+        }
+    }
+
+    /// `wincode` shadows `bincode` in the account accessors above, so the two encodings
+    /// must agree byte-for-byte for feature accounts to stay readable under either codec.
+    #[cfg(all(feature = "bincode", feature = "wincode"))]
+    #[test]
+    fn wire_compat_bincode_vs_wincode() {
+        for feature in [
+            Feature { activated_at: None },
+            Feature {
+                activated_at: Some(0),
+            },
+            Feature {
+                activated_at: Some(1),
+            },
+            Feature {
+                activated_at: Some(u64::MAX),
+            },
+        ] {
+            let bincode_bytes = bincode::serialize(&feature).unwrap();
+            let wincode_bytes = wincode::serialize(&feature).unwrap();
+            assert_eq!(bincode_bytes, wincode_bytes);
+            assert_eq!(
+                bincode::serialized_size(&feature).unwrap(),
+                wincode::serialized_size(&feature).unwrap()
+            );
+            // Each codec reads what the other wrote.
+            assert_eq!(
+                bincode::deserialize::<Feature>(&wincode_bytes).unwrap(),
+                feature
+            );
+            assert_eq!(
+                wincode::deserialize::<Feature>(&bincode_bytes).unwrap(),
+                feature
             );
         }
     }
@@ -132,6 +187,43 @@ mod test {
             )),
             Err(ProgramError::InvalidAccountOwner),
         );
+    }
+
+    #[test]
+    fn feature_create_account_round_trip() {
+        for feature in [
+            Feature { activated_at: None },
+            Feature {
+                activated_at: Some(u64::MAX),
+            },
+        ] {
+            let account = create_account(&feature, 42);
+            assert_eq!(account.lamports(), 42);
+            assert_eq!(account.owner(), &id());
+            // Every `Feature` gets a `size_of()`-byte account, `None` included.
+            assert_eq!(account.data().len(), Feature::size_of());
+            assert_eq!(from_account(&account), Some(feature));
+        }
+    }
+
+    /// The readers gate on `len() < size_of()`, a lower bound, so data longer than
+    /// [`Feature::size_of`] must still parse. This pins the tolerant semantics.
+    #[test]
+    fn feature_deserialize_ignores_trailing_bytes() {
+        let feature = Feature {
+            activated_at: Some(42),
+        };
+        let mut account = AccountSharedData::new(1, Feature::size_of() + 8, &id());
+        assert_eq!(to_account(&feature, &mut account), Some(()));
+
+        // The codec that is not compiled into the readers above agrees.
+        #[cfg(all(feature = "bincode", feature = "wincode"))]
+        assert_eq!(
+            bincode::deserialize::<Feature>(account.data()).unwrap(),
+            feature
+        );
+
+        assert_eq!(from_account(&account), Some(feature));
     }
 
     #[test]


### PR DESCRIPTION
Provides a bincode-free path for `Feature` account state. wincode shadows bincode when both features are enabled; the two encodings are byte-for-byte identical.

`solana-system-interface/bincode` moves off the dependency line into the `bincode` feature so it is no longer enabled unconditionally.

The account writers go through `StateMut`/`StateMutWincode`, which share method names, so `to_account`/`create_account` need no cfg. The readers keep a raw `deserialize` helper, as those traits are only implemented for `Account`/`AccountSharedData` while `from_account` is generic over `ReadableAccount` and `from_account_info` takes an `AccountInfo`.
