### PR TITLE
fix: replace `unimplemented!()` panics with spanned `syn::Error` in proc-macro derives

### DIFF
--- a/frozen-abi-macro/src/lib.rs
+++ b/frozen-abi-macro/src/lib.rs
@@ -452,7 +452,7 @@ fn derive_stable_abi_sample_enum_type(input: ItemEnum) -> Result<TokenStream2, E
 }
 
 #[cfg(feature = "frozen-abi")]
-fn derive_abi_sample_enum_type(input: ItemEnum) -> TokenStream {
+fn derive_abi_sample_enum_type(input: ItemEnum) -> syn::Result<TokenStream2> {
     let type_name = &input.ident;
 
     let mut sample_variant = quote! {};
@@ -525,11 +525,11 @@ fn derive_abi_sample_enum_type(input: ItemEnum) -> TokenStream {
             }
         }
     };
-    result.into()
+    Ok(result)
 }
 
 #[cfg(feature = "frozen-abi")]
-fn derive_abi_sample_struct_type(input: ItemStruct) -> TokenStream {
+fn derive_abi_sample_struct_type(input: ItemStruct) -> syn::Result<TokenStream2> {
     let type_name = &input.ident;
     let fields = &input.fields;
     let mut sample_fields = quote! {};
@@ -576,7 +576,7 @@ fn derive_abi_sample_struct_type(input: ItemStruct) -> TokenStream {
         }
     };
 
-    result.into()
+    Ok(result)
 }
 
 #[cfg(feature = "frozen-abi")]
@@ -584,17 +584,19 @@ fn derive_abi_sample_struct_type(input: ItemStruct) -> TokenStream {
 pub fn derive_abi_sample(item: TokenStream) -> TokenStream {
     let item = parse_macro_input!(item as Item);
 
-    match item {
+    let expanded = match item {
         Item::Struct(input) => derive_abi_sample_struct_type(input),
         Item::Enum(input) => derive_abi_sample_enum_type(input),
-        _ => Error::new_spanned(item, "AbiSample isn't applicable; only for struct and enum")
-            .to_compile_error()
-            .into(),
-    }
+        _ => Err(Error::new_spanned(
+            item,
+            "AbiSample isn't applicable; only for struct and enum",
+        )),
+    };
+    expanded.unwrap_or_else(|err| err.to_compile_error()).into()
 }
 
 #[cfg(feature = "frozen-abi")]
-fn do_derive_abi_enum_visitor(input: ItemEnum) -> TokenStream {
+fn do_derive_abi_enum_visitor(input: ItemEnum) -> syn::Result<TokenStream2> {
     let type_name = &input.ident;
     let mut serialized_variants = quote! {};
     let mut variant_count: u64 = 0;
@@ -604,7 +606,7 @@ fn do_derive_abi_enum_visitor(input: ItemEnum) -> TokenStream {
         if filter_serde_attrs(&variant.attrs) {
             continue;
         };
-        let sample_variant = quote_sample_variant(type_name, &ty_generics, variant);
+        let sample_variant = quote_sample_variant(type_name, &ty_generics, variant)?;
         variant_count = if let Some(variant_count) = variant_count.checked_add(1) {
             variant_count
         } else {
@@ -617,7 +619,7 @@ fn do_derive_abi_enum_visitor(input: ItemEnum) -> TokenStream {
     }
 
     let type_str = format!("{type_name}");
-    (quote! {
+    Ok(quote! {
         impl #impl_generics ::solana_frozen_abi::abi_example::AbiEnumVisitor for #type_name #ty_generics #where_clause {
             fn visit_for_abi(&self, digester: &mut ::solana_frozen_abi::abi_digester::AbiDigester) -> ::solana_frozen_abi::abi_digester::DigestResult {
                 let enum_name = #type_str;
@@ -628,7 +630,7 @@ fn do_derive_abi_enum_visitor(input: ItemEnum) -> TokenStream {
                 digester.create_child()
             }
         }
-    }).into()
+    })
 }
 
 #[cfg(feature = "frozen-abi")]
@@ -636,12 +638,14 @@ fn do_derive_abi_enum_visitor(input: ItemEnum) -> TokenStream {
 pub fn derive_abi_enum_visitor(item: TokenStream) -> TokenStream {
     let item = parse_macro_input!(item as Item);
 
-    match item {
+    let expanded = match item {
         Item::Enum(input) => do_derive_abi_enum_visitor(input),
-        _ => Error::new_spanned(item, "AbiEnumVisitor not applicable; only for enum")
-            .to_compile_error()
-            .into(),
-    }
+        _ => Err(Error::new_spanned(
+            item,
+            "AbiEnumVisitor not applicable; only for enum",
+        )),
+    };
+    expanded.unwrap_or_else(|err| err.to_compile_error()).into()
 }
 
 #[cfg(feature = "frozen-abi")]
@@ -832,13 +836,13 @@ fn quote_sample_variant(
     type_name: &Ident,
     ty_generics: &syn::TypeGenerics,
     variant: &Variant,
-) -> TokenStream2 {
+) -> syn::Result<TokenStream2> {
     let variant_name = &variant.ident;
     let variant = &variant.fields;
     if *variant == Fields::Unit {
-        quote! {
+        Ok(quote! {
             let sample_variant: #type_name #ty_generics = #type_name::#variant_name;
-        }
+        })
     } else if let Fields::Unnamed(variant_fields) = variant {
         let mut fields = quote! {};
         for field in &variant_fields.unnamed {
@@ -850,9 +854,9 @@ fn quote_sample_variant(
                 <#ty>::example(),
             });
         }
-        quote! {
+        Ok(quote! {
             let sample_variant: #type_name #ty_generics = #type_name::#variant_name(#fields);
-        }
+        })
     } else if let Fields::Named(variant_fields) = variant {
         let mut fields = quote! {};
         for field in &variant_fields.named {
@@ -865,9 +869,9 @@ fn quote_sample_variant(
                 #field_name: <#field_type_name>::example(),
             });
         }
-        quote! {
+        Ok(quote! {
             let sample_variant: #type_name #ty_generics = #type_name::#variant_name{#fields};
-        }
+        })
     } else {
         unimplemented!("variant: {:?}", variant)
     }

--- a/frozen-abi-macro/src/lib.rs
+++ b/frozen-abi-macro/src/lib.rs
@@ -469,7 +469,10 @@ fn derive_abi_sample_enum_type(input: ItemEnum) -> syn::Result<TokenStream2> {
             let mut fields = quote! {};
             for field in &variant_fields.unnamed {
                 if !(field.ident.is_none() && field.colon_token.is_none()) {
-                    unimplemented!("tuple enum: {:?}", field);
+                    return Err(Error::new_spanned(
+                        field,
+                        "AbiExample: tuple variant fields cannot have idents or colons",
+                    ));
                 }
                 let field_type = &field.ty;
                 fields.extend(quote! {
@@ -483,7 +486,10 @@ fn derive_abi_sample_enum_type(input: ItemEnum) -> syn::Result<TokenStream2> {
             let mut fields = quote! {};
             for field in &variant_fields.named {
                 if field.ident.is_none() || field.colon_token.is_none() {
-                    unimplemented!("tuple enum: {:?}", field);
+                    return Err(Error::new_spanned(
+                        field,
+                        "AbiExample: named variant fields must have idents and colons",
+                    ));
                 }
                 let field_type = &field.ty;
                 let field_name = &field.ident;
@@ -495,7 +501,10 @@ fn derive_abi_sample_enum_type(input: ItemEnum) -> syn::Result<TokenStream2> {
                 #type_name::#variant_name{#fields}
             });
         } else {
-            unimplemented!("{:?}", variant);
+            return Err(Error::new_spanned(
+                variant,
+                "AbiExample: unsupported variant shape",
+            ));
         }
 
         if !sample_variant_found {
@@ -505,7 +514,10 @@ fn derive_abi_sample_enum_type(input: ItemEnum) -> syn::Result<TokenStream2> {
     }
 
     if !sample_variant_found {
-        unimplemented!("empty enum");
+        return Err(Error::new_spanned(
+            &input.ident,
+            "AbiExample cannot be derived for empty enums",
+        ));
     }
 
     let mut attrs = input.attrs.clone();
@@ -552,7 +564,12 @@ fn derive_abi_sample_struct_type(input: ItemStruct) -> syn::Result<TokenStream2>
             }
             sample_fields = quote! {( #sample_fields )};
         }
-        _ => unimplemented!("fields: {:?}", fields),
+        _ => {
+            return Err(Error::new_spanned(
+                &input.ident,
+                "AbiExample cannot be derived for unit structs or unsupported field layouts",
+            ))
+        }
     }
 
     let mut attrs = input.attrs.clone();
@@ -847,7 +864,10 @@ fn quote_sample_variant(
         let mut fields = quote! {};
         for field in &variant_fields.unnamed {
             if !(field.ident.is_none() && field.colon_token.is_none()) {
-                unimplemented!();
+                return Err(Error::new_spanned(
+                    field,
+                    "AbiEnumVisitor: tuple variant fields cannot have idents or colons",
+                ));
             }
             let ty = &field.ty;
             fields.extend(quote! {
@@ -861,7 +881,10 @@ fn quote_sample_variant(
         let mut fields = quote! {};
         for field in &variant_fields.named {
             if field.ident.is_none() || field.colon_token.is_none() {
-                unimplemented!();
+                return Err(Error::new_spanned(
+                    field,
+                    "AbiEnumVisitor: named variant fields must have idents and colons",
+                ));
             }
             let field_type_name = &field.ty;
             let field_name = &field.ident;
@@ -873,7 +896,10 @@ fn quote_sample_variant(
             let sample_variant: #type_name #ty_generics = #type_name::#variant_name{#fields};
         })
     } else {
-        unimplemented!("variant: {:?}", variant)
+        Err(Error::new_spanned(
+            variant,
+            "AbiEnumVisitor: unsupported variant shape",
+        ))
     }
 }
 
@@ -1045,15 +1071,16 @@ mod parse_abi_serializers_tests {
 
 #[cfg(all(test, feature = "frozen-abi"))]
 mod abi_sample_tests {
-    use {super::*, std::panic::catch_unwind, syn::parse_quote};
+    use {super::*, syn::parse_quote};
 
     #[test]
     fn test_abi_sample_empty_enum() {
         let input = parse_quote! {
             enum Empty {}
         };
-        let result = catch_unwind(|| derive_abi_sample_enum_type(input));
-        assert!(result.is_err(), "Expected panic on empty enum");
+        let result = derive_abi_sample_enum_type(input);
+        assert!(result.is_err(), "Expected error on empty enum");
+        assert!(result.unwrap_err().to_string().contains("empty enums"));
     }
 
     #[test]
@@ -1061,7 +1088,8 @@ mod abi_sample_tests {
         let input = parse_quote! {
             struct Unit;
         };
-        let result = catch_unwind(|| derive_abi_sample_struct_type(input));
-        assert!(result.is_err(), "Expected panic on unit struct");
+        let result = derive_abi_sample_struct_type(input);
+        assert!(result.is_err(), "Expected error on unit struct");
+        assert!(result.unwrap_err().to_string().contains("unit structs"));
     }
 }

--- a/frozen-abi-macro/src/lib.rs
+++ b/frozen-abi-macro/src/lib.rs
@@ -1042,3 +1042,26 @@ mod parse_abi_serializers_tests {
         assert_eq!(parse_abi_serializers(&grouped).unwrap(), vec![Wincode]);
     }
 }
+
+#[cfg(all(test, feature = "frozen-abi"))]
+mod abi_sample_tests {
+    use {super::*, std::panic::catch_unwind, syn::parse_quote};
+
+    #[test]
+    fn test_abi_sample_empty_enum() {
+        let input = parse_quote! {
+            enum Empty {}
+        };
+        let result = catch_unwind(|| derive_abi_sample_enum_type(input));
+        assert!(result.is_err(), "Expected panic on empty enum");
+    }
+
+    #[test]
+    fn test_abi_sample_unit_struct() {
+        let input = parse_quote! {
+            struct Unit;
+        };
+        let result = catch_unwind(|| derive_abi_sample_struct_type(input));
+        assert!(result.is_err(), "Expected panic on unit struct");
+    }
+}

--- a/sdk-macro/src/lib.rs
+++ b/sdk-macro/src/lib.rs
@@ -275,3 +275,26 @@ pub fn derive_clone_zeroed(input: proc_macro::TokenStream) -> proc_macro::TokenS
         .unwrap_or_else(|err| err.to_compile_error())
         .into()
 }
+
+#[cfg(test)]
+mod tests {
+    use {super::*, std::panic::catch_unwind};
+
+    #[test]
+    fn test_clone_zeroed_tuple_struct() {
+        let input = quote::quote! {
+            struct Tuple(u8);
+        };
+        let result = catch_unwind(|| derive_clone_zeroed_inner(input));
+        assert!(result.is_err(), "Expected panic on tuple struct");
+    }
+
+    #[test]
+    fn test_clone_zeroed_enum() {
+        let input = quote::quote! {
+            enum E { A }
+        };
+        let result = catch_unwind(|| derive_clone_zeroed_inner(input));
+        assert!(result.is_err(), "Expected panic on non-struct item");
+    }
+}

--- a/sdk-macro/src/lib.rs
+++ b/sdk-macro/src/lib.rs
@@ -242,7 +242,12 @@ fn derive_clone_zeroed_inner(
                         core::ptr::addr_of_mut!((*ptr).#name).write(self.#name.clone());
                     }
                 }),
-                _ => unimplemented!(),
+                _ => {
+                    return Err(syn::Error::new_spanned(
+                        &item_struct.ident,
+                        "CloneZeroed can only be derived for structs with named fields",
+                    ))
+                }
             };
             let name = &item_struct.ident;
             Ok(quote! {
@@ -263,7 +268,10 @@ fn derive_clone_zeroed_inner(
                 }
             })
         }
-        _ => unimplemented!(),
+        item => Err(syn::Error::new_spanned(
+            item,
+            "CloneZeroed cannot be derived for non-struct items",
+        )),
     }
 }
 
@@ -278,15 +286,19 @@ pub fn derive_clone_zeroed(input: proc_macro::TokenStream) -> proc_macro::TokenS
 
 #[cfg(test)]
 mod tests {
-    use {super::*, std::panic::catch_unwind};
+    use super::*;
 
     #[test]
     fn test_clone_zeroed_tuple_struct() {
         let input = quote::quote! {
             struct Tuple(u8);
         };
-        let result = catch_unwind(|| derive_clone_zeroed_inner(input));
-        assert!(result.is_err(), "Expected panic on tuple struct");
+        let result = derive_clone_zeroed_inner(input);
+        assert!(result.is_err(), "Expected error on tuple struct");
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("structs with named fields"));
     }
 
     #[test]
@@ -294,7 +306,8 @@ mod tests {
         let input = quote::quote! {
             enum E { A }
         };
-        let result = catch_unwind(|| derive_clone_zeroed_inner(input));
-        assert!(result.is_err(), "Expected panic on non-struct item");
+        let result = derive_clone_zeroed_inner(input);
+        assert!(result.is_err(), "Expected error on non-struct item");
+        assert!(result.unwrap_err().to_string().contains("non-struct items"));
     }
 }

--- a/sdk-macro/src/lib.rs
+++ b/sdk-macro/src/lib.rs
@@ -230,11 +230,10 @@ pub fn pubkeys(input: TokenStream) -> TokenStream {
     TokenStream::from(quote! {#pubkeys})
 }
 
-// Sets padding in structures to zero explicitly.
-// Otherwise padding could be inconsistent across the network and lead to divergence / consensus failures.
-#[proc_macro_derive(CloneZeroed)]
-pub fn derive_clone_zeroed(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    match parse_macro_input!(input as syn::Item) {
+fn derive_clone_zeroed_inner(
+    input: proc_macro2::TokenStream,
+) -> syn::Result<proc_macro2::TokenStream> {
+    match syn::parse2::<syn::Item>(input)? {
         syn::Item::Struct(item_struct) => {
             let clone_statements = match item_struct.fields {
                 syn::Fields::Named(ref fields) => fields.named.iter().map(|f| {
@@ -246,7 +245,7 @@ pub fn derive_clone_zeroed(input: proc_macro::TokenStream) -> proc_macro::TokenS
                 _ => unimplemented!(),
             };
             let name = &item_struct.ident;
-            quote! {
+            Ok(quote! {
                 impl Clone for #name {
                     // Clippy lint `incorrect_clone_impl_on_copy_type` requires that clone
                     // implementations on `Copy` types are simply wrappers of `Copy`.
@@ -262,9 +261,17 @@ pub fn derive_clone_zeroed(input: proc_macro::TokenStream) -> proc_macro::TokenS
                         }
                     }
                 }
-            }
+            })
         }
         _ => unimplemented!(),
     }
-    .into()
+}
+
+// Sets padding in structures to zero explicitly.
+// Otherwise padding could be inconsistent across the network and lead to divergence / consensus failures.
+#[proc_macro_derive(CloneZeroed)]
+pub fn derive_clone_zeroed(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    derive_clone_zeroed_inner(input.into())
+        .unwrap_or_else(|err| err.to_compile_error())
+        .into()
 }


### PR DESCRIPTION
Several `unimplemented!()` branches in `frozen-abi-macro` and `sdk-macro` panicked on unsupported derive shapes instead of emitting a `compile_error!`. Converted the reachable ones to spanned `syn::Error`, and the remaining unreachable/defensive branches for consistency.