### PR TITLE
fix(program-log): avoid panic on invalid UTF-8 in host logger

### DIFF
--- a/program-log/src/lib.rs
+++ b/program-log/src/lib.rs
@@ -669,10 +669,7 @@ mod tests {
     }
     #[test]
     #[cfg(feature = "std")]
-    #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: Utf8Error")]
     fn test_logger_invalid_utf8_does_not_panic() {
-        // Passes an invalid UTF-8 byte slice to the logger.
-        // Currently, the host `std` path panics because it unconditionally `unwrap()`s `from_utf8`.
         let invalid_utf8: &[u8] = &[0xff, b'a'];
         crate::logger::log_message(invalid_utf8);
     }

--- a/program-log/src/lib.rs
+++ b/program-log/src/lib.rs
@@ -667,4 +667,13 @@ mod tests {
 
         assert!(&*logger == "fal@".as_bytes());
     }
+    #[test]
+    #[cfg(feature = "std")]
+    #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: Utf8Error")]
+    fn test_logger_invalid_utf8_does_not_panic() {
+        // Passes an invalid UTF-8 byte slice to the logger.
+        // Currently, the host `std` path panics because it unconditionally `unwrap()`s `from_utf8`.
+        let invalid_utf8: &[u8] = &[0xff, b'a'];
+        crate::logger::log_message(invalid_utf8);
+    }
 }

--- a/program-log/src/logger.rs
+++ b/program-log/src/logger.rs
@@ -118,7 +118,7 @@ pub fn log_message(message: &[u8]) {
     }
     #[cfg(all(not(any(target_os = "solana", target_arch = "bpf")), feature = "std"))]
     {
-        let message = core::str::from_utf8(message).unwrap();
+        let message = std::string::String::from_utf8_lossy(message);
         std::println!("{message}");
     }
 


### PR DESCRIPTION
The host `std` logging path unconditionally called `from_utf8(message).unwrap()`, panicking on non-UTF-8 byte buffers, while the on-chain path passes raw bytes to `sol_log_` with no validation causing a host-only crash for callers that log byte buffers rather than `str`. Switched the host path to `String::from_utf8_lossy`.