### PR TITLE
message: Deprecate `v1::Message::try_compile`

### DIFF
--- a/message/src/versions/v1/message.rs
+++ b/message/src/versions/v1/message.rs
@@ -212,6 +212,7 @@ impl Message {
     /// # create_v1_tx(&client, instruction, &payer)?;
     /// # Ok::<(), anyhow::Error>(())
     /// ```
+    #[deprecated(since = "4.6.0", note = "Use `try_compile_with_config`")]
     pub fn try_compile(
         payer: &Address,
         instructions: &[Instruction],

--- a/transaction/src/sanitized.rs
+++ b/transaction/src/sanitized.rs
@@ -466,8 +466,13 @@ mod tests {
             &[1, 2, 3],
             vec![AccountMeta::new(payer.pubkey(), true)],
         );
-        let message =
-            v1::Message::try_compile(&payer.pubkey(), &[instruction], Hash::new_unique()).unwrap();
+        let message = v1::Message::try_compile_with_config(
+            &payer.pubkey(),
+            &[instruction],
+            Hash::new_unique(),
+            v1::TransactionConfig::empty(),
+        )
+        .unwrap();
         let versioned_tx =
             VersionedTransaction::try_new(VersionedMessage::V1(message), &[&payer]).unwrap();
 


### PR DESCRIPTION
#### Problem

As pointed out in #871, the `try_compile` function on v1 Message creates a transaction that won't execute because its transaction configuration is unusable.

#### Summary of changes

Deprecate the function.

Fixes #871