### PR TITLE
[bls12-381] Reject empty pairing slices, improve comments, and add additional utility functions

### DIFF
--- a/bls12-381/README.md
+++ b/bls12-381/README.md
@@ -1,33 +1,29 @@
 # solana-bls12-381
 
-A Rust library for BLS12-381 elliptic curve operations
-on Solana, wrapping the native syscalls defined in
+BLS12-381 elliptic curve operations for Solana programs, wrapping the native
+syscalls defined in
 [SIMD-0388](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0388-bls12-381-syscalls.md).
 
-This crate provides the standard interface for Solana program
-developers to perform pairing-based cryptography, such as BLS signature
-verification and zero-knowledge proof (e.g., Groth16) validation.
+Intended for on-chain pairing-based cryptography: BLS signature verification
+and zero-knowledge proof (e.g. Groth16) validation.
 
 ## Features
 
-- **Zero-Copy Deserialization:** Types are `#[repr(transparent)]` and implement
-  `bytemuck::Pod`. Developers can cast transaction instruction data directly
-  into curve points without heap allocations.
-- **CU-Optimized Mutations:** Provides `_assign` variants for all group
-  operations (e.g., `add_assign`), which write into a caller-supplied
-  `MaybeUninit` buffer to strictly control Compute Unit (CU) consumption.
-- **Validated & Unchecked APIs:** Group operations validate their operands by
-  default, with `_unchecked` variants that skip subgroup checks for cheaper
-  point accumulation.
-- **Ergonomic Pairings:** Includes `pairing_check` for evaluating if the
-  product of multiple pairings equals the identity element, avoiding costly
-  target group (`Gt`) allocations in ZK verifiers.
-- **Dual Endianness:** Full support for both Big-Endian (canonical Zcash/IETF
-  standard) and Little-Endian memory layouts.
+- **Zero-copy deserialization.** Types are `#[repr(transparent)]` and implement
+  `bytemuck::Pod`, so instruction data can be cast directly into curve points
+  without allocation.
+- **In-place operations.** Every group operation has an `_assign` variant that
+  writes into a caller-supplied `MaybeUninit` buffer, bounding compute unit
+  consumption.
+- **Validated and unchecked APIs.** Group operations validate their operands by
+  default; `_unchecked` variants skip the subgroup check for cheaper
+  accumulation.
+- **Pairing checks.** `pairing_check` tests whether a product of pairings is the
+  identity without materializing a 576-byte `Gt` element.
+- **Dual endianness.** Big-endian (the canonical Zcash/IETF encoding) and
+  little-endian layouts.
 
 ## Usage
-
-Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
@@ -35,40 +31,54 @@ solana-bls12-381 = "0.1.0"
 ```
 
 The `bytemuck` feature is enabled by default and provides the `Pod` and
-`Zeroable` implementations that make zero-copy casting possible. It can be
-turned off with `default-features = false` for on-chain builds that do not
-need them, but off-chain builds always include them, since the host
-implementation depends on them internally.
+`Zeroable` implementations used for zero-copy casting. On-chain builds that do
+not need them can set `default-features = false`. Off-chain builds always
+include them, since the host implementation depends on them internally.
 
-### Zero-Copy Point Addition
+### Zero-copy point addition
 
 ```rust
 use solana_bls12_381::{G1Point, Endianness};
 use core::mem::MaybeUninit;
-use bytemuck;
 
-// 1. Cast raw byte slices directly to G1Point references (Zero-Copy)
+// Cast raw instruction data directly to `G1Point` references.
 let p1: &G1Point = bytemuck::cast_ref(raw_bytes_1);
 let p2: &G1Point = bytemuck::cast_ref(raw_bytes_2);
 
-// 2. Reserve an output buffer. It is never read before being written, so it
-//    does not need to be initialized.
+// The output buffer is never read before it is written, so it does not need
+// to be initialized.
 let mut out = MaybeUninit::uninit();
 
-// 3. Perform validated, in-place addition
 let success = p1.add_assign(p2, &mut out, Endianness::Little);
 assert!(success);
 
-// SAFETY: `add_assign` returned `true`, so every byte of `out` was written.
+// SAFETY: `add_assign` returned `true`, so `out` is fully initialized.
 let sum = unsafe { out.assume_init() };
 ```
 
-Every `_assign` method follows the same contract: on `true` the output buffer
-is fully initialized and may be `assume_init`ed; on `false` it is left
-untouched and must not be assumed initialized.
+### Output buffer contract
 
-To recycle buffers across a loop, keep the accumulator in a `MaybeUninit` and
-swap the two buffers each iteration:
+Every `_assign` method follows the same contract:
+
+- On `true`, the output buffer is fully initialized and may be `assume_init`ed.
+- On `false`, it must be treated as uninitialized and must not be read, **even
+  if it held a valid value before the call**. A failed operation may write part
+  of the buffer before detecting the error, so any prior contents are no longer
+  guaranteed to be valid.
+
+Permitting `assume_init` on `true` requires that the syscall wrote every byte of
+the buffer, since reading an uninitialized byte is undefined behavior.
+SIMD-0388 does not state this. The guarantee instead follows from consensus: the
+result buffer is observable to the program — its contents can be logged,
+returned, or fed into a later syscall — so an implementation that left a byte
+unwritten would produce a different program result from Agave and fork the
+network. `test_success_writes_full_buffer` pins the property.
+
+Nothing constrains what a _failing_ syscall leaves in the buffer, hence the
+poisoning rule above rather than a guarantee that the buffer is left untouched.
+
+To reuse buffers across a loop, keep the accumulator in a `MaybeUninit` and swap
+the two buffers each iteration:
 
 ```rust
 use solana_bls12_381::{G1Point, Endianness};
@@ -81,6 +91,8 @@ let mut scratch = MaybeUninit::uninit();
 for p in points {
     // SAFETY: `acc` is initialized, by `new` above and by the swap below.
     let lhs = unsafe { acc.assume_init_ref() };
+    // The early return is load-bearing: on failure `scratch` is poisoned and
+    // must not be swapped into `acc` or read afterwards.
     if !lhs.add_assign_unchecked(p, &mut scratch, e) {
         return Err(ProgramError::InvalidArgument);
     }
@@ -91,7 +103,7 @@ for p in points {
 let total = unsafe { acc.assume_init() };
 ```
 
-### Multi-Pairing Check (e.g., BLS Signatures or ZK Proofs)
+### Multi-pairing check (BLS signatures, ZK proofs)
 
 ```rust
 use solana_bls12_381::{G1Point, G2Point, pairing_check, Endianness};
@@ -100,15 +112,38 @@ let g1_points: &[G1Point] = get_g1_batch();
 let g2_points: &[G2Point] = get_g2_batch();
 
 // Evaluates e(P_1, Q_1) * ... * e(P_n, Q_n) == 1
-let is_valid = pairing_check(g1_points, g2_points, Endianness::Big)
-    .expect("Pairing execution failed");
-
-assert!(is_valid);
+if pairing_check(g1_points, g2_points, Endianness::Big) != Ok(true) {
+    return Err(ProgramError::InvalidArgument);
+}
 ```
 
-### Security & Validation
+`pairing_check` returns `Err` when the check could not be run at all —
+mismatched or over-long batches, an empty batch, or an invalid point. `Err` is
+not the same as "verification failed", but both must be treated as failure.
+Compare against `Ok(true)` as above; never branch on `.is_ok()`.
 
-All group operations except the `_unchecked` variants, along with
-multiplication and decompression, inherently perform full point validation.
-This includes checking that the coordinates represent valid field elements,
-satisfy the curve equation, and exist within the correct prime-order subgroup.
+`pairing_check` rejects an empty batch, while `pairing_map` returns the identity
+for one as the syscall requires. The divergence is deliberate: `pairing_check` is
+a verification primitive whose inputs are typically built from
+attacker-controlled instruction data, and a zero-length batch that reported
+`Ok(true)` would be a verification bypass. For the empty product, call
+`pairing_map` and compare against `GtElement::identity`.
+
+### Validation
+
+Group operations validate both operands by default: the coordinates are checked
+to be field elements, the point to satisfy the curve equation, and the point to
+lie in the prime-order subgroup. The `_unchecked` variants skip these checks.
+Multiplication and decompression are validated by the syscall itself and have no
+`_unchecked` variant.
+
+The subgroup check dominates the cost. Since the subgroup is closed under
+addition, an accumulator built from validated points remains valid: validate at
+the trust boundary and accumulate with `add_assign_unchecked`.
+
+### Aliasing
+
+SIMD-0388 does not specify whether the result pointer of a syscall may alias an
+input pointer. This crate is unaffected either way: every `_assign` method takes
+`&self` alongside `&mut MaybeUninit<Self>`, so an aliasing call cannot be
+expressed in safe Rust.

--- a/bls12-381/src/error.rs
+++ b/bls12-381/src/error.rs
@@ -1,0 +1,27 @@
+use core::fmt;
+
+/// Errors returned by this crate.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Bls12381Error {
+    /// The G1 and G2 slices were different lengths.
+    LengthMismatch,
+    /// The batch exceeded 8 pairs.
+    TooManyPairs,
+    /// The pairing batch was empty.
+    EmptyBatch,
+    /// The syscall rejected the operation.
+    InvalidInput,
+}
+
+impl fmt::Display for Bls12381Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let message = match self {
+            Self::LengthMismatch => "G1 and G2 batches have different lengths",
+            Self::TooManyPairs => "pairing batch exceeds the maximum length",
+            Self::EmptyBatch => "pairing batch is empty",
+            Self::InvalidInput => "the syscall rejected the operation",
+        };
+        f.write_str(message)
+    }
+}

--- a/bls12-381/src/g1.rs
+++ b/bls12-381/src/g1.rs
@@ -107,7 +107,7 @@ impl G1Point {
             if i != flag_index && self.0[i] != 0 {
                 return false;
             }
-            i += 1;
+            i = i.wrapping_add(1);
         }
         true
     }
@@ -541,7 +541,7 @@ impl G1Compressed {
             if i != flag_index && self.0[i] != 0 {
                 return false;
             }
-            i += 1;
+            i = i.wrapping_add(1);
         }
         true
     }

--- a/bls12-381/src/g1.rs
+++ b/bls12-381/src/g1.rs
@@ -14,8 +14,10 @@ pub const G1_COMPRESSED_POINT_SIZE: usize = 48;
 /// Size of an uncompressed BLS12-381 G1 affine point in bytes.
 pub const G1_UNCOMPRESSED_POINT_SIZE: usize = 96;
 
-/// Uncompressed BLS12-381 G1 affine point.
-/// Represents the `x` and `y` coordinates (96 bytes total).
+/// An uncompressed G1 affine point: `x` and `y`, 96 bytes.
+///
+/// The all-zero encoding is not the identity; use [`Self::infinity`]. See the
+/// crate documentation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(
     any(
@@ -25,10 +27,13 @@ pub const G1_UNCOMPRESSED_POINT_SIZE: usize = 96;
     derive(Pod, Zeroable)
 )]
 #[repr(transparent)]
-pub struct G1Point(pub [u8; G1_UNCOMPRESSED_POINT_SIZE]);
+pub struct G1Point(
+    /// The raw affine encoding, in whichever [`Endianness`] each operation is
+    /// given. No validity invariant: these bytes may not be a curve point.
+    pub [u8; G1_UNCOMPRESSED_POINT_SIZE],
+);
 
-/// Compressed BLS12-381 G1 point.
-/// Represents the `x` coordinate with control flags in the MSB (48 bytes).
+/// A compressed G1 point: `x` with control flags in the top byte, 48 bytes.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(
     any(
@@ -38,10 +43,34 @@ pub struct G1Point(pub [u8; G1_UNCOMPRESSED_POINT_SIZE]);
     derive(Pod, Zeroable)
 )]
 #[repr(transparent)]
-pub struct G1Compressed(pub [u8; G1_COMPRESSED_POINT_SIZE]);
+pub struct G1Compressed(
+    /// The raw compressed encoding, in whichever [`Endianness`] each operation
+    /// is given. No validity invariant.
+    pub [u8; G1_COMPRESSED_POINT_SIZE],
+);
+
+/// G1 base point, big-endian.
+const G1_GENERATOR_BE: [u8; G1_UNCOMPRESSED_POINT_SIZE] = [
+    0x17, 0xF1, 0xD3, 0xA7, 0x31, 0x97, 0xD7, 0x94, 0x26, 0x95, 0x63, 0x8C, 0x4F, 0xA9, 0xAC, 0x0F,
+    0xC3, 0x68, 0x8C, 0x4F, 0x97, 0x74, 0xB9, 0x05, 0xA1, 0x4E, 0x3A, 0x3F, 0x17, 0x1B, 0xAC, 0x58,
+    0x6C, 0x55, 0xE8, 0x3F, 0xF9, 0x7A, 0x1A, 0xEF, 0xFB, 0x3A, 0xF0, 0x0A, 0xDB, 0x22, 0xC6, 0xBB,
+    0x08, 0xB3, 0xF4, 0x81, 0xE3, 0xAA, 0xA0, 0xF1, 0xA0, 0x9E, 0x30, 0xED, 0x74, 0x1D, 0x8A, 0xE4,
+    0xFC, 0xF5, 0xE0, 0x95, 0xD5, 0xD0, 0x0A, 0xF6, 0x00, 0xDB, 0x18, 0xCB, 0x2C, 0x04, 0xB3, 0xED,
+    0xD0, 0x3C, 0xC7, 0x44, 0xA2, 0x88, 0x8A, 0xE4, 0x0C, 0xAA, 0x23, 0x29, 0x46, 0xC5, 0xE7, 0xE1,
+];
+
+/// G1 base point, little-endian.
+const G1_GENERATOR_LE: [u8; G1_UNCOMPRESSED_POINT_SIZE] = [
+    0xBB, 0xC6, 0x22, 0xDB, 0x0A, 0xF0, 0x3A, 0xFB, 0xEF, 0x1A, 0x7A, 0xF9, 0x3F, 0xE8, 0x55, 0x6C,
+    0x58, 0xAC, 0x1B, 0x17, 0x3F, 0x3A, 0x4E, 0xA1, 0x05, 0xB9, 0x74, 0x97, 0x4F, 0x8C, 0x68, 0xC3,
+    0x0F, 0xAC, 0xA9, 0x4F, 0x8C, 0x63, 0x95, 0x26, 0x94, 0xD7, 0x97, 0x31, 0xA7, 0xD3, 0xF1, 0x17,
+    0xE1, 0xE7, 0xC5, 0x46, 0x29, 0x23, 0xAA, 0x0C, 0xE4, 0x8A, 0x88, 0xA2, 0x44, 0xC7, 0x3C, 0xD0,
+    0xED, 0xB3, 0x04, 0x2C, 0xCB, 0x18, 0xDB, 0x00, 0xF6, 0x0A, 0xD0, 0xD5, 0x95, 0xE0, 0xF5, 0xFC,
+    0xE4, 0x8A, 0x1D, 0x74, 0xED, 0x30, 0x9E, 0xA0, 0xF1, 0xA0, 0xAA, 0xE3, 0x81, 0xF4, 0xB3, 0x08,
+];
 
 impl G1Point {
-    /// Returns the identity (infinity) element for the given endianness.
+    /// Returns the identity (infinity) element in the given encoding.
     pub const fn infinity(endianness: Endianness) -> Self {
         let mut bytes = [0u8; G1_UNCOMPRESSED_POINT_SIZE];
         match endianness {
@@ -52,32 +81,127 @@ impl G1Point {
         Self(bytes)
     }
 
-    /// Constructs a point from a byte array via a memory copy.
+    /// The standard G1 base point from the Zcash/IETF specification.
+    pub const fn generator(endianness: Endianness) -> Self {
+        match endianness {
+            Endianness::Big => Self(G1_GENERATOR_BE),
+            Endianness::Little => Self(G1_GENERATOR_LE),
+        }
+    }
+
+    /// Whether this is the canonical infinity encoding: infinity flag set,
+    /// every other bit clear.
     ///
-    /// Note: For zero-copy deserialization from instruction data, use
-    /// `bytemuck::cast_ref` directly on the byte slice.
+    /// Evaluated locally, without a syscall. A point that fails this check is
+    /// not thereby invalid — that question belongs to [`Self::validate`].
+    pub const fn is_infinity(&self, endianness: Endianness) -> bool {
+        let flag_index = match endianness {
+            Endianness::Big => 0,
+            Endianness::Little => 47,
+        };
+        if self.0[flag_index] != 0x40 {
+            return false;
+        }
+        let mut i = 0;
+        while i < G1_UNCOMPRESSED_POINT_SIZE {
+            if i != flag_index && self.0[i] != 0 {
+                return false;
+            }
+            i += 1;
+        }
+        true
+    }
+
+    /// Copies a byte array into a point.
+    ///
+    /// For instruction data, [`Self::from_bytes_ref`] or `bytemuck::cast_ref`
+    /// avoid the copy.
     pub const fn from_bytes(bytes: [u8; G1_UNCOMPRESSED_POINT_SIZE]) -> Self {
         Self(bytes)
     }
 
-    /// Returns the underlying byte array via a memory copy.
+    /// Copies out the raw 96-byte encoding. [`Self::as_bytes`] borrows
+    /// instead.
     pub const fn to_bytes(&self) -> [u8; G1_UNCOMPRESSED_POINT_SIZE] {
         self.0
     }
 
-    /// Safely negates the point by subtracting it from infinity.
-    pub fn neg(&self, endianness: Endianness) -> Option<Self> {
-        Self::infinity(endianness).sub(self, endianness)
+    /// Borrows the raw encoding.
+    pub const fn as_bytes(&self) -> &[u8; G1_UNCOMPRESSED_POINT_SIZE] {
+        &self.0
     }
 
-    /// In-place point addition.
+    /// Reinterprets a byte array as a point, without copying.
     ///
-    /// WARNING: This operation skips the prime-order subgroup check
-    /// for performance. Only use this if inputs are known to be valid.
+    /// Available under `default-features = false`, unlike `bytemuck::cast_ref`.
+    /// Performs no validation.
+    pub const fn from_bytes_ref(bytes: &[u8; G1_UNCOMPRESSED_POINT_SIZE]) -> &Self {
+        // SAFETY: `G1Point` is `#[repr(transparent)]` over
+        // `[u8; G1_UNCOMPRESSED_POINT_SIZE]`, so the two have identical
+        // layout and a reference to one may be reinterpreted as a reference to
+        // the other.
+        unsafe { &*(bytes as *const [u8; G1_UNCOMPRESSED_POINT_SIZE] as *const Self) }
+    }
+
+    /// Negates in place, skipping the subgroup check on `self`.
     ///
-    /// Returns `true` if and only if every byte of `out` was written, in
-    /// which case the caller may `assume_init` it. On `false`, `out` is
-    /// left untouched and must not be assumed initialized.
+    /// An off-subgroup input yields an off-subgroup result rather than an error.
+    ///
+    /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
+    /// it is poisoned. See
+    /// [Output buffer contract](crate#output-buffer-contract).
+    pub fn neg_assign_unchecked(
+        &self,
+        out: &mut MaybeUninit<Self>,
+        endianness: Endianness,
+    ) -> bool {
+        Self::infinity(endianness).sub_assign_unchecked(self, out, endianness)
+    }
+
+    /// Allocating form of [`Self::neg_assign_unchecked`].
+    pub fn neg_unchecked(&self, endianness: Endianness) -> Option<Self> {
+        Self::infinity(endianness).sub_unchecked(self, endianness)
+    }
+
+    /// Negates in place, validating `self` first.
+    ///
+    /// Issues two syscalls: validation, then subtraction from infinity.
+    /// Infinity needs no validation of its own, and the subtraction syscall
+    /// repeats the field and on-curve checks internally, so one validation
+    /// covers the pair.
+    ///
+    /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
+    /// it is poisoned. See
+    /// [Output buffer contract](crate#output-buffer-contract).
+    pub fn neg_assign(&self, out: &mut MaybeUninit<Self>, endianness: Endianness) -> bool {
+        if !self.validate(endianness) {
+            return false;
+        }
+        self.neg_assign_unchecked(out, endianness)
+    }
+
+    /// Allocating form of [`Self::neg_assign`].
+    pub fn neg(&self, endianness: Endianness) -> Option<Self> {
+        let mut out = MaybeUninit::uninit();
+        if self.neg_assign(&mut out, endianness) {
+            // SAFETY: `neg_assign` returned `true`, so `out` is fully
+            // initialized.
+            Some(unsafe { out.assume_init() })
+        } else {
+            None
+        }
+    }
+
+    /// Adds in place, skipping the subgroup check on both operands.
+    ///
+    /// The principal compute-unit optimization. The subgroup is closed under
+    /// addition, so an accumulator built from validated points remains valid
+    /// and re-validating it each iteration buys nothing: validate at the trust
+    /// boundary and accumulate with this method. See the README for the loop.
+    ///
+    /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
+    /// it is poisoned. See
+    /// [Output buffer contract](crate#output-buffer-contract).
     pub fn add_assign_unchecked(
         &self,
         other: &Self,
@@ -90,10 +214,10 @@ impl G1Point {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G1_LE,
                 Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G1_BE,
             };
-            // SAFETY: the input pointers are valid for reads of their
-            // respective sizes and `out` is valid for writes of
-            // `G1_UNCOMPRESSED_POINT_SIZE` bytes. Per SIMD-0388 the syscall writes
-            // the full output buffer whenever it returns 0.
+            // SAFETY: inputs are valid for reads of their sizes, `out` for
+            // writes of `G1_UNCOMPRESSED_POINT_SIZE`. A 0 return means the
+            // syscall wrote all of it — see "Output buffer contract" in lib.rs
+            // for why that holds even though SIMD-0388 never says so.
             let status = unsafe {
                 solana_define_syscall::definitions::sol_curve_group_op(
                     curve_id,
@@ -130,25 +254,23 @@ impl G1Point {
         }
     }
 
-    /// Point addition returning a new allocated point.
-    /// Skips subgroup checks.
+    /// Allocating form of [`Self::add_assign_unchecked`].
     pub fn add_unchecked(&self, other: &Self, endianness: Endianness) -> Option<Self> {
         let mut out = MaybeUninit::uninit();
         if self.add_assign_unchecked(other, &mut out, endianness) {
-            // SAFETY: `add_assign_unchecked` returned `true`, so every byte of
-            // `out` has been written.
+            // SAFETY: `add_assign_unchecked` returned `true`, so `out` is fully
+            // initialized.
             Some(unsafe { out.assume_init() })
         } else {
             None
         }
     }
 
-    /// Safe in-place point addition.
-    /// Validates both operands (field, curve, subgroup) prior to addition.
+    /// Adds in place, validating both operands first.
     ///
-    /// Returns `true` if and only if every byte of `out` was written, in
-    /// which case the caller may `assume_init` it. On `false`, `out` is
-    /// left untouched and must not be assumed initialized.
+    /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
+    /// it is poisoned. See
+    /// [Output buffer contract](crate#output-buffer-contract).
     pub fn add_assign(
         &self,
         other: &Self,
@@ -161,26 +283,25 @@ impl G1Point {
         self.add_assign_unchecked(other, out, endianness)
     }
 
-    /// Safe point addition returning a new allocated point.
+    /// Allocating form of [`Self::add_assign`].
     pub fn add(&self, other: &Self, endianness: Endianness) -> Option<Self> {
         let mut out = MaybeUninit::uninit();
         if self.add_assign(other, &mut out, endianness) {
-            // SAFETY: `add_assign` returned `true`, so every byte of
-            // `out` has been written.
+            // SAFETY: `add_assign` returned `true`, so `out` is fully
+            // initialized.
             Some(unsafe { out.assume_init() })
         } else {
             None
         }
     }
 
-    /// In-place point subtraction.
+    /// Subtracts in place, skipping the subgroup check on both operands.
     ///
-    /// WARNING: This operation skips the prime-order subgroup check
-    /// for performance. Only use this if inputs are known to be valid.
+    /// Carries the same caveat as [`Self::add_assign_unchecked`].
     ///
-    /// Returns `true` if and only if every byte of `out` was written, in
-    /// which case the caller may `assume_init` it. On `false`, `out` is
-    /// left untouched and must not be assumed initialized.
+    /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
+    /// it is poisoned. See
+    /// [Output buffer contract](crate#output-buffer-contract).
     pub fn sub_assign_unchecked(
         &self,
         other: &Self,
@@ -193,10 +314,10 @@ impl G1Point {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G1_LE,
                 Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G1_BE,
             };
-            // SAFETY: the input pointers are valid for reads of their
-            // respective sizes and `out` is valid for writes of
-            // `G1_UNCOMPRESSED_POINT_SIZE` bytes. Per SIMD-0388 the syscall writes
-            // the full output buffer whenever it returns 0.
+            // SAFETY: inputs are valid for reads of their sizes, `out` for
+            // writes of `G1_UNCOMPRESSED_POINT_SIZE`. A 0 return means the
+            // syscall wrote all of it — see "Output buffer contract" in lib.rs
+            // for why that holds even though SIMD-0388 never says so.
             let status = unsafe {
                 solana_define_syscall::definitions::sol_curve_group_op(
                     curve_id,
@@ -233,25 +354,23 @@ impl G1Point {
         }
     }
 
-    /// Point subtraction returning a new allocated point.
-    /// Skips subgroup checks.
+    /// Allocating form of [`Self::sub_assign_unchecked`].
     pub fn sub_unchecked(&self, other: &Self, endianness: Endianness) -> Option<Self> {
         let mut out = MaybeUninit::uninit();
         if self.sub_assign_unchecked(other, &mut out, endianness) {
-            // SAFETY: `sub_assign_unchecked` returned `true`, so every byte of
-            // `out` has been written.
+            // SAFETY: `sub_assign_unchecked` returned `true`, so `out` is fully
+            // initialized.
             Some(unsafe { out.assume_init() })
         } else {
             None
         }
     }
 
-    /// Safe in-place point subtraction.
-    /// Validates both operands prior to subtraction.
+    /// Subtracts in place, validating both operands first.
     ///
-    /// Returns `true` if and only if every byte of `out` was written, in
-    /// which case the caller may `assume_init` it. On `false`, `out` is
-    /// left untouched and must not be assumed initialized.
+    /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
+    /// it is poisoned. See
+    /// [Output buffer contract](crate#output-buffer-contract).
     pub fn sub_assign(
         &self,
         other: &Self,
@@ -264,26 +383,27 @@ impl G1Point {
         self.sub_assign_unchecked(other, out, endianness)
     }
 
-    /// Safe point subtraction returning a new allocated point.
+    /// Allocating form of [`Self::sub_assign`].
     pub fn sub(&self, other: &Self, endianness: Endianness) -> Option<Self> {
         let mut out = MaybeUninit::uninit();
         if self.sub_assign(other, &mut out, endianness) {
-            // SAFETY: `sub_assign` returned `true`, so every byte of
-            // `out` has been written.
+            // SAFETY: `sub_assign` returned `true`, so `out` is fully
+            // initialized.
             Some(unsafe { out.assume_init() })
         } else {
             None
         }
     }
 
-    /// In-place scalar multiplication.
+    /// Multiplies by a scalar in place.
     ///
-    /// Note: The underlying syscall inherently performs full validation
-    /// (field, curve, and subgroup checks) on the input point.
+    /// The syscall validates the point itself, so there is no `_unchecked`
+    /// variant and calling [`Self::validate`] beforehand pays for the check
+    /// twice. The scalar must be canonical; see [`Scalar`].
     ///
-    /// Returns `true` if and only if every byte of `out` was written, in
-    /// which case the caller may `assume_init` it. On `false`, `out` is
-    /// left untouched and must not be assumed initialized.
+    /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
+    /// it is poisoned. See
+    /// [Output buffer contract](crate#output-buffer-contract).
     pub fn mul_assign(
         &self,
         scalar: &Scalar,
@@ -296,10 +416,10 @@ impl G1Point {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G1_LE,
                 Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G1_BE,
             };
-            // SAFETY: the input pointers are valid for reads of their
-            // respective sizes and `out` is valid for writes of
-            // `G1_UNCOMPRESSED_POINT_SIZE` bytes. Per SIMD-0388 the syscall writes
-            // the full output buffer whenever it returns 0.
+            // SAFETY: inputs are valid for reads of their sizes, `out` for
+            // writes of `G1_UNCOMPRESSED_POINT_SIZE`. A 0 return means the
+            // syscall wrote all of it — see "Output buffer contract" in lib.rs
+            // for why that holds even though SIMD-0388 never says so.
             let status = unsafe {
                 solana_define_syscall::definitions::sol_curve_group_op(
                     curve_id,
@@ -336,21 +456,23 @@ impl G1Point {
         }
     }
 
-    /// Scalar multiplication returning a new allocated point.
+    /// Allocating form of [`Self::mul_assign`].
     pub fn mul(&self, scalar: &Scalar, endianness: Endianness) -> Option<Self> {
         let mut out = MaybeUninit::uninit();
         if self.mul_assign(scalar, &mut out, endianness) {
-            // SAFETY: `mul_assign` returned `true`, so every byte of
-            // `out` has been written.
+            // SAFETY: `mul_assign` returned `true`, so `out` is fully
+            // initialized.
             Some(unsafe { out.assume_init() })
         } else {
             None
         }
     }
 
-    /// Full point validation.
-    /// Checks that coordinates represent a valid field element, satisfy the
-    /// curve equation, and exist within the prime-order subgroup.
+    /// Checks that the coordinates are field elements, that the point is on
+    /// the curve, and that it lies in the prime-order subgroup.
+    ///
+    /// The subgroup check dominates the cost. See the README for when to hoist
+    /// this out of a loop.
     pub fn validate(&self, endianness: Endianness) -> bool {
         #[cfg(any(target_os = "solana", target_arch = "bpf"))]
         {
@@ -358,7 +480,12 @@ impl G1Point {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G1_LE,
                 Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G1_BE,
             };
+            // For BLS12-381 curve IDs the runtime ignores the result pointer
+            // and answers through the return value. The one-byte buffer is
+            // just there to keep the call well-formed.
             let mut dummy = [0u8; 1];
+            // SAFETY: `self.0` is valid for reads of `G1_UNCOMPRESSED_POINT_SIZE`
+            // bytes, `dummy` for writes of 1.
             let status = unsafe {
                 solana_define_syscall::definitions::sol_curve_validate_point(
                     curve_id,
@@ -388,22 +515,81 @@ impl G1Point {
 }
 
 impl G1Compressed {
-    /// Constructs a compressed point from a byte array via a memory copy.
+    /// Compressed infinity: compression and infinity flags set, the rest
+    /// clear.
+    pub const fn infinity(endianness: Endianness) -> Self {
+        let mut bytes = [0u8; G1_COMPRESSED_POINT_SIZE];
+        match endianness {
+            Endianness::Big => bytes[0] = 0xC0,
+            Endianness::Little => bytes[G1_COMPRESSED_POINT_SIZE - 1] = 0xC0,
+        }
+        Self(bytes)
+    }
+
+    /// Whether this is the canonical compressed infinity encoding. Evaluated
+    /// locally, without a syscall.
+    pub const fn is_infinity(&self, endianness: Endianness) -> bool {
+        let flag_index = match endianness {
+            Endianness::Big => 0,
+            Endianness::Little => G1_COMPRESSED_POINT_SIZE - 1,
+        };
+        if self.0[flag_index] != 0xC0 {
+            return false;
+        }
+        let mut i = 0;
+        while i < G1_COMPRESSED_POINT_SIZE {
+            if i != flag_index && self.0[i] != 0 {
+                return false;
+            }
+            i += 1;
+        }
+        true
+    }
+
+    /// Copies a byte array into a compressed point.
     pub const fn from_bytes(bytes: [u8; G1_COMPRESSED_POINT_SIZE]) -> Self {
         Self(bytes)
     }
 
-    /// Returns the underlying compressed byte array via a memory copy.
+    /// Reinterprets a byte array as a compressed point, without copying.
+    ///
+    /// Available under `default-features = false`. Performs no validation.
+    pub const fn from_bytes_ref(bytes: &[u8; G1_COMPRESSED_POINT_SIZE]) -> &Self {
+        // SAFETY: `G1Compressed` is `#[repr(transparent)]` over
+        // `[u8; G1_COMPRESSED_POINT_SIZE]`, so the two have identical layout
+        // and a reference to one may be reinterpreted as a reference to the
+        // other.
+        unsafe { &*(bytes as *const [u8; G1_COMPRESSED_POINT_SIZE] as *const Self) }
+    }
+
+    /// Copies out the raw compressed encoding.
     pub const fn to_bytes(&self) -> [u8; G1_COMPRESSED_POINT_SIZE] {
         self.0
     }
 
-    /// In-place decompression into an uncompressed affine point.
-    /// Inherently performs format, field, curve, and subgroup validation.
+    /// Borrows the raw compressed encoding.
+    pub const fn as_bytes(&self) -> &[u8; G1_COMPRESSED_POINT_SIZE] {
+        &self.0
+    }
+
+    /// Checks the control bits, the `x` coordinate, the curve equation, and
+    /// subgroup membership.
     ///
-    /// Returns `true` if and only if every byte of `out` was written, in
-    /// which case the caller may `assume_init` it. On `false`, `out` is
-    /// left untouched and must not be assumed initialized.
+    /// There is no validate-compressed syscall, so this decompresses and
+    /// discards the result, costing exactly what [`Self::decompress`] costs.
+    /// Callers that intend to decompress should do so and match on `None`
+    /// rather than pay for both.
+    pub fn validate(&self, endianness: Endianness) -> bool {
+        let mut out = MaybeUninit::uninit();
+        self.decompress_assign(&mut out, endianness)
+    }
+
+    /// Decompresses into an affine point, checking format, field, curve
+    /// equation, and subgroup membership.
+    ///
+    /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
+    /// it is poisoned. See
+    /// [Output buffer contract](crate#output-buffer-contract).
     pub fn decompress_assign(
         &self,
         out: &mut MaybeUninit<G1Point>,
@@ -415,10 +601,9 @@ impl G1Compressed {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G1_LE,
                 Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G1_BE,
             };
-            // SAFETY: `self.0` is valid for reads of its size and `out`
-            // is valid for writes of `G1_UNCOMPRESSED_POINT_SIZE` bytes. Per
-            // SIMD-0388 the syscall writes the full output buffer
-            // whenever it returns 0.
+            // SAFETY: `self.0` is valid for reads of its size, `out` for
+            // writes of `G1_UNCOMPRESSED_POINT_SIZE`. A 0 return means the
+            // syscall wrote all of it — see "Output buffer contract" in lib.rs.
             let status = unsafe {
                 solana_define_syscall::definitions::sol_curve_decompress(
                     curve_id,
@@ -451,12 +636,12 @@ impl G1Compressed {
         }
     }
 
-    /// Decompresses into a new allocated affine point.
+    /// Allocating form of [`Self::decompress_assign`].
     pub fn decompress(&self, endianness: Endianness) -> Option<G1Point> {
         let mut out = MaybeUninit::uninit();
         if self.decompress_assign(&mut out, endianness) {
-            // SAFETY: `decompress_assign` returned `true`, so every byte of
-            // `out` has been written.
+            // SAFETY: `decompress_assign` returned `true`, so `out` is fully
+            // initialized.
             Some(unsafe { out.assume_init() })
         } else {
             None

--- a/bls12-381/src/g2.rs
+++ b/bls12-381/src/g2.rs
@@ -120,7 +120,7 @@ impl G2Point {
             if i != flag_index && self.0[i] != 0 {
                 return false;
             }
-            i += 1;
+            i = i.wrapping_add(1);
         }
         true
     }
@@ -554,7 +554,7 @@ impl G2Compressed {
             if i != flag_index && self.0[i] != 0 {
                 return false;
             }
-            i += 1;
+            i = i.wrapping_add(1);
         }
         true
     }

--- a/bls12-381/src/g2.rs
+++ b/bls12-381/src/g2.rs
@@ -14,8 +14,11 @@ pub const G2_COMPRESSED_POINT_SIZE: usize = 96;
 /// Size of an uncompressed BLS12-381 G2 affine point in bytes.
 pub const G2_UNCOMPRESSED_POINT_SIZE: usize = 192;
 
-/// Uncompressed BLS12-381 G2 affine point.
-/// Represents the `x` and `y` coordinates in the extension field (192 bytes).
+/// An uncompressed G2 affine point: `x` and `y` in the extension field,
+/// 192 bytes.
+///
+/// The all-zero encoding is not the identity; use [`Self::infinity`]. See the
+/// crate documentation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(
     any(
@@ -25,10 +28,13 @@ pub const G2_UNCOMPRESSED_POINT_SIZE: usize = 192;
     derive(Pod, Zeroable)
 )]
 #[repr(transparent)]
-pub struct G2Point(pub [u8; G2_UNCOMPRESSED_POINT_SIZE]);
+pub struct G2Point(
+    /// The raw affine encoding, in whichever [`Endianness`] each operation is
+    /// given. No validity invariant: these bytes may not be a curve point.
+    pub [u8; G2_UNCOMPRESSED_POINT_SIZE],
+);
 
-/// Compressed BLS12-381 G2 point.
-/// Represents the `x` coordinate with control flags in the MSB (96 bytes).
+/// A compressed G2 point: `x` with control flags in the top byte, 96 bytes.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(
     any(
@@ -38,10 +44,46 @@ pub struct G2Point(pub [u8; G2_UNCOMPRESSED_POINT_SIZE]);
     derive(Pod, Zeroable)
 )]
 #[repr(transparent)]
-pub struct G2Compressed(pub [u8; G2_COMPRESSED_POINT_SIZE]);
+pub struct G2Compressed(
+    /// The raw compressed encoding, in whichever [`Endianness`] each operation
+    /// is given. No validity invariant.
+    pub [u8; G2_COMPRESSED_POINT_SIZE],
+);
+
+/// G2 base point, big-endian.
+const G2_GENERATOR_BE: [u8; G2_UNCOMPRESSED_POINT_SIZE] = [
+    0x13, 0xE0, 0x2B, 0x60, 0x52, 0x71, 0x9F, 0x60, 0x7D, 0xAC, 0xD3, 0xA0, 0x88, 0x27, 0x4F, 0x65,
+    0x59, 0x6B, 0xD0, 0xD0, 0x99, 0x20, 0xB6, 0x1A, 0xB5, 0xDA, 0x61, 0xBB, 0xDC, 0x7F, 0x50, 0x49,
+    0x33, 0x4C, 0xF1, 0x12, 0x13, 0x94, 0x5D, 0x57, 0xE5, 0xAC, 0x7D, 0x05, 0x5D, 0x04, 0x2B, 0x7E,
+    0x02, 0x4A, 0xA2, 0xB2, 0xF0, 0x8F, 0x0A, 0x91, 0x26, 0x08, 0x05, 0x27, 0x2D, 0xC5, 0x10, 0x51,
+    0xC6, 0xE4, 0x7A, 0xD4, 0xFA, 0x40, 0x3B, 0x02, 0xB4, 0x51, 0x0B, 0x64, 0x7A, 0xE3, 0xD1, 0x77,
+    0x0B, 0xAC, 0x03, 0x26, 0xA8, 0x05, 0xBB, 0xEF, 0xD4, 0x80, 0x56, 0xC8, 0xC1, 0x21, 0xBD, 0xB8,
+    0x06, 0x06, 0xC4, 0xA0, 0x2E, 0xA7, 0x34, 0xCC, 0x32, 0xAC, 0xD2, 0xB0, 0x2B, 0xC2, 0x8B, 0x99,
+    0xCB, 0x3E, 0x28, 0x7E, 0x85, 0xA7, 0x63, 0xAF, 0x26, 0x74, 0x92, 0xAB, 0x57, 0x2E, 0x99, 0xAB,
+    0x3F, 0x37, 0x0D, 0x27, 0x5C, 0xEC, 0x1D, 0xA1, 0xAA, 0xA9, 0x07, 0x5F, 0xF0, 0x5F, 0x79, 0xBE,
+    0x0C, 0xE5, 0xD5, 0x27, 0x72, 0x7D, 0x6E, 0x11, 0x8C, 0xC9, 0xCD, 0xC6, 0xDA, 0x2E, 0x35, 0x1A,
+    0xAD, 0xFD, 0x9B, 0xAA, 0x8C, 0xBD, 0xD3, 0xA7, 0x6D, 0x42, 0x9A, 0x69, 0x51, 0x60, 0xD1, 0x2C,
+    0x92, 0x3A, 0xC9, 0xCC, 0x3B, 0xAC, 0xA2, 0x89, 0xE1, 0x93, 0x54, 0x86, 0x08, 0xB8, 0x28, 0x01,
+];
+
+/// G2 base point, little-endian.
+const G2_GENERATOR_LE: [u8; G2_UNCOMPRESSED_POINT_SIZE] = [
+    0xB8, 0xBD, 0x21, 0xC1, 0xC8, 0x56, 0x80, 0xD4, 0xEF, 0xBB, 0x05, 0xA8, 0x26, 0x03, 0xAC, 0x0B,
+    0x77, 0xD1, 0xE3, 0x7A, 0x64, 0x0B, 0x51, 0xB4, 0x02, 0x3B, 0x40, 0xFA, 0xD4, 0x7A, 0xE4, 0xC6,
+    0x51, 0x10, 0xC5, 0x2D, 0x27, 0x05, 0x08, 0x26, 0x91, 0x0A, 0x8F, 0xF0, 0xB2, 0xA2, 0x4A, 0x02,
+    0x7E, 0x2B, 0x04, 0x5D, 0x05, 0x7D, 0xAC, 0xE5, 0x57, 0x5D, 0x94, 0x13, 0x12, 0xF1, 0x4C, 0x33,
+    0x49, 0x50, 0x7F, 0xDC, 0xBB, 0x61, 0xDA, 0xB5, 0x1A, 0xB6, 0x20, 0x99, 0xD0, 0xD0, 0x6B, 0x59,
+    0x65, 0x4F, 0x27, 0x88, 0xA0, 0xD3, 0xAC, 0x7D, 0x60, 0x9F, 0x71, 0x52, 0x60, 0x2B, 0xE0, 0x13,
+    0x01, 0x28, 0xB8, 0x08, 0x86, 0x54, 0x93, 0xE1, 0x89, 0xA2, 0xAC, 0x3B, 0xCC, 0xC9, 0x3A, 0x92,
+    0x2C, 0xD1, 0x60, 0x51, 0x69, 0x9A, 0x42, 0x6D, 0xA7, 0xD3, 0xBD, 0x8C, 0xAA, 0x9B, 0xFD, 0xAD,
+    0x1A, 0x35, 0x2E, 0xDA, 0xC6, 0xCD, 0xC9, 0x8C, 0x11, 0x6E, 0x7D, 0x72, 0x27, 0xD5, 0xE5, 0x0C,
+    0xBE, 0x79, 0x5F, 0xF0, 0x5F, 0x07, 0xA9, 0xAA, 0xA1, 0x1D, 0xEC, 0x5C, 0x27, 0x0D, 0x37, 0x3F,
+    0xAB, 0x99, 0x2E, 0x57, 0xAB, 0x92, 0x74, 0x26, 0xAF, 0x63, 0xA7, 0x85, 0x7E, 0x28, 0x3E, 0xCB,
+    0x99, 0x8B, 0xC2, 0x2B, 0xB0, 0xD2, 0xAC, 0x32, 0xCC, 0x34, 0xA7, 0x2E, 0xA0, 0xC4, 0x06, 0x06,
+];
 
 impl G2Point {
-    /// Returns the identity (infinity) element for the given endianness.
+    /// Returns the identity (infinity) element in the given encoding.
     pub const fn infinity(endianness: Endianness) -> Self {
         let mut bytes = [0u8; G2_UNCOMPRESSED_POINT_SIZE];
         match endianness {
@@ -52,32 +94,127 @@ impl G2Point {
         Self(bytes)
     }
 
-    /// Constructs a point from a byte array via a memory copy.
+    /// The standard G2 base point from the Zcash/IETF specification.
+    pub const fn generator(endianness: Endianness) -> Self {
+        match endianness {
+            Endianness::Big => Self(G2_GENERATOR_BE),
+            Endianness::Little => Self(G2_GENERATOR_LE),
+        }
+    }
+
+    /// Whether this is the canonical infinity encoding: infinity flag set,
+    /// every other bit clear.
     ///
-    /// Note: For zero-copy deserialization from instruction data, use
-    /// `bytemuck::cast_ref` directly on the byte slice.
+    /// Evaluated locally, without a syscall. A point that fails this check is
+    /// not thereby invalid — that question belongs to [`Self::validate`].
+    pub const fn is_infinity(&self, endianness: Endianness) -> bool {
+        let flag_index = match endianness {
+            Endianness::Big => 0,
+            Endianness::Little => 95,
+        };
+        if self.0[flag_index] != 0x40 {
+            return false;
+        }
+        let mut i = 0;
+        while i < G2_UNCOMPRESSED_POINT_SIZE {
+            if i != flag_index && self.0[i] != 0 {
+                return false;
+            }
+            i += 1;
+        }
+        true
+    }
+
+    /// Copies a byte array into a point.
+    ///
+    /// For instruction data, [`Self::from_bytes_ref`] or `bytemuck::cast_ref`
+    /// avoid the copy.
     pub const fn from_bytes(bytes: [u8; G2_UNCOMPRESSED_POINT_SIZE]) -> Self {
         Self(bytes)
     }
 
-    /// Returns the underlying byte array via a memory copy.
+    /// Copies out the raw 192-byte encoding. [`Self::as_bytes`] borrows
+    /// instead.
     pub const fn to_bytes(&self) -> [u8; G2_UNCOMPRESSED_POINT_SIZE] {
         self.0
     }
 
-    /// Safely negates the point by subtracting it from infinity.
-    pub fn neg(&self, endianness: Endianness) -> Option<Self> {
-        Self::infinity(endianness).sub(self, endianness)
+    /// Borrows the raw encoding.
+    pub const fn as_bytes(&self) -> &[u8; G2_UNCOMPRESSED_POINT_SIZE] {
+        &self.0
     }
 
-    /// In-place point addition.
+    /// Reinterprets a byte array as a point, without copying.
     ///
-    /// WARNING: This operation skips the prime-order subgroup check
-    /// for performance. Only use this if inputs are known to be valid.
+    /// Available under `default-features = false`, unlike `bytemuck::cast_ref`.
+    /// Performs no validation.
+    pub const fn from_bytes_ref(bytes: &[u8; G2_UNCOMPRESSED_POINT_SIZE]) -> &Self {
+        // SAFETY: `G2Point` is `#[repr(transparent)]` over
+        // `[u8; G2_UNCOMPRESSED_POINT_SIZE]`, so the two have identical
+        // layout and a reference to one may be reinterpreted as a reference to
+        // the other.
+        unsafe { &*(bytes as *const [u8; G2_UNCOMPRESSED_POINT_SIZE] as *const Self) }
+    }
+
+    /// Negates in place, skipping the subgroup check on `self`.
     ///
-    /// Returns `true` if and only if every byte of `out` was written, in
-    /// which case the caller may `assume_init` it. On `false`, `out` is
-    /// left untouched and must not be assumed initialized.
+    /// An off-subgroup input yields an off-subgroup result rather than an error.
+    ///
+    /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
+    /// it is poisoned. See
+    /// [Output buffer contract](crate#output-buffer-contract).
+    pub fn neg_assign_unchecked(
+        &self,
+        out: &mut MaybeUninit<Self>,
+        endianness: Endianness,
+    ) -> bool {
+        Self::infinity(endianness).sub_assign_unchecked(self, out, endianness)
+    }
+
+    /// Allocating form of [`Self::neg_assign_unchecked`].
+    pub fn neg_unchecked(&self, endianness: Endianness) -> Option<Self> {
+        Self::infinity(endianness).sub_unchecked(self, endianness)
+    }
+
+    /// Negates in place, validating `self` first.
+    ///
+    /// Issues two syscalls: validation, then subtraction from infinity.
+    /// Infinity needs no validation of its own, and the subtraction syscall
+    /// repeats the field and on-curve checks internally, so one validation
+    /// covers the pair.
+    ///
+    /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
+    /// it is poisoned. See
+    /// [Output buffer contract](crate#output-buffer-contract).
+    pub fn neg_assign(&self, out: &mut MaybeUninit<Self>, endianness: Endianness) -> bool {
+        if !self.validate(endianness) {
+            return false;
+        }
+        self.neg_assign_unchecked(out, endianness)
+    }
+
+    /// Allocating form of [`Self::neg_assign`].
+    pub fn neg(&self, endianness: Endianness) -> Option<Self> {
+        let mut out = MaybeUninit::uninit();
+        if self.neg_assign(&mut out, endianness) {
+            // SAFETY: `neg_assign` returned `true`, so `out` is fully
+            // initialized.
+            Some(unsafe { out.assume_init() })
+        } else {
+            None
+        }
+    }
+
+    /// Adds in place, skipping the subgroup check on both operands.
+    ///
+    /// The principal compute-unit optimization. The subgroup is closed under
+    /// addition, so an accumulator built from validated points remains valid
+    /// and re-validating it each iteration buys nothing: validate at the trust
+    /// boundary and accumulate with this method. See the README for the loop.
+    ///
+    /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
+    /// it is poisoned. See
+    /// [Output buffer contract](crate#output-buffer-contract).
     pub fn add_assign_unchecked(
         &self,
         other: &Self,
@@ -90,10 +227,10 @@ impl G2Point {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G2_LE,
                 Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G2_BE,
             };
-            // SAFETY: the input pointers are valid for reads of their
-            // respective sizes and `out` is valid for writes of
-            // `G2_UNCOMPRESSED_POINT_SIZE` bytes. Per SIMD-0388 the syscall writes
-            // the full output buffer whenever it returns 0.
+            // SAFETY: inputs are valid for reads of their sizes, `out` for
+            // writes of `G2_UNCOMPRESSED_POINT_SIZE`. A 0 return means the
+            // syscall wrote all of it — see "Output buffer contract" in lib.rs
+            // for why that holds even though SIMD-0388 never says so.
             let status = unsafe {
                 solana_define_syscall::definitions::sol_curve_group_op(
                     curve_id,
@@ -130,25 +267,23 @@ impl G2Point {
         }
     }
 
-    /// Point addition returning a new allocated point.
-    /// Skips subgroup checks.
+    /// Allocating form of [`Self::add_assign_unchecked`].
     pub fn add_unchecked(&self, other: &Self, endianness: Endianness) -> Option<Self> {
         let mut out = MaybeUninit::uninit();
         if self.add_assign_unchecked(other, &mut out, endianness) {
-            // SAFETY: `add_assign_unchecked` returned `true`, so every byte of
-            // `out` has been written.
+            // SAFETY: `add_assign_unchecked` returned `true`, so `out` is fully
+            // initialized.
             Some(unsafe { out.assume_init() })
         } else {
             None
         }
     }
 
-    /// Safe in-place point addition.
-    /// Validates both operands (field, curve, subgroup) prior to addition.
+    /// Adds in place, validating both operands first.
     ///
-    /// Returns `true` if and only if every byte of `out` was written, in
-    /// which case the caller may `assume_init` it. On `false`, `out` is
-    /// left untouched and must not be assumed initialized.
+    /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
+    /// it is poisoned. See
+    /// [Output buffer contract](crate#output-buffer-contract).
     pub fn add_assign(
         &self,
         other: &Self,
@@ -161,26 +296,25 @@ impl G2Point {
         self.add_assign_unchecked(other, out, endianness)
     }
 
-    /// Safe point addition returning a new allocated point.
+    /// Allocating form of [`Self::add_assign`].
     pub fn add(&self, other: &Self, endianness: Endianness) -> Option<Self> {
         let mut out = MaybeUninit::uninit();
         if self.add_assign(other, &mut out, endianness) {
-            // SAFETY: `add_assign` returned `true`, so every byte of
-            // `out` has been written.
+            // SAFETY: `add_assign` returned `true`, so `out` is fully
+            // initialized.
             Some(unsafe { out.assume_init() })
         } else {
             None
         }
     }
 
-    /// In-place point subtraction.
+    /// Subtracts in place, skipping the subgroup check on both operands.
     ///
-    /// WARNING: This operation skips the prime-order subgroup check
-    /// for performance. Only use this if inputs are known to be valid.
+    /// Carries the same caveat as [`Self::add_assign_unchecked`].
     ///
-    /// Returns `true` if and only if every byte of `out` was written, in
-    /// which case the caller may `assume_init` it. On `false`, `out` is
-    /// left untouched and must not be assumed initialized.
+    /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
+    /// it is poisoned. See
+    /// [Output buffer contract](crate#output-buffer-contract).
     pub fn sub_assign_unchecked(
         &self,
         other: &Self,
@@ -193,10 +327,10 @@ impl G2Point {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G2_LE,
                 Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G2_BE,
             };
-            // SAFETY: the input pointers are valid for reads of their
-            // respective sizes and `out` is valid for writes of
-            // `G2_UNCOMPRESSED_POINT_SIZE` bytes. Per SIMD-0388 the syscall writes
-            // the full output buffer whenever it returns 0.
+            // SAFETY: inputs are valid for reads of their sizes, `out` for
+            // writes of `G2_UNCOMPRESSED_POINT_SIZE`. A 0 return means the
+            // syscall wrote all of it — see "Output buffer contract" in lib.rs
+            // for why that holds even though SIMD-0388 never says so.
             let status = unsafe {
                 solana_define_syscall::definitions::sol_curve_group_op(
                     curve_id,
@@ -233,25 +367,23 @@ impl G2Point {
         }
     }
 
-    /// Point subtraction returning a new allocated point.
-    /// Skips subgroup checks.
+    /// Allocating form of [`Self::sub_assign_unchecked`].
     pub fn sub_unchecked(&self, other: &Self, endianness: Endianness) -> Option<Self> {
         let mut out = MaybeUninit::uninit();
         if self.sub_assign_unchecked(other, &mut out, endianness) {
-            // SAFETY: `sub_assign_unchecked` returned `true`, so every byte of
-            // `out` has been written.
+            // SAFETY: `sub_assign_unchecked` returned `true`, so `out` is fully
+            // initialized.
             Some(unsafe { out.assume_init() })
         } else {
             None
         }
     }
 
-    /// Safe in-place point subtraction.
-    /// Validates both operands prior to subtraction.
+    /// Subtracts in place, validating both operands first.
     ///
-    /// Returns `true` if and only if every byte of `out` was written, in
-    /// which case the caller may `assume_init` it. On `false`, `out` is
-    /// left untouched and must not be assumed initialized.
+    /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
+    /// it is poisoned. See
+    /// [Output buffer contract](crate#output-buffer-contract).
     pub fn sub_assign(
         &self,
         other: &Self,
@@ -264,26 +396,27 @@ impl G2Point {
         self.sub_assign_unchecked(other, out, endianness)
     }
 
-    /// Safe point subtraction returning a new allocated point.
+    /// Allocating form of [`Self::sub_assign`].
     pub fn sub(&self, other: &Self, endianness: Endianness) -> Option<Self> {
         let mut out = MaybeUninit::uninit();
         if self.sub_assign(other, &mut out, endianness) {
-            // SAFETY: `sub_assign` returned `true`, so every byte of
-            // `out` has been written.
+            // SAFETY: `sub_assign` returned `true`, so `out` is fully
+            // initialized.
             Some(unsafe { out.assume_init() })
         } else {
             None
         }
     }
 
-    /// In-place scalar multiplication.
+    /// Multiplies by a scalar in place.
     ///
-    /// Note: The underlying syscall inherently performs full validation
-    /// (field, curve, and subgroup checks) on the input point.
+    /// The syscall validates the point itself, so there is no `_unchecked`
+    /// variant and calling [`Self::validate`] beforehand pays for the check
+    /// twice. The scalar must be canonical; see [`Scalar`].
     ///
-    /// Returns `true` if and only if every byte of `out` was written, in
-    /// which case the caller may `assume_init` it. On `false`, `out` is
-    /// left untouched and must not be assumed initialized.
+    /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
+    /// it is poisoned. See
+    /// [Output buffer contract](crate#output-buffer-contract).
     pub fn mul_assign(
         &self,
         scalar: &Scalar,
@@ -296,10 +429,10 @@ impl G2Point {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G2_LE,
                 Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G2_BE,
             };
-            // SAFETY: the input pointers are valid for reads of their
-            // respective sizes and `out` is valid for writes of
-            // `G2_UNCOMPRESSED_POINT_SIZE` bytes. Per SIMD-0388 the syscall writes
-            // the full output buffer whenever it returns 0.
+            // SAFETY: inputs are valid for reads of their sizes, `out` for
+            // writes of `G2_UNCOMPRESSED_POINT_SIZE`. A 0 return means the
+            // syscall wrote all of it — see "Output buffer contract" in lib.rs
+            // for why that holds even though SIMD-0388 never says so.
             let status = unsafe {
                 solana_define_syscall::definitions::sol_curve_group_op(
                     curve_id,
@@ -336,21 +469,23 @@ impl G2Point {
         }
     }
 
-    /// Scalar multiplication returning a new allocated point.
+    /// Allocating form of [`Self::mul_assign`].
     pub fn mul(&self, scalar: &Scalar, endianness: Endianness) -> Option<Self> {
         let mut out = MaybeUninit::uninit();
         if self.mul_assign(scalar, &mut out, endianness) {
-            // SAFETY: `mul_assign` returned `true`, so every byte of
-            // `out` has been written.
+            // SAFETY: `mul_assign` returned `true`, so `out` is fully
+            // initialized.
             Some(unsafe { out.assume_init() })
         } else {
             None
         }
     }
 
-    /// Full point validation.
-    /// Checks that coordinates represent valid field elements, satisfy the
-    /// curve equation, and exist within the prime-order subgroup.
+    /// Checks that the coordinates are field elements, that the point is on
+    /// the curve, and that it lies in the prime-order subgroup.
+    ///
+    /// The subgroup check dominates the cost. See the README for when to hoist
+    /// this out of a loop.
     pub fn validate(&self, endianness: Endianness) -> bool {
         #[cfg(any(target_os = "solana", target_arch = "bpf"))]
         {
@@ -358,7 +493,12 @@ impl G2Point {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G2_LE,
                 Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G2_BE,
             };
+            // For BLS12-381 curve IDs the runtime ignores the result pointer
+            // and answers through the return value. The one-byte buffer is
+            // just there to keep the call well-formed.
             let mut dummy = [0u8; 1];
+            // SAFETY: `self.0` is valid for reads of `G2_UNCOMPRESSED_POINT_SIZE`
+            // bytes, `dummy` for writes of 1.
             let status = unsafe {
                 solana_define_syscall::definitions::sol_curve_validate_point(
                     curve_id,
@@ -388,22 +528,81 @@ impl G2Point {
 }
 
 impl G2Compressed {
-    /// Constructs a compressed point from a byte array via a memory copy.
+    /// Compressed infinity: compression and infinity flags set, the rest
+    /// clear.
+    pub const fn infinity(endianness: Endianness) -> Self {
+        let mut bytes = [0u8; G2_COMPRESSED_POINT_SIZE];
+        match endianness {
+            Endianness::Big => bytes[0] = 0xC0,
+            Endianness::Little => bytes[G2_COMPRESSED_POINT_SIZE - 1] = 0xC0,
+        }
+        Self(bytes)
+    }
+
+    /// Whether this is the canonical compressed infinity encoding. Evaluated
+    /// locally, without a syscall.
+    pub const fn is_infinity(&self, endianness: Endianness) -> bool {
+        let flag_index = match endianness {
+            Endianness::Big => 0,
+            Endianness::Little => G2_COMPRESSED_POINT_SIZE - 1,
+        };
+        if self.0[flag_index] != 0xC0 {
+            return false;
+        }
+        let mut i = 0;
+        while i < G2_COMPRESSED_POINT_SIZE {
+            if i != flag_index && self.0[i] != 0 {
+                return false;
+            }
+            i += 1;
+        }
+        true
+    }
+
+    /// Copies a byte array into a compressed point.
     pub const fn from_bytes(bytes: [u8; G2_COMPRESSED_POINT_SIZE]) -> Self {
         Self(bytes)
     }
 
-    /// Returns the underlying compressed byte array via a memory copy.
+    /// Reinterprets a byte array as a compressed point, without copying.
+    ///
+    /// Available under `default-features = false`. Performs no validation.
+    pub const fn from_bytes_ref(bytes: &[u8; G2_COMPRESSED_POINT_SIZE]) -> &Self {
+        // SAFETY: `G2Compressed` is `#[repr(transparent)]` over
+        // `[u8; G2_COMPRESSED_POINT_SIZE]`, so the two have identical layout
+        // and a reference to one may be reinterpreted as a reference to the
+        // other.
+        unsafe { &*(bytes as *const [u8; G2_COMPRESSED_POINT_SIZE] as *const Self) }
+    }
+
+    /// Copies out the raw compressed encoding.
     pub const fn to_bytes(&self) -> [u8; G2_COMPRESSED_POINT_SIZE] {
         self.0
     }
 
-    /// In-place decompression into an uncompressed affine point.
-    /// Inherently performs format, field, curve, and subgroup validation.
+    /// Borrows the raw compressed encoding.
+    pub const fn as_bytes(&self) -> &[u8; G2_COMPRESSED_POINT_SIZE] {
+        &self.0
+    }
+
+    /// Checks the control bits, the `x` coordinate, the curve equation, and
+    /// subgroup membership.
     ///
-    /// Returns `true` if and only if every byte of `out` was written, in
-    /// which case the caller may `assume_init` it. On `false`, `out` is
-    /// left untouched and must not be assumed initialized.
+    /// There is no validate-compressed syscall, so this decompresses and
+    /// discards the result, costing exactly what [`Self::decompress`] costs.
+    /// Callers that intend to decompress should do so and match on `None`
+    /// rather than pay for both.
+    pub fn validate(&self, endianness: Endianness) -> bool {
+        let mut out = MaybeUninit::uninit();
+        self.decompress_assign(&mut out, endianness)
+    }
+
+    /// Decompresses into an affine point, checking format, field, curve
+    /// equation, and subgroup membership.
+    ///
+    /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
+    /// it is poisoned. See
+    /// [Output buffer contract](crate#output-buffer-contract).
     pub fn decompress_assign(
         &self,
         out: &mut MaybeUninit<G2Point>,
@@ -415,10 +614,9 @@ impl G2Compressed {
                 Endianness::Little => solana_define_syscall::curve_constants::BLS12_381_G2_LE,
                 Endianness::Big => solana_define_syscall::curve_constants::BLS12_381_G2_BE,
             };
-            // SAFETY: `self.0` is valid for reads of its size and `out`
-            // is valid for writes of `G2_UNCOMPRESSED_POINT_SIZE` bytes. Per
-            // SIMD-0388 the syscall writes the full output buffer
-            // whenever it returns 0.
+            // SAFETY: `self.0` is valid for reads of its size, `out` for
+            // writes of `G2_UNCOMPRESSED_POINT_SIZE`. A 0 return means the
+            // syscall wrote all of it — see "Output buffer contract" in lib.rs.
             let status = unsafe {
                 solana_define_syscall::definitions::sol_curve_decompress(
                     curve_id,
@@ -451,12 +649,12 @@ impl G2Compressed {
         }
     }
 
-    /// Decompresses into a new allocated affine point.
+    /// Allocating form of [`Self::decompress_assign`].
     pub fn decompress(&self, endianness: Endianness) -> Option<G2Point> {
         let mut out = MaybeUninit::uninit();
         if self.decompress_assign(&mut out, endianness) {
-            // SAFETY: `decompress_assign` returned `true`, so every byte of
-            // `out` has been written.
+            // SAFETY: `decompress_assign` returned `true`, so `out` is fully
+            // initialized.
             Some(unsafe { out.assume_init() })
         } else {
             None

--- a/bls12-381/src/lib.rs
+++ b/bls12-381/src/lib.rs
@@ -1,15 +1,66 @@
+//! BLS12-381 elliptic curve operations for Solana programs, wrapping the
+//! native syscalls defined in [SIMD-0388].
+//!
+//! [SIMD-0388]: https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0388-bls12-381-syscalls.md
+//!
+//! # Output buffer contract
+//!
+//! Every `_assign` method writes into a caller-supplied
+//! [`MaybeUninit`](core::mem::MaybeUninit) buffer and reports success as a
+//! `bool`:
+//!
+//! - On `true`, the buffer is fully initialized and may be `assume_init`ed.
+//! - On `false`, treat it as uninitialized, even if it held a valid value
+//!   going in. A failed operation may write part of the buffer before
+//!   detecting the error, so it poisons its output.
+//!
+//! The `true` case is a soundness requirement: reading an uninitialized byte is
+//! undefined behavior. SIMD-0388 does not state that a syscall fills the buffer
+//! on success.
+//!
+//! Nothing constrains a *failing* syscall, hence the poisoning rule above
+//! rather than a guarantee that the buffer is left untouched.
+//!
+//! # The all-zero encoding is not the identity
+//!
+//! The point types implement `bytemuck::Zeroable`, so `G1Point::zeroed()`
+//! compiles. All-zero is not infinity, and is not a point at all, since
+//! `(0, 0)` does not satisfy `y^2 = x^3 + 4`. [`G1Point::infinity`] is the
+//! identity.
+//!
+//! [`G1Point::infinity`]: g1::G1Point::infinity
+//!
+//! # Aliasing
+//!
+//! SIMD-0388 does not specify whether the result pointer may alias an input
+//! pointer. This crate is unaffected: `_assign` methods take `&self` alongside
+//! `&mut MaybeUninit<Self>`, so an aliasing call cannot be expressed in safe
+//! Rust.
+
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+/// Error type for the operations that distinguish their failure modes.
+pub mod error;
+/// Points and encodings in the G1 group.
 pub mod g1;
+/// Points and encodings in the G2 group.
 pub mod g2;
+/// Pairing operations and the target group.
 pub mod pairing;
+/// Scalar field elements.
 pub mod scalar;
 
-pub use {g1::*, g2::*, pairing::*, scalar::*};
+pub use {error::*, g1::*, g2::*, pairing::*, scalar::*};
 
+/// Byte order of the base field (`Fq`) elements.
+///
+/// Picks between the `_LE` and `_BE` curve IDs in SIMD-0388.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Endianness {
+    /// `Fq` byte-reversed relative to [`Endianness::Big`]; `Fq2` ordered `c0`
+    /// then `c1`.
     Little,
+    /// The canonical Zcash/IETF encoding. `Fq2` ordered `c1` then `c0`.
     Big,
 }

--- a/bls12-381/src/pairing.rs
+++ b/bls12-381/src/pairing.rs
@@ -57,7 +57,7 @@ impl GtElement {
             if i != one_index && self.0[i] != 0 {
                 return false;
             }
-            i += 1;
+            i = i.wrapping_add(1);
         }
         true
     }

--- a/bls12-381/src/pairing.rs
+++ b/bls12-381/src/pairing.rs
@@ -160,23 +160,52 @@ pub fn pairing(
     )
 }
 
-/// Evaluates if the product of pairings equals the identity element.
+/// Evaluates whether the product of pairings equals the identity element.
 ///
-/// Highly efficient for ZK verifiers (e.g., Groth16) as it avoids returning
-/// the raw 576-byte `GtElement` to the caller.
+/// Returns `Some(true)` if `e(P_1, Q_1) * ... * e(P_n, Q_n) == 1`,
+/// `Some(false)` if the product is some other target group element, and
+/// `None` if the check could not be run at all.
+///
+/// # Empty batches
+///
+/// Unlike [`pairing_map`], this rejects an empty batch with `None` rather
+/// than reporting the vacuously-true identity. `pairing_check` is a
+/// verification primitive, and callers typically build these slices from
+/// attacker-controlled instruction data: a zero-length batch that reports
+/// `Some(true)` is a verification bypass, not a mathematical convenience.
+/// If you genuinely want the empty product, call [`pairing_map`] and compare
+/// against [`GtElement::identity`] yourself.
+///
+/// # Correct usage
+///
+/// `None` means "the check did not run", which is not the same as
+/// "verification failed" — but both must be treated as failure:
+///
+/// ```ignore
+/// if pairing_check(g1, g2, e) != Some(true) {
+///     return Err(ProgramError::InvalidArgument);
+/// }
+/// ```
+///
+/// Never branch on `.is_some()`.
 pub fn pairing_check(
     g1_points: &[G1Point],
     g2_points: &[G2Point],
     endianness: Endianness,
 ) -> Option<bool> {
+    // A check that asserts nothing must not report success.
+    if g1_points.is_empty() {
+        return None;
+    }
+
     let mut out = MaybeUninit::uninit();
 
     if !pairing_map_assign(g1_points, g2_points, &mut out, endianness) {
         return None;
     }
 
-    // SAFETY: `pairing_map_assign` returned `true`, so every byte of `out` has
-    // been written.
+    // SAFETY: `pairing_map_assign` returned `true`, so every byte of `out`
+    // has been written.
     let gt = unsafe { out.assume_init() };
 
     Some(gt == GtElement::identity(endianness))

--- a/bls12-381/src/pairing.rs
+++ b/bls12-381/src/pairing.rs
@@ -4,18 +4,17 @@
 ))]
 use bytemuck_derive::{Pod, Zeroable};
 use {
-    crate::{g1::G1Point, g2::G2Point, Endianness},
+    crate::{error::Bls12381Error, g1::G1Point, g2::G2Point, Endianness},
     core::mem::MaybeUninit,
 };
 
 /// Size of a target group (Gt) element in bytes.
 pub const GT_ELEMENT_SIZE: usize = 576;
 
-/// Maximum number of pairs allowed in a single batch pairing operation.
+/// Maximum number of pairs in a single batch pairing.
 pub const MAX_PAIRING_LENGTH: usize = 8;
 
-/// An element in the target group (Gt).
-/// Represents an element in the extension field Fq12 (576 bytes).
+/// A target group (Gt) element — a point in Fq12, 576 bytes.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(
     any(
@@ -25,11 +24,13 @@ pub const MAX_PAIRING_LENGTH: usize = 8;
     derive(Pod, Zeroable)
 )]
 #[repr(transparent)]
-pub struct GtElement(pub [u8; GT_ELEMENT_SIZE]);
+pub struct GtElement(
+    /// The raw encoding, in whichever [`Endianness`] produced it.
+    pub [u8; GT_ELEMENT_SIZE],
+);
 
 impl GtElement {
-    /// Returns the multiplicative identity of the target group for the given
-    /// endianness.
+    /// The multiplicative identity, in the given encoding.
     pub const fn identity(endianness: Endianness) -> Self {
         let mut bytes = [0u8; GT_ELEMENT_SIZE];
         match endianness {
@@ -38,29 +39,86 @@ impl GtElement {
         }
         Self(bytes)
     }
+
+    /// Whether this is the multiplicative identity.
+    ///
+    /// Evaluated locally, and cheaper than `== identity()`, which constructs a
+    /// 576-byte value solely for the comparison.
+    pub const fn is_identity(&self, endianness: Endianness) -> bool {
+        let one_index = match endianness {
+            Endianness::Little => 0,
+            Endianness::Big => GT_ELEMENT_SIZE - 1,
+        };
+        if self.0[one_index] != 1 {
+            return false;
+        }
+        let mut i = 0;
+        while i < GT_ELEMENT_SIZE {
+            if i != one_index && self.0[i] != 0 {
+                return false;
+            }
+            i += 1;
+        }
+        true
+    }
+
+    /// Copies a byte array into a target group element.
+    pub const fn from_bytes(bytes: [u8; GT_ELEMENT_SIZE]) -> Self {
+        Self(bytes)
+    }
+
+    /// Reinterprets a byte array as a target group element, without copying.
+    ///
+    /// Available under `default-features = false`.
+    pub const fn from_bytes_ref(bytes: &[u8; GT_ELEMENT_SIZE]) -> &Self {
+        // SAFETY: `GtElement` is `#[repr(transparent)]` over
+        // `[u8; GT_ELEMENT_SIZE]`, so the two have identical layout and a
+        // reference to one may be reinterpreted as a reference to the other.
+        unsafe { &*(bytes as *const [u8; GT_ELEMENT_SIZE] as *const Self) }
+    }
+
+    /// Copies out the raw 576-byte encoding. [`Self::as_bytes`] borrows
+    /// instead.
+    pub const fn to_bytes(&self) -> [u8; GT_ELEMENT_SIZE] {
+        self.0
+    }
+
+    /// Borrows the raw encoding.
+    pub const fn as_bytes(&self) -> &[u8; GT_ELEMENT_SIZE] {
+        &self.0
+    }
 }
 
-/// In-place product of pairings for a batch of G1 and G2 points.
+/// Writes `e(P_1, Q_1) * ... * e(P_n, Q_n)` into `out`.
 ///
-/// Computes `e(P_1, Q_1) * ... * e(P_n, Q_n)` and writes the resulting
-/// `GtElement` into `out`.
+/// An empty batch is the empty product and yields the identity, as SIMD-0388
+/// requires of the syscall. [`pairing_check`] deliberately differs; see its
+/// documentation.
 ///
-/// Returns `true` if and only if every byte of `out` was written, in
-/// which case the caller may `assume_init` it. On `false`, `out` is
-/// left untouched and must not be assumed initialized.
+/// # Errors
+///
+/// [`Bls12381Error::LengthMismatch`] if the slices differ in length,
+/// [`Bls12381Error::TooManyPairs`] if the batch exceeds [`MAX_PAIRING_LENGTH`],
+/// and [`Bls12381Error::InvalidInput`] if the syscall rejects a point.
+///
+/// On `Ok`, `out` is initialized and may be `assume_init`ed; on `Err` it is
+/// poisoned. See [Output buffer contract](crate#output-buffer-contract).
 pub fn pairing_map_assign(
     g1_points: &[G1Point],
     g2_points: &[G2Point],
     out: &mut MaybeUninit<GtElement>,
     endianness: Endianness,
-) -> bool {
-    if g1_points.len() != g2_points.len() || g1_points.len() > MAX_PAIRING_LENGTH {
-        return false;
+) -> Result<(), Bls12381Error> {
+    if g1_points.len() != g2_points.len() {
+        return Err(Bls12381Error::LengthMismatch);
+    }
+    if g1_points.len() > MAX_PAIRING_LENGTH {
+        return Err(Bls12381Error::TooManyPairs);
     }
 
     if g1_points.is_empty() {
         out.write(GtElement::identity(endianness));
-        return true;
+        return Ok(());
     }
 
     #[cfg(any(target_os = "solana", target_arch = "bpf"))]
@@ -71,9 +129,10 @@ pub fn pairing_map_assign(
         };
 
         // SAFETY: the point slices are valid for reads of their respective
-        // sizes and `out` is valid for writes of `GT_ELEMENT_SIZE` bytes. Per
-        // SIMD-0388 the syscall writes the full output buffer whenever it
-        // returns 0.
+        // sizes and `out` is valid for writes of `GT_ELEMENT_SIZE` bytes. The
+        // syscall writes every byte of `out` whenever it returns 0; see the
+        // "Output buffer contract" section in the crate documentation for why
+        // this holds despite not being stated in SIMD-0388.
         let status = unsafe {
             solana_define_syscall::definitions::sol_curve_pairing_map(
                 curve_id,
@@ -83,7 +142,11 @@ pub fn pairing_map_assign(
                 out.as_mut_ptr().cast::<u8>(),
             )
         };
-        status == 0
+        if status == 0 {
+            Ok(())
+        } else {
+            Err(Bls12381Error::InvalidInput)
+        }
     }
 
     #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
@@ -103,42 +166,41 @@ pub fn pairing_map_assign(
             end,
         ) {
             out.write(GtElement(res.0));
-            true
+            Ok(())
         } else {
-            false
+            Err(Bls12381Error::InvalidInput)
         }
     }
 }
 
-/// Product of pairings returning a new allocated target group element.
+/// Allocating form of [`pairing_map_assign`].
 pub fn pairing_map(
     g1_points: &[G1Point],
     g2_points: &[G2Point],
     endianness: Endianness,
-) -> Option<GtElement> {
+) -> Result<GtElement, Bls12381Error> {
     let mut out = MaybeUninit::uninit();
 
-    if pairing_map_assign(g1_points, g2_points, &mut out, endianness) {
-        // SAFETY: `pairing_map_assign` returned `true`, so every byte of `out`
-        // has been written.
-        Some(unsafe { out.assume_init() })
-    } else {
-        None
-    }
+    pairing_map_assign(g1_points, g2_points, &mut out, endianness)?;
+
+    // SAFETY: `pairing_map_assign` returned `Ok`, so `out` is initialized.
+    Ok(unsafe { out.assume_init() })
 }
 
-/// In-place pairing for a single G1 and G2 point pair.
-/// Zero-allocation wrapper around `pairing_map_assign`.
+/// Single-pair form of [`pairing_map_assign`].
 ///
-/// Returns `true` if and only if every byte of `out` was written, in
-/// which case the caller may `assume_init` it. On `false`, `out` is
-/// left untouched and must not be assumed initialized.
+/// # Errors
+///
+/// [`Bls12381Error::InvalidInput`] if the syscall rejects either point.
+///
+/// On `Ok`, `out` is initialized and may be `assume_init`ed; on `Err` it is
+/// poisoned. See [Output buffer contract](crate#output-buffer-contract).
 pub fn pairing_assign(
     g1_point: &G1Point,
     g2_point: &G2Point,
     out: &mut MaybeUninit<GtElement>,
     endianness: Endianness,
-) -> bool {
+) -> Result<(), Bls12381Error> {
     pairing_map_assign(
         core::slice::from_ref(g1_point),
         core::slice::from_ref(g2_point),
@@ -147,12 +209,12 @@ pub fn pairing_assign(
     )
 }
 
-/// Single pairing returning a new allocated target group element.
+/// Allocating form of [`pairing_assign`].
 pub fn pairing(
     g1_point: &G1Point,
     g2_point: &G2Point,
     endianness: Endianness,
-) -> Option<GtElement> {
+) -> Result<GtElement, Bls12381Error> {
     pairing_map(
         core::slice::from_ref(g1_point),
         core::slice::from_ref(g2_point),
@@ -160,53 +222,54 @@ pub fn pairing(
     )
 }
 
-/// Evaluates whether the product of pairings equals the identity element.
+/// Whether the product of pairings is the identity.
 ///
-/// Returns `Some(true)` if `e(P_1, Q_1) * ... * e(P_n, Q_n) == 1`,
-/// `Some(false)` if the product is some other target group element, and
-/// `None` if the check could not be run at all.
+/// Returns `Ok(true)` if `e(P_1, Q_1) * ... * e(P_n, Q_n) == 1`, `Ok(false)` if
+/// the product is any other Gt element, and `Err` if the check never ran. Keeps
+/// the 576-byte [`GtElement`] off the caller's stack, which suits a Groth16
+/// verifier that would only discard it.
+///
+/// # Errors
+///
+/// [`Bls12381Error::LengthMismatch`], [`Bls12381Error::TooManyPairs`], and
+/// [`Bls12381Error::EmptyBatch`] indicate a bug in the calling program.
+/// [`Bls12381Error::InvalidInput`] means the syscall rejected a point.
 ///
 /// # Empty batches
 ///
-/// Unlike [`pairing_map`], this rejects an empty batch with `None` rather
-/// than reporting the vacuously-true identity. `pairing_check` is a
-/// verification primitive, and callers typically build these slices from
-/// attacker-controlled instruction data: a zero-length batch that reports
-/// `Some(true)` is a verification bypass, not a mathematical convenience.
-/// If you genuinely want the empty product, call [`pairing_map`] and compare
-/// against [`GtElement::identity`] yourself.
+/// [`pairing_map`] returns the identity for an empty batch; this returns
+/// [`Bls12381Error::EmptyBatch`] instead.
 ///
-/// # Correct usage
+/// # Examples
 ///
-/// `None` means "the check did not run", which is not the same as
-/// "verification failed" — but both must be treated as failure:
+/// `Err` means the check did not run, which is not the same as verification
+/// failing — but both are failures:
 ///
 /// ```ignore
-/// if pairing_check(g1, g2, e) != Some(true) {
+/// if pairing_check(g1_points, g2_points, endianness) != Ok(true) {
 ///     return Err(ProgramError::InvalidArgument);
 /// }
 /// ```
 ///
-/// Never branch on `.is_some()`.
+/// Do not branch on `.is_ok()`: it reports whether the check *ran*, not whether
+/// it passed, and the difference is a signature forgery.
 pub fn pairing_check(
     g1_points: &[G1Point],
     g2_points: &[G2Point],
     endianness: Endianness,
-) -> Option<bool> {
-    // A check that asserts nothing must not report success.
+) -> Result<bool, Bls12381Error> {
+    // A check that asserts nothing must not report success. Testing `g1_points`
+    // alone is enough — a mismatched (empty, non-empty) pair already trips the
+    // length check in `pairing_map_assign`.
     if g1_points.is_empty() {
-        return None;
+        return Err(Bls12381Error::EmptyBatch);
     }
 
     let mut out = MaybeUninit::uninit();
+    pairing_map_assign(g1_points, g2_points, &mut out, endianness)?;
 
-    if !pairing_map_assign(g1_points, g2_points, &mut out, endianness) {
-        return None;
-    }
-
-    // SAFETY: `pairing_map_assign` returned `true`, so every byte of `out`
-    // has been written.
+    // SAFETY: `pairing_map_assign` returned `Ok`, so `out` is initialized.
     let gt = unsafe { out.assume_init() };
 
-    Some(gt == GtElement::identity(endianness))
+    Ok(gt.is_identity(endianness))
 }

--- a/bls12-381/src/pairing.rs
+++ b/bls12-381/src/pairing.rs
@@ -235,6 +235,10 @@ pub fn pairing(
 /// [`Bls12381Error::EmptyBatch`] indicate a bug in the calling program.
 /// [`Bls12381Error::InvalidInput`] means the syscall rejected a point.
 ///
+/// Slices of differing lengths report [`Bls12381Error::LengthMismatch`] even
+/// when one of them is empty; [`Bls12381Error::EmptyBatch`] is reserved for a
+/// batch that is empty on both sides.
+///
 /// # Empty batches
 ///
 /// [`pairing_map`] returns the identity for an empty batch; this returns
@@ -258,9 +262,16 @@ pub fn pairing_check(
     g2_points: &[G2Point],
     endianness: Endianness,
 ) -> Result<bool, Bls12381Error> {
-    // A check that asserts nothing must not report success. Testing `g1_points`
-    // alone is enough — a mismatched (empty, non-empty) pair already trips the
-    // length check in `pairing_map_assign`.
+    // Diagnosed before the empty check so that a mismatched batch reports
+    // `LengthMismatch` whichever side is the empty one. Deferring to
+    // `pairing_map_assign` would report `EmptyBatch` for `(&[], &[q])` and
+    // `LengthMismatch` for `(&[p], &[])`, for the same caller bug.
+    if g1_points.len() != g2_points.len() {
+        return Err(Bls12381Error::LengthMismatch);
+    }
+
+    // A check that asserts nothing must not report success. The lengths are
+    // equal by now, so testing `g1_points` alone covers both slices.
     if g1_points.is_empty() {
         return Err(Bls12381Error::EmptyBatch);
     }

--- a/bls12-381/src/scalar.rs
+++ b/bls12-381/src/scalar.rs
@@ -1,11 +1,9 @@
+use crate::Endianness;
 #[cfg(any(
     feature = "bytemuck",
     not(any(target_os = "solana", target_arch = "bpf"))
 ))]
-use {
-    crate::Endianness,
-    bytemuck_derive::{Pod, Zeroable},
-};
+use bytemuck_derive::{Pod, Zeroable};
 
 /// Size of a BLS12-381 scalar field element in bytes.
 pub const SCALAR_SIZE: usize = 32;
@@ -59,6 +57,9 @@ impl Scalar {
     /// Widens a `u64` into a scalar. Always canonical, since `r` is far larger
     /// than `u64::MAX`.
     pub const fn from_u64(value: u64, endianness: Endianness) -> Self {
+        // Index of the first limb byte in the big-endian layout.
+        const BE_LIMB_OFFSET: usize = SCALAR_SIZE - 8;
+
         let mut bytes = [0u8; SCALAR_SIZE];
         let mut i = 0;
         match endianness {
@@ -66,14 +67,16 @@ impl Scalar {
                 let limb = value.to_le_bytes();
                 while i < 8 {
                     bytes[i] = limb[i];
-                    i += 1;
+                    i = i.wrapping_add(1);
                 }
             }
             Endianness::Big => {
                 let limb = value.to_be_bytes();
                 while i < 8 {
-                    bytes[SCALAR_SIZE - 8 + i] = limb[i];
-                    i += 1;
+                    // `i < 8` and `BE_LIMB_OFFSET + 8 == SCALAR_SIZE`, so the
+                    // sum is in bounds and never wraps.
+                    bytes[BE_LIMB_OFFSET.wrapping_add(i)] = limb[i];
+                    i = i.wrapping_add(1);
                 }
             }
         }
@@ -113,7 +116,7 @@ impl Scalar {
             if self.0[i] != 0 {
                 return false;
             }
-            i += 1;
+            i = i.wrapping_add(1);
         }
         true
     }

--- a/bls12-381/src/scalar.rs
+++ b/bls12-381/src/scalar.rs
@@ -2,13 +2,34 @@
     feature = "bytemuck",
     not(any(target_os = "solana", target_arch = "bpf"))
 ))]
-use bytemuck_derive::{Pod, Zeroable};
+use {
+    crate::Endianness,
+    bytemuck_derive::{Pod, Zeroable},
+};
 
 /// Size of a BLS12-381 scalar field element in bytes.
 pub const SCALAR_SIZE: usize = 32;
 
-/// A BLS12-381 scalar field element.
-/// Represents a 256-bit integer used for scalar multiplication.
+/// A scalar field element: a 256-bit integer, used for scalar multiplication.
+///
+/// # Canonicity
+///
+/// Scalars must be canonical — strictly below the scalar field order `r`.
+/// A value at or above `r` is rejected rather than reduced mod `r`, so
+/// [`G1Point::mul`] and [`G2Point::mul`] return `None`, the same result they
+/// give for an invalid point.
+///
+/// Scalars that do not arrive already reduced — a hash output, or bytes taken
+/// directly from instruction data — must be reduced by the caller, on-chain or
+/// off.
+///
+/// # Endianness
+///
+/// A scalar's byte order must match the [`Endianness`] of the operation
+/// consuming it.
+///
+/// [`G1Point::mul`]: crate::g1::G1Point::mul
+/// [`G2Point::mul`]: crate::g2::G2Point::mul
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(
     any(
@@ -18,4 +39,82 @@ pub const SCALAR_SIZE: usize = 32;
     derive(Pod, Zeroable)
 )]
 #[repr(transparent)]
-pub struct Scalar(pub [u8; SCALAR_SIZE]);
+pub struct Scalar(
+    /// The raw encoding, in whichever [`Endianness`] the consuming operation
+    /// uses. Canonicity unchecked.
+    pub [u8; SCALAR_SIZE],
+);
+
+impl Scalar {
+    /// Zero. Canonical in both encodings; takes any point to infinity.
+    pub const fn zero() -> Self {
+        Self([0u8; SCALAR_SIZE])
+    }
+
+    /// One, in the given encoding. Leaves any point unchanged.
+    pub const fn one(endianness: Endianness) -> Self {
+        Self::from_u64(1, endianness)
+    }
+
+    /// Widens a `u64` into a scalar. Always canonical, since `r` is far larger
+    /// than `u64::MAX`.
+    pub const fn from_u64(value: u64, endianness: Endianness) -> Self {
+        let mut bytes = [0u8; SCALAR_SIZE];
+        let mut i = 0;
+        match endianness {
+            Endianness::Little => {
+                let limb = value.to_le_bytes();
+                while i < 8 {
+                    bytes[i] = limb[i];
+                    i += 1;
+                }
+            }
+            Endianness::Big => {
+                let limb = value.to_be_bytes();
+                while i < 8 {
+                    bytes[SCALAR_SIZE - 8 + i] = limb[i];
+                    i += 1;
+                }
+            }
+        }
+        Self(bytes)
+    }
+
+    /// Copies a byte array into a scalar. Canonicity is not checked; see the
+    /// type documentation.
+    pub const fn from_bytes(bytes: [u8; SCALAR_SIZE]) -> Self {
+        Self(bytes)
+    }
+
+    /// Reinterprets a byte array as a scalar, without copying.
+    ///
+    /// Available under `default-features = false`.
+    pub const fn from_bytes_ref(bytes: &[u8; SCALAR_SIZE]) -> &Self {
+        // SAFETY: `Scalar` is `#[repr(transparent)]` over
+        // `[u8; SCALAR_SIZE]`, so the two have identical layout and a
+        // reference to one may be reinterpreted as a reference to the other.
+        unsafe { &*(bytes as *const [u8; SCALAR_SIZE] as *const Self) }
+    }
+
+    /// Copies out the raw encoding.
+    pub const fn to_bytes(&self) -> [u8; SCALAR_SIZE] {
+        self.0
+    }
+
+    /// Borrows the raw encoding.
+    pub const fn as_bytes(&self) -> &[u8; SCALAR_SIZE] {
+        &self.0
+    }
+
+    /// Whether this scalar is zero.
+    pub const fn is_zero(&self) -> bool {
+        let mut i = 0;
+        while i < SCALAR_SIZE {
+            if self.0[i] != 0 {
+                return false;
+            }
+            i += 1;
+        }
+        true
+    }
+}

--- a/bls12-381/tests/bls12_381.rs
+++ b/bls12-381/tests/bls12_381.rs
@@ -1,10 +1,50 @@
 use {
     core::mem::MaybeUninit,
     solana_bls12_381::{
-        pairing, pairing_assign, pairing_check, pairing_map, Endianness, G1Point, G2Point,
-        GtElement, G1_UNCOMPRESSED_POINT_SIZE,
+        pairing, pairing_assign, pairing_check, pairing_map, Bls12381Error, Endianness,
+        G1Compressed, G1Point, G2Compressed, G2Point, GtElement, Scalar,
+        G1_UNCOMPRESSED_POINT_SIZE, MAX_PAIRING_LENGTH,
     },
 };
+
+/// Builds a value of `T` with every byte set to `byte`.
+fn filled<T: bytemuck::Pod>(byte: u8) -> T {
+    let mut value = T::zeroed();
+    bytemuck::bytes_of_mut(&mut value).fill(byte);
+    value
+}
+
+/// Asserts that a successful operation writes every byte of its output buffer.
+///
+/// Runs `op` into two buffers with different prior contents. If any byte were
+/// left unwritten, that byte's fill value would carry through and the two
+/// results would differ.
+///
+/// This does not require knowing the expected output, which is what makes it
+/// usable as a blanket check across every operation.
+fn assert_full_write<T, F>(context: &str, mut op: F)
+where
+    T: bytemuck::Pod + PartialEq + core::fmt::Debug,
+    F: FnMut(&mut MaybeUninit<T>) -> bool,
+{
+    let mut a = MaybeUninit::new(filled::<T>(0x00));
+    let mut b = MaybeUninit::new(filled::<T>(0xFF));
+
+    assert!(op(&mut a), "{context}: operation unexpectedly failed");
+    assert!(op(&mut b), "{context}: operation unexpectedly failed");
+
+    // SAFETY: both calls returned `true`, so both buffers are fully
+    // initialized. Both were additionally initialized by `MaybeUninit::new`
+    // beforehand, so these reads are sound even if the property under test does
+    // not hold — a partial write produces a failed assertion rather than
+    // undefined behavior.
+    let (a, b) = unsafe { (a.assume_init(), b.assume_init()) };
+
+    assert_eq!(
+        a, b,
+        "{context}: prior buffer contents leaked into the result"
+    );
+}
 
 #[test]
 fn test_zero_copy_and_constructors() {
@@ -32,29 +72,93 @@ fn test_validated_arithmetic_routing() {
     let success = p1.add_assign(&p2, &mut out, Endianness::Little);
     assert!(success);
 
-    // SAFETY: `add_assign` returned `true`, so every byte of `out` was written.
+    // SAFETY: `add_assign` returned `true`, so `out` is fully initialized.
     let out = unsafe { out.assume_init() };
 
     // Verify both methods yielded the exact same underlying bytes.
     assert_eq!(sum.unwrap().to_bytes(), out.to_bytes());
 }
 
+/// The `_assign` contract permits `assume_init` only on a `true` return, which
+/// is sound only if the operation wrote every byte of the buffer. Reading even
+/// one uninitialized byte is undefined behavior, so this is a soundness
+/// property rather than a correctness nicety.
+///
+/// SIMD-0388 does not state the guarantee, so pin it here rather than assuming
+/// it. See the "Output buffer contract" section in the crate documentation.
 #[test]
-fn test_assign_leaves_out_untouched_on_failure() {
-    let sentinel = G1Point::infinity(Endianness::Little);
-    let mut out = MaybeUninit::new(sentinel);
+fn test_success_writes_full_buffer() {
+    for endianness in [Endianness::Little, Endianness::Big] {
+        let g1 = G1Point::infinity(endianness);
+        let g2 = G2Point::infinity(endianness);
+        // Zero is a canonical scalar, so multiplication succeeds.
+        let scalar = Scalar([0u8; 32]);
 
-    // An all-ones encoding is not a valid field element, so validation must
-    // reject it before the operation writes anything.
+        assert_full_write::<G1Point, _>("g1 add", |out| g1.add_assign(&g1, out, endianness));
+        assert_full_write::<G1Point, _>("g1 add_unchecked", |out| {
+            g1.add_assign_unchecked(&g1, out, endianness)
+        });
+        assert_full_write::<G1Point, _>("g1 sub", |out| g1.sub_assign(&g1, out, endianness));
+        assert_full_write::<G1Point, _>("g1 mul", |out| g1.mul_assign(&scalar, out, endianness));
+        assert_full_write::<G1Point, _>("g1 decompress", |out| {
+            G1Compressed::infinity(endianness).decompress_assign(out, endianness)
+        });
+
+        assert_full_write::<G2Point, _>("g2 add", |out| g2.add_assign(&g2, out, endianness));
+        assert_full_write::<G2Point, _>("g2 add_unchecked", |out| {
+            g2.add_assign_unchecked(&g2, out, endianness)
+        });
+        assert_full_write::<G2Point, _>("g2 sub", |out| g2.sub_assign(&g2, out, endianness));
+        assert_full_write::<G2Point, _>("g2 mul", |out| g2.mul_assign(&scalar, out, endianness));
+        assert_full_write::<G2Point, _>("g2 decompress", |out| {
+            G2Compressed::infinity(endianness).decompress_assign(out, endianness)
+        });
+
+        // The 576-byte Gt buffer is the one most likely to be partially written
+        // by an implementation that assembles the result coefficient by
+        // coefficient.
+        assert_full_write::<GtElement, _>("pairing", |out| {
+            pairing_assign(&g1, &g2, out, endianness).is_ok()
+        });
+    }
+}
+
+/// On failure the output buffer is poisoned: the contract gives the caller no
+/// way to read it, so there is nothing to assert about its contents here.
+#[test]
+fn test_assign_reports_failure_and_poisons_out() {
+    let valid = G1Point::infinity(Endianness::Little);
+    // An all-ones encoding is not a valid field element.
+    let invalid = G1Point::from_bytes([0xFF; G1_UNCOMPRESSED_POINT_SIZE]);
+
+    let mut out = MaybeUninit::uninit();
+    assert!(!valid.add_assign(&invalid, &mut out, Endianness::Little));
+    // Deliberately no `assume_init` on `out`.
+
+    // The allocating wrapper surfaces the same failure as `None`.
+    assert!(valid.add(&invalid, Endianness::Little).is_none());
+}
+
+/// Pins current runtime behavior: a failing operation does not write the output
+/// buffer.
+///
+/// This is NOT part of the public contract — the documentation treats `out` as
+/// poisoned on failure, and callers must not rely on this. The test exists so
+/// that a change in behavior is noticed rather than discovered in production.
+#[test]
+fn test_failure_leaves_buffer_unwritten() {
     let valid = G1Point::infinity(Endianness::Little);
     let invalid = G1Point::from_bytes([0xFF; G1_UNCOMPRESSED_POINT_SIZE]);
 
-    let success = valid.add_assign(&invalid, &mut out, Endianness::Little);
-    assert!(!success);
+    let fill = G1Point::from_bytes([0xAB; G1_UNCOMPRESSED_POINT_SIZE]);
+    let mut out = MaybeUninit::new(fill);
 
-    // SAFETY: `out` was initialized by `MaybeUninit::new`, and `add_assign`
-    // returned `false`, which guarantees it was left untouched.
-    assert_eq!(unsafe { out.assume_init() }, sentinel);
+    assert!(!valid.add_assign(&invalid, &mut out, Endianness::Little));
+
+    // SAFETY: `out` was initialized by `MaybeUninit::new`. This read is sound
+    // regardless of what the syscall did; the assertion is about behavior, not
+    // safety.
+    assert_eq!(unsafe { out.assume_init() }, fill);
 }
 
 #[test]
@@ -63,26 +167,42 @@ fn test_pairing_ergonomics_and_limits() {
     let g2 = G2Point::infinity(Endianness::Little);
 
     // Test Single Pairing Wrapper (Returning)
-    let gt_owned = pairing(&g1, &g2, Endianness::Little);
-    assert!(gt_owned.is_some());
+    let gt_owned = pairing(&g1, &g2, Endianness::Little).expect("pairing must succeed");
 
     // Test Single Pairing Wrapper (In-Place)
     let mut gt_out = MaybeUninit::uninit();
-    let success = pairing_assign(&g1, &g2, &mut gt_out, Endianness::Little);
-    assert!(success);
+    pairing_assign(&g1, &g2, &mut gt_out, Endianness::Little).expect("pairing must succeed");
 
-    // SAFETY: `pairing_assign` returned `true`, so `gt_out` is initialized.
+    // SAFETY: `pairing_assign` returned `Ok`, so `gt_out` is fully initialized.
     let gt_out = unsafe { gt_out.assume_init() };
-    assert_eq!(gt_owned.unwrap().0, gt_out.0);
+    assert_eq!(gt_owned.0, gt_out.0);
+}
 
-    // Test Max Pairing Limit (SIMD-0388 restricts batch to 8 pairs)
-    let g1_batch_ok = vec![g1; 8];
-    let g2_batch_ok = vec![g2; 8];
-    assert!(pairing_check(&g1_batch_ok, &g2_batch_ok, Endianness::Little).is_some());
+/// Pins `MAX_PAIRING_LENGTH` against the limit the syscall enforces
+/// independently. The constant is duplicated between this crate and
+/// `solana-bls12-381-syscall`, where it is private, so drift would otherwise go
+/// unnoticed until a batch of the wrong size reached the runtime.
+#[test]
+fn test_pairing_batch_limit() {
+    let g1 = G1Point::infinity(Endianness::Little);
+    let g2 = G2Point::infinity(Endianness::Little);
 
-    let g1_batch_fail = vec![g1; 9];
-    let g2_batch_fail = vec![g2; 9];
-    assert!(pairing_check(&g1_batch_fail, &g2_batch_fail, Endianness::Little).is_none());
+    let g1_ok = vec![g1; MAX_PAIRING_LENGTH];
+    let g2_ok = vec![g2; MAX_PAIRING_LENGTH];
+    assert!(pairing_check(&g1_ok, &g2_ok, Endianness::Little).is_ok());
+
+    let g1_over = vec![g1; MAX_PAIRING_LENGTH + 1];
+    let g2_over = vec![g2; MAX_PAIRING_LENGTH + 1];
+    assert_eq!(
+        pairing_check(&g1_over, &g2_over, Endianness::Little),
+        Err(Bls12381Error::TooManyPairs),
+    );
+
+    // A mismatched batch is distinguishable from an over-long one.
+    assert_eq!(
+        pairing_check(&g1_ok, &g2_ok[..1], Endianness::Little),
+        Err(Bls12381Error::LengthMismatch),
+    );
 }
 
 #[test]
@@ -98,6 +218,7 @@ fn test_pairing_check_identity() {
     assert!(is_identity);
 }
 
+/// `pairing_map` and `pairing_check` deliberately diverge on an empty batch.
 #[test]
 fn test_empty_batch() {
     for endianness in [Endianness::Little, Endianness::Big] {
@@ -105,7 +226,224 @@ fn test_empty_batch() {
         let gt = pairing_map(&[], &[], endianness).expect("empty batch must succeed");
         assert_eq!(gt, GtElement::identity(endianness));
 
-        // `pairing_check` refuses to succeed vacuously.
-        assert_eq!(pairing_check(&[], &[], endianness), None);
+        // `pairing_check` refuses to succeed vacuously: a zero-length batch
+        // asserts nothing, and reporting `Ok(true)` would be a verification
+        // bypass for any caller building its batch from instruction data. The
+        // dedicated variant distinguishes this programmer error from a failed
+        // verification.
+        assert_eq!(
+            pairing_check(&[], &[], endianness),
+            Err(Bls12381Error::EmptyBatch),
+        );
+    }
+}
+
+/// Reverses each 48-byte `Fq` coefficient, converting between the LE and BE
+/// encodings of a G1 point.
+fn swap_fq(bytes: &mut [u8]) {
+    for chunk in bytes.chunks_mut(48) {
+        chunk.reverse();
+    }
+}
+
+/// Swaps the `c0` and `c1` halves of each 96-byte `Fq2` coordinate.
+fn swap_c0_c1(bytes: &mut [u8]) {
+    for chunk in bytes.chunks_mut(96) {
+        let (c0, c1) = chunk.split_at_mut(48);
+        c0.swap_with_slice(c1);
+    }
+}
+
+/// Pins the G1 generator constants.
+///
+/// Fails on the all-zero placeholders shipped in `src/g1.rs`; run
+/// `cargo run --example gen_constants` and paste the output there.
+///
+/// Between them these assertions make a transcription error essentially
+/// impossible to miss: a corrupted byte puts the point off the curve, and a
+/// corrupted byte in only one of the two encodings breaks parity.
+#[test]
+fn test_g1_generator_is_canonical() {
+    for endianness in [Endianness::Little, Endianness::Big] {
+        let g = G1Point::generator(endianness);
+
+        assert!(
+            g.validate(endianness),
+            "G1 generator is not a valid point — did you paste the output of \
+             `cargo run --example gen_constants` into src/g1.rs?"
+        );
+        assert!(
+            !g.is_infinity(endianness),
+            "G1 generator must not be infinity"
+        );
+
+        // g * 1 == g
+        assert_eq!(
+            g.mul(&Scalar::one(endianness), endianness),
+            Some(g),
+            "G1 generator failed identity multiplication"
+        );
+
+        // g * 0 == infinity
+        assert_eq!(
+            g.mul(&Scalar::zero(), endianness),
+            Some(G1Point::infinity(endianness)),
+            "G1 generator times zero must be infinity"
+        );
+
+        // g + (-g) == infinity
+        let neg = g.neg(endianness).expect("negation must succeed");
+        assert_eq!(
+            g.add(&neg, endianness),
+            Some(G1Point::infinity(endianness)),
+            "G1 generator plus its negation must be infinity"
+        );
+    }
+
+    // The two encodings must describe the same point.
+    let mut converted = G1Point::generator(Endianness::Big).to_bytes();
+    swap_fq(&mut converted);
+    assert_eq!(
+        converted,
+        G1Point::generator(Endianness::Little).to_bytes(),
+        "G1 generator LE and BE constants disagree"
+    );
+}
+
+/// Pins the G2 generator constants. See `test_g1_generator_is_canonical`.
+#[test]
+fn test_g2_generator_is_canonical() {
+    for endianness in [Endianness::Little, Endianness::Big] {
+        let g = G2Point::generator(endianness);
+
+        assert!(
+            g.validate(endianness),
+            "G2 generator is not a valid point — did you paste the output of \
+             `cargo run --example gen_constants` into src/g2.rs?"
+        );
+        assert!(
+            !g.is_infinity(endianness),
+            "G2 generator must not be infinity"
+        );
+
+        assert_eq!(
+            g.mul(&Scalar::one(endianness), endianness),
+            Some(g),
+            "G2 generator failed identity multiplication"
+        );
+        assert_eq!(
+            g.mul(&Scalar::zero(), endianness),
+            Some(G2Point::infinity(endianness)),
+            "G2 generator times zero must be infinity"
+        );
+
+        let neg = g.neg(endianness).expect("negation must succeed");
+        assert_eq!(
+            g.add(&neg, endianness),
+            Some(G2Point::infinity(endianness)),
+            "G2 generator plus its negation must be infinity"
+        );
+    }
+
+    let mut converted = G2Point::generator(Endianness::Big).to_bytes();
+    swap_c0_c1(&mut converted);
+    swap_fq(&mut converted);
+    assert_eq!(
+        converted,
+        G2Point::generator(Endianness::Little).to_bytes(),
+        "G2 generator LE and BE constants disagree"
+    );
+}
+
+/// `e(G1, G2)` generates the target group, so it is not the identity. A
+/// `Ok(true)` here would mean the generators or the pairing are wrong.
+#[test]
+fn test_generator_pairing_is_not_identity() {
+    for endianness in [Endianness::Little, Endianness::Big] {
+        let g1 = G1Point::generator(endianness);
+        let g2 = G2Point::generator(endianness);
+
+        assert_eq!(
+            pairing_check(&[g1], &[g2], endianness),
+            Ok(false),
+            "e(G1, G2) must not be the target group identity"
+        );
+    }
+}
+
+/// Bilinearity, expressed without target group arithmetic:
+/// `e(aP, bQ) * e(-(ab)P, Q) == 1`.
+#[test]
+fn test_pairing_bilinearity() {
+    for endianness in [Endianness::Little, Endianness::Big] {
+        let g1 = G1Point::generator(endianness);
+        let g2 = G2Point::generator(endianness);
+
+        let (a, b) = (7u64, 11u64);
+        let scalar_a = Scalar::from_u64(a, endianness);
+        let scalar_b = Scalar::from_u64(b, endianness);
+        let scalar_ab = Scalar::from_u64(a * b, endianness);
+
+        let ap = g1.mul(&scalar_a, endianness).expect("aP");
+        let bq = g2.mul(&scalar_b, endianness).expect("bQ");
+        let abp = g1.mul(&scalar_ab, endianness).expect("abP");
+        let neg_abp = abp.neg(endianness).expect("-abP");
+
+        assert_eq!(
+            pairing_check(&[ap, neg_abp], &[bq, g2], endianness),
+            Ok(true),
+            "bilinearity check failed"
+        );
+    }
+}
+
+#[test]
+fn test_is_infinity_and_is_identity() {
+    for endianness in [Endianness::Little, Endianness::Big] {
+        assert!(G1Point::infinity(endianness).is_infinity(endianness));
+        assert!(G2Point::infinity(endianness).is_infinity(endianness));
+        assert!(!G1Point::generator(endianness).is_infinity(endianness));
+        assert!(!G2Point::generator(endianness).is_infinity(endianness));
+
+        // The all-zero encoding is NOT infinity: `bytemuck::Zeroable` produces
+        // an invalid point, not the identity.
+        assert!(!G1Point::from_bytes([0u8; G1_UNCOMPRESSED_POINT_SIZE]).is_infinity(endianness));
+
+        assert!(GtElement::identity(endianness).is_identity(endianness));
+        assert!(!GtElement::from_bytes([0u8; 576]).is_identity(endianness));
+
+        // The compressed infinity constructors must round-trip through
+        // decompression, which pins their control-bit encoding.
+        assert_eq!(
+            G1Compressed::infinity(endianness).decompress(endianness),
+            Some(G1Point::infinity(endianness)),
+        );
+        assert_eq!(
+            G2Compressed::infinity(endianness).decompress(endianness),
+            Some(G2Point::infinity(endianness)),
+        );
+        assert!(G1Compressed::infinity(endianness).validate(endianness));
+        assert!(G2Compressed::infinity(endianness).validate(endianness));
+    }
+}
+
+#[test]
+fn test_scalar_constructors() {
+    for endianness in [Endianness::Little, Endianness::Big] {
+        assert!(Scalar::zero().is_zero());
+        assert!(!Scalar::one(endianness).is_zero());
+        assert_eq!(Scalar::one(endianness), Scalar::from_u64(1, endianness));
+
+        // `from_u64` places the value at the correct end for each encoding.
+        let s = Scalar::from_u64(0x0102_0304_0506_0708, endianness);
+        match endianness {
+            Endianness::Little => assert_eq!(s.as_bytes()[0], 0x08),
+            Endianness::Big => assert_eq!(s.as_bytes()[31], 0x08),
+        }
+
+        // Borrowing accessors agree with the copying ones.
+        let g = G1Point::generator(endianness);
+        assert_eq!(g.as_bytes(), &g.to_bytes());
+        assert_eq!(G1Point::from_bytes_ref(g.as_bytes()), &g);
     }
 }

--- a/bls12-381/tests/bls12_381.rs
+++ b/bls12-381/tests/bls12_381.rs
@@ -99,11 +99,13 @@ fn test_pairing_check_identity() {
 }
 
 #[test]
-fn test_empty_batch_maps_to_identity() {
+fn test_empty_batch() {
     for endianness in [Endianness::Little, Endianness::Big] {
+        // `pairing_map` mirrors the syscall: the empty product is the identity.
         let gt = pairing_map(&[], &[], endianness).expect("empty batch must succeed");
         assert_eq!(gt, GtElement::identity(endianness));
 
-        assert_eq!(pairing_check(&[], &[], endianness), Some(true));
+        // `pairing_check` refuses to succeed vacuously.
+        assert_eq!(pairing_check(&[], &[], endianness), None);
     }
 }

--- a/bls12-381/tests/bls12_381.rs
+++ b/bls12-381/tests/bls12_381.rs
@@ -135,6 +135,13 @@ fn test_assign_reports_failure_and_poisons_out() {
     assert!(!valid.add_assign(&invalid, &mut out, Endianness::Little));
     // Deliberately no `assume_init` on `out`.
 
+    // The same contract holds when the failure originates in the syscall
+    // rather than in the crate's own `validate` call: `add_assign` rejects
+    // `invalid` before the group op runs, `add_assign_unchecked` carries it
+    // through to the syscall, and both must report `false`.
+    let mut out_unchecked = MaybeUninit::uninit();
+    assert!(!valid.add_assign_unchecked(&invalid, &mut out_unchecked, Endianness::Little));
+
     // The allocating wrapper surfaces the same failure as `None`.
     assert!(valid.add(&invalid, Endianness::Little).is_none());
 }
@@ -153,7 +160,13 @@ fn test_failure_leaves_buffer_unwritten() {
     let fill = G1Point::from_bytes([0xAB; G1_UNCOMPRESSED_POINT_SIZE]);
     let mut out = MaybeUninit::new(fill);
 
-    assert!(!valid.add_assign(&invalid, &mut out, Endianness::Little));
+    // Unchecked deliberately: `add_assign` would reject `invalid` in its own
+    // `validate` call and return before the group op ever runs, which would pin
+    // an early return in this crate rather than what the syscall does to `out`
+    // on failure. The unchecked variant skips only the subgroup check — an
+    // all-ones encoding is still not a field element, so the syscall itself
+    // fails and the buffer is the syscall's to write or leave alone.
+    assert!(!valid.add_assign_unchecked(&invalid, &mut out, Endianness::Little));
 
     // SAFETY: `out` was initialized by `MaybeUninit::new`. This read is sound
     // regardless of what the syscall did; the assertion is about behavior, not
@@ -218,10 +231,14 @@ fn test_pairing_check_identity() {
     assert!(is_identity);
 }
 
-/// `pairing_map` and `pairing_check` deliberately diverge on an empty batch.
+/// `pairing_map` and `pairing_check` deliberately diverge on an empty batch,
+/// and a half-empty batch is a length mismatch rather than either.
 #[test]
 fn test_empty_batch() {
     for endianness in [Endianness::Little, Endianness::Big] {
+        let g1 = G1Point::infinity(endianness);
+        let g2 = G2Point::infinity(endianness);
+
         // `pairing_map` mirrors the syscall: the empty product is the identity.
         let gt = pairing_map(&[], &[], endianness).expect("empty batch must succeed");
         assert_eq!(gt, GtElement::identity(endianness));
@@ -234,6 +251,19 @@ fn test_empty_batch() {
         assert_eq!(
             pairing_check(&[], &[], endianness),
             Err(Bls12381Error::EmptyBatch),
+        );
+
+        // `EmptyBatch` means empty on both sides. One empty slice is a length
+        // mismatch whichever side it is on — the check that makes this true is
+        // the length comparison ahead of the empty check in `pairing_check`,
+        // without which the second assertion would report `EmptyBatch`.
+        assert_eq!(
+            pairing_check(&[g1], &[], endianness),
+            Err(Bls12381Error::LengthMismatch),
+        );
+        assert_eq!(
+            pairing_check(&[], &[g2], endianness),
+            Err(Bls12381Error::LengthMismatch),
         );
     }
 }


### PR DESCRIPTION
#### Summary of Changes

I made some smaller improvements on the crate:

- Two behavior changes. `pairing_check` now rejects empty slices rather than reporting the identity — a zero-length batch reporting success is a verification bypass when the slices come from instruction data. `pairing_map` still returns the identity for the empty product to match the syscall. The pairing functions also moved to `Result` with a new `Bls12381Error`, so a malformed batch is distinguishable from a failed verification. Point operations keep `Option`, since the syscall only gives us one bit.
- Filled in API that every consumer would otherwise hand-roll: group generators, `is_infinity` / `is_identity`, borrowing accessors, zero-copy casting that doesn't need the `bytemuck` feature, `Scalar` constructors, and the missing `neg` variants. Also made `neg` two syscalls instead of three.
- Made the docs match what the SIMD actually guarantees. The `_assign` contract no longer promises the output buffer is left untouched on failure, and the SAFETY comments no longer cite SIMD-0388 for the full-write-on-success guarantee — they give the real reasoning instead, and there's a test for it.
- Extended the tests. The existing ones mostly used infinity points, so they would pass against an implementation that returned the identity for everything.