### PR TITLE
fix(transaction): sanitize before signature verification

### DIFF
--- a/transaction/src/lib.rs
+++ b/transaction/src/lib.rs
@@ -1025,8 +1025,10 @@ impl Transaction {
     ///
     /// # Errors
     ///
-    /// Returns [`TransactionError::SignatureFailure`] on error.
+    /// Returns [`TransactionError::SanitizeFailure`] if the transaction is malformed, or
+    /// [`TransactionError::SignatureFailure`] if any signature is invalid.
     pub fn verify(&self) -> TransactionResult<()> {
+        self.sanitize()?;
         let message_bytes = self.message_data();
         if !self
             ._verify_with_results(&message_bytes)
@@ -1044,8 +1046,10 @@ impl Transaction {
     ///
     /// # Errors
     ///
-    /// Returns [`TransactionError::SignatureFailure`] on error.
+    /// Returns [`TransactionError::SanitizeFailure`] if the transaction is malformed, or
+    /// [`TransactionError::SignatureFailure`] if any signature is invalid.
     pub fn verify_and_hash_message(&self) -> TransactionResult<Hash> {
+        self.sanitize()?;
         let message_bytes = self.message_data();
         if !self
             ._verify_with_results(&message_bytes)
@@ -1307,6 +1311,50 @@ mod tests {
         tx.message.header.num_required_signatures = 1;
         tx.signatures.truncate(1);
         assert_eq!(tx.sanitize(), Err(SanitizeError::IndexOutOfBounds));
+    }
+
+    #[test]
+    fn test_verify_sanitizes_transaction() {
+        let keypair = Keypair::new();
+        let message = Message::new(&[], Some(&keypair.pubkey()));
+        let tx = Transaction::new(&[&keypair], message, Hash::default());
+
+        assert_eq!(tx.verify(), Ok(()));
+        assert!(tx.verify_and_hash_message().is_ok());
+
+        let mut tx_with_missing_signature = tx.clone();
+        tx_with_missing_signature.signatures.clear();
+        assert_eq!(
+            tx_with_missing_signature.verify(),
+            Err(TransactionError::SanitizeFailure)
+        );
+        assert_eq!(
+            tx_with_missing_signature.verify_and_hash_message(),
+            Err(TransactionError::SanitizeFailure)
+        );
+
+        let mut tx_with_extra_signature = tx.clone();
+        tx_with_extra_signature
+            .signatures
+            .push(Signature::default());
+        assert_eq!(
+            tx_with_extra_signature.verify(),
+            Err(TransactionError::SanitizeFailure)
+        );
+
+        let mut tx_with_missing_account_key = tx.clone();
+        tx_with_missing_account_key.message.account_keys.clear();
+        assert_eq!(
+            tx_with_missing_account_key.verify(),
+            Err(TransactionError::SanitizeFailure)
+        );
+
+        let mut tx_with_invalid_signature = tx;
+        tx_with_invalid_signature.signatures[0] = Signature::default();
+        assert_eq!(
+            tx_with_invalid_signature.verify(),
+            Err(TransactionError::SignatureFailure)
+        );
     }
 
     fn create_sample_transaction() -> Transaction {

--- a/transaction/src/lib.rs
+++ b/transaction/src/lib.rs
@@ -150,6 +150,26 @@ pub mod sanitized;
 pub mod simple_vote_transaction_checker;
 pub mod versioned;
 
+#[cfg(feature = "verify")]
+/// Verifies each signature against its corresponding account key.
+///
+/// Callers must first ensure that signature and account-key counts are sanitized.
+fn verify_signatures(
+    signatures: &[Signature],
+    account_keys: &[Address],
+    message_bytes: &[u8],
+) -> TransactionResult<()> {
+    if signatures
+        .iter()
+        .zip(account_keys)
+        .any(|(signature, pubkey)| !signature.verify(pubkey.as_ref(), message_bytes))
+    {
+        Err(TransactionError::SignatureFailure)
+    } else {
+        Ok(())
+    }
+}
+
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum TransactionVerificationMode {
     HashOnly,
@@ -1030,15 +1050,7 @@ impl Transaction {
     pub fn verify(&self) -> TransactionResult<()> {
         self.sanitize()?;
         let message_bytes = self.message_data();
-        if !self
-            ._verify_with_results(&message_bytes)
-            .iter()
-            .all(|verify_result| *verify_result)
-        {
-            Err(TransactionError::SignatureFailure)
-        } else {
-            Ok(())
-        }
+        verify_signatures(&self.signatures, &self.message.account_keys, &message_bytes)
     }
 
     #[cfg(feature = "verify")]
@@ -1051,33 +1063,8 @@ impl Transaction {
     pub fn verify_and_hash_message(&self) -> TransactionResult<Hash> {
         self.sanitize()?;
         let message_bytes = self.message_data();
-        if !self
-            ._verify_with_results(&message_bytes)
-            .iter()
-            .all(|verify_result| *verify_result)
-        {
-            Err(TransactionError::SignatureFailure)
-        } else {
-            Ok(Message::hash_raw_message(&message_bytes))
-        }
-    }
-
-    #[cfg(feature = "verify")]
-    /// Verifies that all signers have signed the message.
-    ///
-    /// Returns a vector with the length of required signatures, where each
-    /// element is either `true` if that signer has signed, or `false` if not.
-    pub fn verify_with_results(&self) -> Vec<bool> {
-        self._verify_with_results(&self.message_data())
-    }
-
-    #[cfg(feature = "verify")]
-    pub(crate) fn _verify_with_results(&self, message_bytes: &[u8]) -> Vec<bool> {
-        self.signatures
-            .iter()
-            .zip(&self.message.account_keys)
-            .map(|(signature, pubkey)| signature.verify(pubkey.as_ref(), message_bytes))
-            .collect()
+        verify_signatures(&self.signatures, &self.message.account_keys, &message_bytes)?;
+        Ok(Message::hash_raw_message(&message_bytes))
     }
 
     /// Get the positions of the pubkeys in `account_keys` associated with signing keypairs.

--- a/transaction/src/sanitized.rs
+++ b/transaction/src/sanitized.rs
@@ -281,17 +281,11 @@ impl SanitizedTransaction {
     /// Verify the transaction signatures
     pub fn verify(&self) -> TransactionResult<()> {
         let message_bytes = self.message_data();
-        if self
-            .signatures
-            .iter()
-            .zip(self.message.account_keys().iter())
-            .map(|(signature, pubkey)| signature.verify(pubkey.as_ref(), &message_bytes))
-            .any(|verified| !verified)
-        {
-            Err(TransactionError::SignatureFailure)
-        } else {
-            Ok(())
-        }
+        crate::verify_signatures(
+            &self.signatures,
+            self.message.static_account_keys(),
+            &message_bytes,
+        )
     }
 
     /// Validate a transaction message against locked accounts

--- a/transaction/src/versioned/mod.rs
+++ b/transaction/src/versioned/mod.rs
@@ -297,6 +297,7 @@ impl VersionedTransaction {
     pub fn verify_and_hash_message(
         &self,
     ) -> solana_transaction_error::TransactionResult<solana_hash::Hash> {
+        self.sanitize()?;
         let message_bytes = self.message.serialize();
         if !self
             ._verify_with_results(&message_bytes)
@@ -528,6 +529,49 @@ mod tests {
             Ok(tx) => assert_eq!(tx.verify_with_results(), vec![true; 2]),
             Err(err) => assert_eq!(Some(err), None),
         }
+    }
+
+    #[test]
+    fn test_verify_and_hash_message() {
+        let keypair = Keypair::new();
+        let message = VersionedMessage::V0(
+            MessageV0::try_compile(&keypair.pubkey(), &[], &[], Hash::default()).unwrap(),
+        );
+        let tx = VersionedTransaction::try_new(message, &[&keypair]).unwrap();
+
+        assert!(tx.verify_and_hash_message().is_ok());
+
+        let mut tx_with_missing_signature = tx.clone();
+        tx_with_missing_signature.signatures.clear();
+        assert_eq!(
+            tx_with_missing_signature.verify_and_hash_message(),
+            Err(solana_transaction_error::TransactionError::SanitizeFailure)
+        );
+
+        let mut tx_with_extra_signature = tx.clone();
+        tx_with_extra_signature
+            .signatures
+            .push(Signature::default());
+        assert_eq!(
+            tx_with_extra_signature.verify_and_hash_message(),
+            Err(solana_transaction_error::TransactionError::SanitizeFailure)
+        );
+
+        let mut tx_with_missing_static_key = tx.clone();
+        if let VersionedMessage::V0(message) = &mut tx_with_missing_static_key.message {
+            message.account_keys.clear();
+        }
+        assert_eq!(
+            tx_with_missing_static_key.verify_and_hash_message(),
+            Err(solana_transaction_error::TransactionError::SanitizeFailure)
+        );
+
+        let mut tx_with_invalid_signature = tx;
+        tx_with_invalid_signature.signatures[0] = Signature::default();
+        assert_eq!(
+            tx_with_invalid_signature.verify_and_hash_message(),
+            Err(solana_transaction_error::TransactionError::SignatureFailure)
+        );
     }
 
     fn nonced_transfer_tx() -> (Pubkey, Pubkey, VersionedTransaction) {

--- a/transaction/src/versioned/mod.rs
+++ b/transaction/src/versioned/mod.rs
@@ -299,31 +299,12 @@ impl VersionedTransaction {
     ) -> solana_transaction_error::TransactionResult<solana_hash::Hash> {
         self.sanitize()?;
         let message_bytes = self.message.serialize();
-        if !self
-            ._verify_with_results(&message_bytes)
-            .iter()
-            .all(|verify_result| *verify_result)
-        {
-            Err(solana_transaction_error::TransactionError::SignatureFailure)
-        } else {
-            Ok(VersionedMessage::hash_raw_message(&message_bytes))
-        }
-    }
-
-    #[cfg(feature = "verify")]
-    /// Verify the transaction and return a list of verification results
-    pub fn verify_with_results(&self) -> Vec<bool> {
-        let message_bytes = self.message.serialize();
-        self._verify_with_results(&message_bytes)
-    }
-
-    #[cfg(feature = "verify")]
-    fn _verify_with_results(&self, message_bytes: &[u8]) -> Vec<bool> {
-        self.signatures
-            .iter()
-            .zip(self.message.static_account_keys().iter())
-            .map(|(signature, pubkey)| signature.verify(pubkey.as_ref(), message_bytes))
-            .collect()
+        crate::verify_signatures(
+            &self.signatures,
+            self.message.static_account_keys(),
+            &message_bytes,
+        )?;
+        Ok(VersionedMessage::hash_raw_message(&message_bytes))
     }
 
     /// Returns true if transaction begins with an advance nonce instruction.
@@ -521,12 +502,12 @@ mod tests {
         );
 
         match VersionedTransaction::try_new(message.clone(), &[&keypair0, &keypair1]) {
-            Ok(tx) => assert_eq!(tx.verify_with_results(), vec![true; 2]),
+            Ok(tx) => assert!(tx.verify_and_hash_message().is_ok()),
             Err(err) => assert_eq!(Some(err), None),
         }
 
         match VersionedTransaction::try_new(message, &[&keypair1, &keypair0]) {
-            Ok(tx) => assert_eq!(tx.verify_with_results(), vec![true; 2]),
+            Ok(tx) => assert!(tx.verify_and_hash_message().is_ok()),
             Err(err) => assert_eq!(Some(err), None),
         }
     }

--- a/transaction/src/versioned/sanitized.rs
+++ b/transaction/src/versioned/sanitized.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "verify")]
-use solana_transaction_error::{TransactionError, TransactionResult};
+use solana_transaction_error::TransactionResult;
 use {
     crate::versioned::VersionedTransaction, alloc::vec::Vec,
     solana_message::SanitizedVersionedMessage, solana_sanitize::SanitizeError,
@@ -43,22 +43,19 @@ impl SanitizedVersionedTransaction {
     ///
     /// # Errors
     ///
-    /// Returns [`TransactionError::SignatureFailure`] if any signature is invalid.
+    /// Returns [`solana_transaction_error::TransactionError::SignatureFailure`]
+    /// if any signature is invalid.
     #[cfg(feature = "verify")]
     pub fn verify_and_hash_message(&self) -> TransactionResult<solana_hash::Hash> {
         let message_bytes = self.message.message.serialize();
-        if self
-            .signatures
-            .iter()
-            .zip(self.message.message.static_account_keys())
-            .any(|(signature, pubkey)| !signature.verify(pubkey.as_ref(), &message_bytes))
-        {
-            Err(TransactionError::SignatureFailure)
-        } else {
-            Ok(solana_message::VersionedMessage::hash_raw_message(
-                &message_bytes,
-            ))
-        }
+        crate::verify_signatures(
+            &self.signatures,
+            self.message.message.static_account_keys(),
+            &message_bytes,
+        )?;
+        Ok(solana_message::VersionedMessage::hash_raw_message(
+            &message_bytes,
+        ))
     }
 
     /// Consumes the SanitizedVersionedTransaction, returning the fields individually.
@@ -77,6 +74,7 @@ mod tests {
         solana_message::{v0, VersionedMessage},
         solana_pubkey::Pubkey,
         solana_signer::Signer,
+        solana_transaction_error::TransactionError,
     };
 
     #[test]


### PR DESCRIPTION
### Problem
- signature verification interface is dangerous because it can return true when signature/pubkey count do not match required values

### Summary of Changes
- call `sanitize` before verifying signatures