### PR TITLE
perf(slot-hashes, stake-history)!: replace tuple entries with repr(C) structs

### DIFF
--- a/address-lookup-table-interface/src/state.rs
+++ b/address-lookup-table-interface/src/state.rs
@@ -320,8 +320,8 @@ mod tests {
             slot_hashes.add(slot, Hash::new_unique());
         }
 
-        let most_recent_slot = slot_hashes.first().unwrap().0;
-        let least_recent_slot = slot_hashes.last().unwrap().0;
+        let most_recent_slot = slot_hashes.first().unwrap().slot;
+        let least_recent_slot = slot_hashes.last().unwrap().slot;
         assert!(least_recent_slot < most_recent_slot);
 
         // 10 was chosen because the current slot isn't necessarily the next

--- a/slot-hashes/src/lib.rs
+++ b/slot-hashes/src/lib.rs
@@ -33,14 +33,53 @@ pub fn set_entries_for_tests_only(entries: usize) {
     NUM_ENTRIES.store(entries, Ordering::Relaxed);
 }
 
-pub type SlotHash = (u64, Hash);
-
 const LEN_PREFIX: usize = size_of::<u64>();
 const SLOT_HASH_SERIALIZED_SIZE: usize = size_of::<u64>() + size_of::<Hash>();
 
 /// Serialized size of the `SlotHashes` sysvar account.
 pub const SIZE: usize = LEN_PREFIX + MAX_ENTRIES * SLOT_HASH_SERIALIZED_SIZE;
 const _: () = assert!(SIZE == 20_488);
+
+/// A single entry of the [`SlotHashes`] sysvar.
+///
+/// `#[repr(C)]` and padding-free so wincode decodes the whole sysvar in one copy.
+#[repr(C)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Deserialize, serde_derive::Serialize)
+)]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
+// Big-endian targets encode integers byte-swapped, so they never qualify as zero-copy.
+#[cfg_attr(
+    all(feature = "wincode", target_endian = "little"),
+    wincode(assert_zero_copy)
+)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Default)]
+pub struct SlotHash {
+    pub slot: u64,
+    pub hash: Hash,
+}
+
+// Unlike `assert_zero_copy`, this also holds on big-endian targets.
+const _: () = assert!(size_of::<SlotHash>() == SLOT_HASH_SERIALIZED_SIZE);
+
+impl SlotHash {
+    pub const fn new(slot: u64, hash: Hash) -> Self {
+        Self { slot, hash }
+    }
+}
+
+impl From<(u64, Hash)> for SlotHash {
+    fn from((slot, hash): (u64, Hash)) -> Self {
+        Self { slot, hash }
+    }
+}
+
+impl From<SlotHash> for (u64, Hash) {
+    fn from(SlotHash { slot, hash }: SlotHash) -> Self {
+        (slot, hash)
+    }
+}
 
 #[repr(C)]
 #[cfg_attr(
@@ -53,24 +92,25 @@ pub struct SlotHashes(Vec<SlotHash>);
 
 impl SlotHashes {
     pub fn add(&mut self, slot: u64, hash: Hash) {
-        match self.binary_search_by(|(probe, _)| slot.cmp(probe)) {
-            Ok(index) => (self.0)[index] = (slot, hash),
-            Err(index) => (self.0).insert(index, (slot, hash)),
+        let entry = SlotHash { slot, hash };
+        match self.binary_search_by(|probe| slot.cmp(&probe.slot)) {
+            Ok(index) => (self.0)[index] = entry,
+            Err(index) => (self.0).insert(index, entry),
         }
         (self.0).truncate(get_entries());
     }
     pub fn position(&self, slot: &u64) -> Option<usize> {
-        self.binary_search_by(|(probe, _)| slot.cmp(probe)).ok()
+        self.binary_search_by(|probe| slot.cmp(&probe.slot)).ok()
     }
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn get(&self, slot: &u64) -> Option<&Hash> {
-        self.binary_search_by(|(probe, _)| slot.cmp(probe))
+        self.binary_search_by(|probe| slot.cmp(&probe.slot))
             .ok()
-            .map(|index| &self[index].1)
+            .map(|index| &self[index].hash)
     }
     pub fn new(slot_hashes: &[SlotHash]) -> Self {
         let mut slot_hashes = slot_hashes.to_vec();
-        slot_hashes.sort_by(|(a, _), (b, _)| b.cmp(a));
+        slot_hashes.sort_by_key(|entry| std::cmp::Reverse(entry.slot));
         Self(slot_hashes)
     }
     pub fn slot_hashes(&self) -> &[SlotHash] {
@@ -78,9 +118,15 @@ impl SlotHashes {
     }
 }
 
+impl FromIterator<SlotHash> for SlotHashes {
+    fn from_iter<I: IntoIterator<Item = SlotHash>>(iter: I) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
 impl FromIterator<(u64, Hash)> for SlotHashes {
     fn from_iter<I: IntoIterator<Item = (u64, Hash)>>(iter: I) -> Self {
-        Self(iter.into_iter().collect())
+        Self(iter.into_iter().map(SlotHash::from).collect())
     }
 }
 
@@ -95,9 +141,13 @@ impl Deref for SlotHashes {
 mod tests {
     use {super::*, solana_sha256_hasher::hash};
 
+    fn entry(slot: u64) -> SlotHash {
+        SlotHash::new(slot, hash(&slot.to_le_bytes()))
+    }
+
     #[test]
     fn test_size_of() {
-        let slot_hashes = SlotHashes(vec![(0, Hash::default()); MAX_ENTRIES]);
+        let slot_hashes = SlotHashes(vec![SlotHash::default(); MAX_ENTRIES]);
         assert_eq!(
             wincode::serialized_size(&slot_hashes).unwrap() as usize,
             SIZE,
@@ -106,16 +156,9 @@ mod tests {
 
     #[test]
     fn test() {
-        let mut slot_hashes = SlotHashes::new(&[(1, Hash::default()), (3, Hash::default())]);
-        slot_hashes.add(2, Hash::default());
-        assert_eq!(
-            slot_hashes,
-            SlotHashes(vec![
-                (3, Hash::default()),
-                (2, Hash::default()),
-                (1, Hash::default()),
-            ])
-        );
+        let mut slot_hashes = SlotHashes::new(&[entry(1), entry(3)]);
+        slot_hashes.add(2, hash(&2u64.to_le_bytes()));
+        assert_eq!(slot_hashes, SlotHashes(vec![entry(3), entry(2), entry(1)]));
 
         let mut slot_hashes = SlotHashes::new(&[]);
         for i in 0..MAX_ENTRIES + 1 {
@@ -125,9 +168,26 @@ mod tests {
             );
         }
         for i in 0..MAX_ENTRIES {
-            assert_eq!(slot_hashes[i].0, (MAX_ENTRIES - i) as u64);
+            assert_eq!(slot_hashes[i].slot, (MAX_ENTRIES - i) as u64);
         }
 
         assert_eq!(slot_hashes.len(), MAX_ENTRIES);
+    }
+
+    /// Deployed accounts fix the layout to a length prefix followed by packed
+    /// slot/hash pairs. Checked against the equivalent tuple encoding.
+    #[test]
+    fn test_wire_compat() {
+        let entries: Vec<SlotHash> = (0..MAX_ENTRIES as u64).rev().map(entry).collect();
+        let tuples: Vec<(u64, Hash)> = entries.iter().cloned().map(Into::into).collect();
+        let slot_hashes = SlotHashes::new(&entries);
+
+        let expected = wincode::serialize(&tuples).unwrap();
+        assert_eq!(expected.len(), SIZE);
+        assert_eq!(wincode::serialize(&slot_hashes).unwrap(), expected);
+        assert_eq!(
+            wincode::deserialize::<SlotHashes>(&expected).unwrap(),
+            slot_hashes
+        );
     }
 }

--- a/stake-history/Cargo.toml
+++ b/stake-history/Cargo.toml
@@ -35,7 +35,7 @@ wincode = { workspace = true, optional = true }
 anyhow = { workspace = true }
 bincode = { workspace = true }
 solana-example-mocks = { path = "../example-mocks" }
-solana-stake-history = { path = ".", features = ["serde", "sysvar"] }
+solana-stake-history = { path = ".", features = ["serde", "sysvar", "wincode"] }
 
 [lints]
 workspace = true

--- a/stake-history/src/lib.rs
+++ b/stake-history/src/lib.rs
@@ -21,7 +21,7 @@ use {
 
 pub const MAX_ENTRIES: usize = 512; // it should never take as many as 512 epochs to warm up or cool down
 
-/// Serialized size of a single `(Epoch, StakeHistoryEntry)` tuple
+/// Serialized size of a single [`StakeHistoryItem`]
 pub(crate) const EPOCH_AND_ENTRY_SERIALIZED_SIZE: usize = 32;
 const _: () =
     assert!(EPOCH_AND_ENTRY_SERIALIZED_SIZE == size_of::<u64>() + size_of::<StakeHistoryEntry>());
@@ -114,6 +114,55 @@ impl core::ops::Add for StakeHistoryEntry {
     }
 }
 
+/// A single entry of the [`StakeHistory`] sysvar.
+///
+/// `#[repr(C)]` and padding-free so wincode decodes the whole sysvar in one copy.
+#[repr(C)]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(
+        solana_frozen_abi_macro::AbiExample,
+        solana_frozen_abi_macro::StableAbi,
+        solana_frozen_abi_macro::StableAbiSample
+    )
+)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Deserialize, serde_derive::Serialize)
+)]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaRead, wincode::SchemaWrite))]
+// Big-endian targets encode integers byte-swapped, so they never qualify as zero-copy.
+#[cfg_attr(
+    all(feature = "wincode", target_endian = "little"),
+    wincode(assert_zero_copy)
+)]
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
+pub struct StakeHistoryItem {
+    pub epoch: Epoch,
+    pub entry: StakeHistoryEntry,
+}
+
+// Unlike `assert_zero_copy`, this also holds on big-endian targets.
+const _: () = assert!(size_of::<StakeHistoryItem>() == EPOCH_AND_ENTRY_SERIALIZED_SIZE);
+
+impl StakeHistoryItem {
+    pub const fn new(epoch: Epoch, entry: StakeHistoryEntry) -> Self {
+        Self { epoch, entry }
+    }
+}
+
+impl From<(Epoch, StakeHistoryEntry)> for StakeHistoryItem {
+    fn from((epoch, entry): (Epoch, StakeHistoryEntry)) -> Self {
+        Self { epoch, entry }
+    }
+}
+
+impl From<StakeHistoryItem> for (Epoch, StakeHistoryEntry) {
+    fn from(StakeHistoryItem { epoch, entry }: StakeHistoryItem) -> Self {
+        (epoch, entry)
+    }
+}
+
 #[repr(C)]
 #[cfg_attr(
     feature = "frozen-abi",
@@ -129,31 +178,32 @@ impl core::ops::Add for StakeHistoryEntry {
 )]
 #[cfg_attr(feature = "wincode", derive(wincode::SchemaRead, wincode::SchemaWrite))]
 #[derive(Debug, PartialEq, Eq, Default, Clone)]
-pub struct StakeHistory(Vec<(Epoch, StakeHistoryEntry)>);
+pub struct StakeHistory(Vec<StakeHistoryItem>);
 
 impl StakeHistory {
     #[inline]
     fn latest_epoch(&self) -> Option<&Epoch> {
-        self.first().map(|(epoch, _)| epoch)
+        self.first().map(|item| &item.epoch)
     }
 
     pub fn get(&self, epoch: Epoch) -> Option<&StakeHistoryEntry> {
         self.latest_epoch()
             .and_then(|latest| latest.checked_sub(epoch))
-            .and_then(|index| self.0.get(index as usize).map(|(_, entry)| entry))
+            .and_then(|index| self.0.get(index as usize).map(|item| &item.entry))
     }
 
     pub fn add(&mut self, epoch: Epoch, entry: StakeHistoryEntry) {
-        match self.binary_search_by(|probe| epoch.cmp(&probe.0)) {
-            Ok(index) => (self.0)[index] = (epoch, entry),
-            Err(index) => (self.0).insert(index, (epoch, entry)),
+        let item = StakeHistoryItem { epoch, entry };
+        match self.binary_search_by(|probe| epoch.cmp(&probe.epoch)) {
+            Ok(index) => (self.0)[index] = item,
+            Err(index) => (self.0).insert(index, item),
         }
         (self.0).truncate(MAX_ENTRIES);
     }
 }
 
 impl Deref for StakeHistory {
-    type Target = Vec<(Epoch, StakeHistoryEntry)>;
+    type Target = Vec<StakeHistoryItem>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
@@ -188,7 +238,10 @@ mod tests {
             );
         }
         assert_eq!(stake_history.len(), MAX_ENTRIES);
-        assert_eq!(stake_history.iter().map(|entry| entry.0).min().unwrap(), 1);
+        assert_eq!(
+            stake_history.iter().map(|item| item.epoch).min().unwrap(),
+            1
+        );
         assert_eq!(stake_history.get(0), None);
         for epoch in 1..current_epoch {
             assert_eq!(
@@ -200,6 +253,27 @@ mod tests {
             );
         }
         assert_eq!(stake_history.get(current_epoch), None);
+    }
+
+    /// Deployed accounts fix the layout to a length prefix followed by packed
+    /// epoch/entry pairs. Checked against the equivalent tuple encoding.
+    #[cfg(feature = "wincode")]
+    #[test]
+    fn test_wire_compat() {
+        let mut stake_history = StakeHistory::default();
+        for i in 0..MAX_ENTRIES as u64 {
+            stake_history.add(i, StakeHistoryEntry::with_effective(i));
+        }
+        let tuples: Vec<(Epoch, StakeHistoryEntry)> =
+            stake_history.iter().cloned().map(Into::into).collect();
+
+        let expected = wincode::serialize(&tuples).unwrap();
+        assert_eq!(expected.len(), SIZE);
+        assert_eq!(wincode::serialize(&stake_history).unwrap(), expected);
+        assert_eq!(
+            wincode::deserialize::<StakeHistory>(&expected).unwrap(),
+            stake_history
+        );
     }
 
     #[cfg(feature = "sysvar")]

--- a/stake-history/src/sysvar.rs
+++ b/stake-history/src/sysvar.rs
@@ -188,7 +188,10 @@ mod tests {
             stake_history.add(i, unique_entry_for_epoch(i));
         }
         assert_eq!(stake_history.len(), MAX_ENTRIES);
-        assert_eq!(stake_history.iter().map(|entry| entry.0).min().unwrap(), 2);
+        assert_eq!(
+            stake_history.iter().map(|item| item.epoch).min().unwrap(),
+            2
+        );
 
         let stake_history_sysvar = StakeHistorySysvar(current_epoch);
         let serialized_stake_history = bincode::serialize(&stake_history).unwrap();

--- a/sysvar/src/slot_hashes.rs
+++ b/sysvar/src/slot_hashes.rs
@@ -181,7 +181,10 @@ impl PodSlotHashes {
 #[cfg(test)]
 mod tests {
     use {
-        super::*, solana_hash::Hash, solana_sha256_hasher::hash, solana_slot_hashes::MAX_ENTRIES,
+        super::*,
+        solana_hash::Hash,
+        solana_sha256_hasher::hash,
+        solana_slot_hashes::{SlotHash, MAX_ENTRIES},
         test_case::test_case,
     };
 
@@ -213,7 +216,7 @@ mod tests {
     fn test_pod_slot_hashes(num_entries: usize) {
         let mut slot_hashes = vec![];
         for i in 0..num_entries {
-            slot_hashes.push((
+            slot_hashes.push(SlotHash::new(
                 i as u64,
                 hash(&[(i >> 24) as u8, (i >> 16) as u8, (i >> 8) as u8, i as u8]),
             ));
@@ -230,7 +233,7 @@ mod tests {
 
         // Assert `PodSlotHashes` and `SlotHashes` contain the same slot hashes
         // in the same order.
-        for slot in slot_hashes.iter().map(|(slot, _hash)| slot) {
+        for slot in slot_hashes.iter().map(|entry| &entry.slot) {
             // `get`:
             assert_eq!(
                 pod_slot_hashes.get(slot).unwrap().as_ref(),


### PR DESCRIPTION
#### Problem: 
wincode does not treat tuples as zero-copy, because Rust guarantees no tuple layout. Both sysvars stored their entries as tuples inside a `Vec`, so decoding a `SlotHashes` (20 KB) or `StakeHistory` (16 KB) account ran a per-element loop instead of a single copy. Both are decoded on every sysvar cache fill.

#### Summary of Changes: 
introduce `SlotHash` and `StakeHistoryItem` as `#[repr(C)]` padding-free structs and store those in the sysvar types. `assert_zero_copy` is gated on little-endian, since a native `u64` never qualifies as zero-copy on big-endian targets; a size assert pins the padding-free layout everywhere.

#### Breaking: 
`SlotHash` changes from a `(u64, Hash)` alias to a struct, and the `Deref` targets become `Vec<SlotHash>` / `Vec<StakeHistoryItem>`, so callers use `.slot`/`.hash` and `.epoch`/`.entry` instead of `.0`/`.1`. The serialized layout is unchanged, and is covered by a new wire-compatibility test in each crate.

This needs `slot-hashes` 4.0.0, `stake-history` 2.0.0, plus majors for `sysvar`, `program`, and `address-lookup-table-interface` since they publicly re-export the changed types.