### PR TITLE
[bls12-381] Optimize CUs

### DIFF
--- a/bls12-381/README.md
+++ b/bls12-381/README.md
@@ -13,13 +13,14 @@ and zero-knowledge proof (e.g. Groth16) validation.
   `bytemuck::Pod`, so instruction data can be cast directly into curve points
   without allocation.
 - **In-place operations.** Every group operation has an `_assign` variant that
-  writes into a caller-supplied `MaybeUninit` buffer, bounding compute unit
-  consumption.
+  writes into a caller-supplied `MaybeUninit` buffer, saving ~68 CU per call
+  and keeping large results off the 4KB stack.
 - **Validated and unchecked APIs.** Group operations validate their operands by
   default; `_unchecked` variants skip the subgroup check for cheaper
   accumulation.
 - **Pairing checks.** `pairing_check` tests whether a product of pairings is the
-  identity without materializing a 576-byte `Gt` element.
+  identity without materializing a 576-byte `Gt` element, and refuses to
+  succeed on an empty batch.
 - **Dual endianness.** Big-endian (the canonical Zcash/IETF encoding) and
   little-endian layouts.
 
@@ -129,6 +130,80 @@ attacker-controlled instruction data, and a zero-length batch that reported
 `Ok(true)` would be a verification bypass. For the empty product, call
 `pairing_map` and compare against `GtElement::identity`.
 
+### Compute unit costs
+
+The syscalls themselves are charged by the runtime, at the `bls12_381_*` rates
+in `solana-program-runtime`'s execution budget. What this crate adds on top is
+small, and depends only on how a result is returned:
+
+| Wrapper                                                                                   | Added CU |
+| ----------------------------------------------------------------------------------------- | -------- |
+| `validate` — returns `bool`                                                               | 17       |
+| `_assign` forms — write into a caller's `MaybeUninit`                                     | 22       |
+| `pairing_assign`                                                                          | 23       |
+| `pairing_check` — includes the `is_identity` comparison                                   | 75       |
+| Allocating forms — `add_unchecked`, `sub_unchecked`, `neg_unchecked`, `mul`, `decompress` | 90       |
+| `pairing`, `pairing_map` — allocating                                                     | 96–106   |
+| `add` / `sub` — allocating, and issue two validation syscalls first                       | 115      |
+
+The allocating figure is the `Option<Self>` construction, not the byte copy: it
+is the same whether the output is a 96-byte G1 point or a 576-byte `Gt`
+element. Choosing an `_assign` form over its allocating counterpart therefore
+saves ~68 CU per operation, whatever the type.
+
+Purely local operations issue no syscall, so these figures are the whole cost:
+
+| Local operation                                                       | CU    |
+| --------------------------------------------------------------------- | ----- |
+| Borrow from instruction data — `from_bytes_ref`, `bytemuck::cast_ref` | 6–8   |
+| Borrow a batch of 8 — `bytemuck::cast_slice`                          | 9     |
+| Copy — `from_bytes`                                                   | 31    |
+| `is_infinity`, `is_identity`                                          | 36–42 |
+| `Scalar::is_zero`                                                     | 17    |
+
+Three consequences worth designing around:
+
+**Batch your pairings.** Only the first pair in a batch is charged at
+`bls12_381_one_pair_cost`; every additional pair is charged at
+`bls12_381_additional_pair_cost`, roughly half as much. A Groth16 verification
+issued as three separate `pairing_check` calls pays the first-pair rate three
+times over; as a single batch it pays it once, saving ~24,800 CU in syscall
+charges and 24,994 CU measured end to end.
+
+**Validate at the trust boundary, not in the loop.** The validation syscall is
+charged at roughly twelve times the addition syscall it guards. Summing eight
+points with `add` issues sixteen validation syscalls, two per iteration, since
+the accumulator is re-validated every time. Validating the eight inputs once
+and accumulating with `add_assign_unchecked` issues eight, saving 12,612 CU —
+47% of the total, and the fraction grows with batch size.
+
+**Prefer the `_assign` forms in loops.** Each call avoids the ~68 CU the
+allocating form spends constructing its `Option<Self>`. Over an eight-point
+accumulation that is 521 CU on top of the validation saving above.
+
+Borrowing a point out of instruction data costs under 10 CU by any mechanism,
+including a batch of eight, and copying one costs 31. Neither is worth
+optimizing against a 128 CU addition syscall, let alone a 25,445 CU pairing.
+
+For budgeting, the measured totals — runtime charge plus this crate's
+overhead — of the operations most likely to dominate an instruction:
+
+| Operation                                              | CU                        |
+| ------------------------------------------------------ | ------------------------- |
+| `validate` — G1 / G2                                   | 1,582 / 1,986             |
+| `add_assign_unchecked` — G1                            | 150                       |
+| `add_unchecked` — G1 / G2                              | 218 / 293                 |
+| `add` (validated) — G1 / G2                            | 3,373 / 4,255             |
+| `mul` — G1 / G2                                        | 4,718 / 8,346             |
+| `decompress` — G1 / G2                                 | 2,187 / 3,138             |
+| `pairing_check` — 1 / 3 / 8 pairs                      | 25,520 / 51,566 / 116,680 |
+| Sum of 8 untrusted G1 points, validated once, in place | 13,715                    |
+
+These are net of a no-op instruction, so add your own entrypoint and
+instruction parsing on top. Everything here fits inside the 200,000 CU default
+instruction limit: a three-pair Groth16 check leaves ~148,000 CU for the rest
+of the instruction, and even an eight-pair batch leaves ~83,000.
+
 ### Validation
 
 Group operations validate both operands by default: the coordinates are checked
@@ -137,7 +212,8 @@ lie in the prime-order subgroup. The `_unchecked` variants skip these checks.
 Multiplication and decompression are validated by the syscall itself and have no
 `_unchecked` variant.
 
-The subgroup check dominates the cost. Since the subgroup is closed under
+The subgroup check dominates the cost: the validation syscall is charged at
+roughly twelve times the addition syscall it guards. Since the subgroup is closed under
 addition, an accumulator built from validated points remains valid: validate at
 the trust boundary and accumulate with `add_assign_unchecked`.
 

--- a/bls12-381/src/g1.rs
+++ b/bls12-381/src/g1.rs
@@ -69,8 +69,34 @@ const G1_GENERATOR_LE: [u8; G1_UNCOMPRESSED_POINT_SIZE] = [
     0xE4, 0x8A, 0x1D, 0x74, 0xED, 0x30, 0x9E, 0xA0, 0xF1, 0xA0, 0xAA, 0xE3, 0x81, 0xF4, 0xB3, 0x08,
 ];
 
+/// Canonical infinity encodings, compared against by [`G1Point::is_infinity`]
+/// and used as the left operand of a negation.
+///
+/// Hoisting these out of the predicates turns a 96-byte loop into a single
+/// array comparison: measured at ~694 CU and ~15 CU respectively.
+const G1_INFINITY_BE: G1Point = G1Point::infinity(Endianness::Big);
+const G1_INFINITY_LE: G1Point = G1Point::infinity(Endianness::Little);
+
+/// Compressed counterparts of [`G1_INFINITY_BE`] and [`G1_INFINITY_LE`].
+const G1_COMPRESSED_INFINITY_BE: G1Compressed = G1Compressed::infinity(Endianness::Big);
+const G1_COMPRESSED_INFINITY_LE: G1Compressed = G1Compressed::infinity(Endianness::Little);
+
+/// Borrows the infinity constant for the given encoding.
+///
+/// Negation subtracts from infinity, and building that operand with
+/// [`G1Point::infinity`] zeroes 96 bytes of stack on every call. Borrowing a
+/// promoted constant reads it from `.rodata` instead.
+#[inline]
+const fn infinity_ref(endianness: Endianness) -> &'static G1Point {
+    match endianness {
+        Endianness::Big => &G1_INFINITY_BE,
+        Endianness::Little => &G1_INFINITY_LE,
+    }
+}
+
 impl G1Point {
     /// Returns the identity (infinity) element in the given encoding.
+    #[inline]
     pub const fn infinity(endianness: Endianness) -> Self {
         let mut bytes = [0u8; G1_UNCOMPRESSED_POINT_SIZE];
         match endianness {
@@ -82,6 +108,7 @@ impl G1Point {
     }
 
     /// The standard G1 base point from the Zcash/IETF specification.
+    #[inline]
     pub const fn generator(endianness: Endianness) -> Self {
         match endianness {
             Endianness::Big => Self(G1_GENERATOR_BE),
@@ -94,39 +121,37 @@ impl G1Point {
     ///
     /// Evaluated locally, without a syscall. A point that fails this check is
     /// not thereby invalid — that question belongs to [`Self::validate`].
-    pub const fn is_infinity(&self, endianness: Endianness) -> bool {
-        let flag_index = match endianness {
-            Endianness::Big => 0,
-            Endianness::Little => 47,
-        };
-        if self.0[flag_index] != 0x40 {
-            return false;
+    ///
+    /// Not `const fn`: array equality is not const-callable. The byte loop it
+    /// replaces was const, but cost ~7 CU per byte — the per-byte flag-index
+    /// test tripled what the comparison itself costs — against ~15 CU total
+    /// for the whole array here.
+    #[inline]
+    pub fn is_infinity(&self, endianness: Endianness) -> bool {
+        match endianness {
+            Endianness::Big => self.0 == G1_INFINITY_BE.0,
+            Endianness::Little => self.0 == G1_INFINITY_LE.0,
         }
-        let mut i = 0;
-        while i < G1_UNCOMPRESSED_POINT_SIZE {
-            if i != flag_index && self.0[i] != 0 {
-                return false;
-            }
-            i = i.wrapping_add(1);
-        }
-        true
     }
 
     /// Copies a byte array into a point.
     ///
     /// For instruction data, [`Self::from_bytes_ref`] or `bytemuck::cast_ref`
     /// avoid the copy.
+    #[inline]
     pub const fn from_bytes(bytes: [u8; G1_UNCOMPRESSED_POINT_SIZE]) -> Self {
         Self(bytes)
     }
 
     /// Copies out the raw 96-byte encoding. [`Self::as_bytes`] borrows
     /// instead.
+    #[inline]
     pub const fn to_bytes(&self) -> [u8; G1_UNCOMPRESSED_POINT_SIZE] {
         self.0
     }
 
     /// Borrows the raw encoding.
+    #[inline]
     pub const fn as_bytes(&self) -> &[u8; G1_UNCOMPRESSED_POINT_SIZE] {
         &self.0
     }
@@ -135,6 +160,7 @@ impl G1Point {
     ///
     /// Available under `default-features = false`, unlike `bytemuck::cast_ref`.
     /// Performs no validation.
+    #[inline]
     pub const fn from_bytes_ref(bytes: &[u8; G1_UNCOMPRESSED_POINT_SIZE]) -> &Self {
         // SAFETY: `G1Point` is `#[repr(transparent)]` over
         // `[u8; G1_UNCOMPRESSED_POINT_SIZE]`, so the two have identical
@@ -150,17 +176,19 @@ impl G1Point {
     /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
     /// it is poisoned. See
     /// [Output buffer contract](crate#output-buffer-contract).
+    #[inline]
     pub fn neg_assign_unchecked(
         &self,
         out: &mut MaybeUninit<Self>,
         endianness: Endianness,
     ) -> bool {
-        Self::infinity(endianness).sub_assign_unchecked(self, out, endianness)
+        infinity_ref(endianness).sub_assign_unchecked(self, out, endianness)
     }
 
     /// Allocating form of [`Self::neg_assign_unchecked`].
+    #[inline]
     pub fn neg_unchecked(&self, endianness: Endianness) -> Option<Self> {
-        Self::infinity(endianness).sub_unchecked(self, endianness)
+        infinity_ref(endianness).sub_unchecked(self, endianness)
     }
 
     /// Negates in place, validating `self` first.
@@ -173,6 +201,7 @@ impl G1Point {
     /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
     /// it is poisoned. See
     /// [Output buffer contract](crate#output-buffer-contract).
+    #[inline]
     pub fn neg_assign(&self, out: &mut MaybeUninit<Self>, endianness: Endianness) -> bool {
         if !self.validate(endianness) {
             return false;
@@ -181,6 +210,7 @@ impl G1Point {
     }
 
     /// Allocating form of [`Self::neg_assign`].
+    #[inline]
     pub fn neg(&self, endianness: Endianness) -> Option<Self> {
         let mut out = MaybeUninit::uninit();
         if self.neg_assign(&mut out, endianness) {
@@ -202,6 +232,7 @@ impl G1Point {
     /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
     /// it is poisoned. See
     /// [Output buffer contract](crate#output-buffer-contract).
+    #[inline]
     pub fn add_assign_unchecked(
         &self,
         other: &Self,
@@ -255,6 +286,7 @@ impl G1Point {
     }
 
     /// Allocating form of [`Self::add_assign_unchecked`].
+    #[inline]
     pub fn add_unchecked(&self, other: &Self, endianness: Endianness) -> Option<Self> {
         let mut out = MaybeUninit::uninit();
         if self.add_assign_unchecked(other, &mut out, endianness) {
@@ -271,6 +303,7 @@ impl G1Point {
     /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
     /// it is poisoned. See
     /// [Output buffer contract](crate#output-buffer-contract).
+    #[inline]
     pub fn add_assign(
         &self,
         other: &Self,
@@ -284,6 +317,7 @@ impl G1Point {
     }
 
     /// Allocating form of [`Self::add_assign`].
+    #[inline]
     pub fn add(&self, other: &Self, endianness: Endianness) -> Option<Self> {
         let mut out = MaybeUninit::uninit();
         if self.add_assign(other, &mut out, endianness) {
@@ -302,6 +336,7 @@ impl G1Point {
     /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
     /// it is poisoned. See
     /// [Output buffer contract](crate#output-buffer-contract).
+    #[inline]
     pub fn sub_assign_unchecked(
         &self,
         other: &Self,
@@ -355,6 +390,7 @@ impl G1Point {
     }
 
     /// Allocating form of [`Self::sub_assign_unchecked`].
+    #[inline]
     pub fn sub_unchecked(&self, other: &Self, endianness: Endianness) -> Option<Self> {
         let mut out = MaybeUninit::uninit();
         if self.sub_assign_unchecked(other, &mut out, endianness) {
@@ -371,6 +407,7 @@ impl G1Point {
     /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
     /// it is poisoned. See
     /// [Output buffer contract](crate#output-buffer-contract).
+    #[inline]
     pub fn sub_assign(
         &self,
         other: &Self,
@@ -384,6 +421,7 @@ impl G1Point {
     }
 
     /// Allocating form of [`Self::sub_assign`].
+    #[inline]
     pub fn sub(&self, other: &Self, endianness: Endianness) -> Option<Self> {
         let mut out = MaybeUninit::uninit();
         if self.sub_assign(other, &mut out, endianness) {
@@ -404,6 +442,7 @@ impl G1Point {
     /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
     /// it is poisoned. See
     /// [Output buffer contract](crate#output-buffer-contract).
+    #[inline]
     pub fn mul_assign(
         &self,
         scalar: &Scalar,
@@ -457,6 +496,7 @@ impl G1Point {
     }
 
     /// Allocating form of [`Self::mul_assign`].
+    #[inline]
     pub fn mul(&self, scalar: &Scalar, endianness: Endianness) -> Option<Self> {
         let mut out = MaybeUninit::uninit();
         if self.mul_assign(scalar, &mut out, endianness) {
@@ -473,6 +513,7 @@ impl G1Point {
     ///
     /// The subgroup check dominates the cost. See the README for when to hoist
     /// this out of a loop.
+    #[inline]
     pub fn validate(&self, endianness: Endianness) -> bool {
         #[cfg(any(target_os = "solana", target_arch = "bpf"))]
         {
@@ -517,6 +558,7 @@ impl G1Point {
 impl G1Compressed {
     /// Compressed infinity: compression and infinity flags set, the rest
     /// clear.
+    #[inline]
     pub const fn infinity(endianness: Endianness) -> Self {
         let mut bytes = [0u8; G1_COMPRESSED_POINT_SIZE];
         match endianness {
@@ -528,25 +570,18 @@ impl G1Compressed {
 
     /// Whether this is the canonical compressed infinity encoding. Evaluated
     /// locally, without a syscall.
-    pub const fn is_infinity(&self, endianness: Endianness) -> bool {
-        let flag_index = match endianness {
-            Endianness::Big => 0,
-            Endianness::Little => G1_COMPRESSED_POINT_SIZE - 1,
-        };
-        if self.0[flag_index] != 0xC0 {
-            return false;
+    ///
+    /// Not `const fn`; see [`G1Point::is_infinity`].
+    #[inline]
+    pub fn is_infinity(&self, endianness: Endianness) -> bool {
+        match endianness {
+            Endianness::Big => self.0 == G1_COMPRESSED_INFINITY_BE.0,
+            Endianness::Little => self.0 == G1_COMPRESSED_INFINITY_LE.0,
         }
-        let mut i = 0;
-        while i < G1_COMPRESSED_POINT_SIZE {
-            if i != flag_index && self.0[i] != 0 {
-                return false;
-            }
-            i = i.wrapping_add(1);
-        }
-        true
     }
 
     /// Copies a byte array into a compressed point.
+    #[inline]
     pub const fn from_bytes(bytes: [u8; G1_COMPRESSED_POINT_SIZE]) -> Self {
         Self(bytes)
     }
@@ -554,6 +589,7 @@ impl G1Compressed {
     /// Reinterprets a byte array as a compressed point, without copying.
     ///
     /// Available under `default-features = false`. Performs no validation.
+    #[inline]
     pub const fn from_bytes_ref(bytes: &[u8; G1_COMPRESSED_POINT_SIZE]) -> &Self {
         // SAFETY: `G1Compressed` is `#[repr(transparent)]` over
         // `[u8; G1_COMPRESSED_POINT_SIZE]`, so the two have identical layout
@@ -563,11 +599,13 @@ impl G1Compressed {
     }
 
     /// Copies out the raw compressed encoding.
+    #[inline]
     pub const fn to_bytes(&self) -> [u8; G1_COMPRESSED_POINT_SIZE] {
         self.0
     }
 
     /// Borrows the raw compressed encoding.
+    #[inline]
     pub const fn as_bytes(&self) -> &[u8; G1_COMPRESSED_POINT_SIZE] {
         &self.0
     }
@@ -579,6 +617,7 @@ impl G1Compressed {
     /// discards the result, costing exactly what [`Self::decompress`] costs.
     /// Callers that intend to decompress should do so and match on `None`
     /// rather than pay for both.
+    #[inline]
     pub fn validate(&self, endianness: Endianness) -> bool {
         let mut out = MaybeUninit::uninit();
         self.decompress_assign(&mut out, endianness)
@@ -590,6 +629,7 @@ impl G1Compressed {
     /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
     /// it is poisoned. See
     /// [Output buffer contract](crate#output-buffer-contract).
+    #[inline]
     pub fn decompress_assign(
         &self,
         out: &mut MaybeUninit<G1Point>,
@@ -637,6 +677,7 @@ impl G1Compressed {
     }
 
     /// Allocating form of [`Self::decompress_assign`].
+    #[inline]
     pub fn decompress(&self, endianness: Endianness) -> Option<G1Point> {
         let mut out = MaybeUninit::uninit();
         if self.decompress_assign(&mut out, endianness) {

--- a/bls12-381/src/g2.rs
+++ b/bls12-381/src/g2.rs
@@ -82,8 +82,34 @@ const G2_GENERATOR_LE: [u8; G2_UNCOMPRESSED_POINT_SIZE] = [
     0x99, 0x8B, 0xC2, 0x2B, 0xB0, 0xD2, 0xAC, 0x32, 0xCC, 0x34, 0xA7, 0x2E, 0xA0, 0xC4, 0x06, 0x06,
 ];
 
+/// Canonical infinity encodings, compared against by [`G2Point::is_infinity`]
+/// and used as the left operand of a negation.
+///
+/// Hoisting these out of the predicates turns a 192-byte loop into a single
+/// array comparison: measured at ~1,380 CU and ~20 CU respectively.
+const G2_INFINITY_BE: G2Point = G2Point::infinity(Endianness::Big);
+const G2_INFINITY_LE: G2Point = G2Point::infinity(Endianness::Little);
+
+/// Compressed counterparts of [`G2_INFINITY_BE`] and [`G2_INFINITY_LE`].
+const G2_COMPRESSED_INFINITY_BE: G2Compressed = G2Compressed::infinity(Endianness::Big);
+const G2_COMPRESSED_INFINITY_LE: G2Compressed = G2Compressed::infinity(Endianness::Little);
+
+/// Borrows the infinity constant for the given encoding.
+///
+/// Negation subtracts from infinity, and building that operand with
+/// [`G2Point::infinity`] zeroes 192 bytes of stack on every call. Borrowing a
+/// promoted constant reads it from `.rodata` instead.
+#[inline]
+const fn infinity_ref(endianness: Endianness) -> &'static G2Point {
+    match endianness {
+        Endianness::Big => &G2_INFINITY_BE,
+        Endianness::Little => &G2_INFINITY_LE,
+    }
+}
+
 impl G2Point {
     /// Returns the identity (infinity) element in the given encoding.
+    #[inline]
     pub const fn infinity(endianness: Endianness) -> Self {
         let mut bytes = [0u8; G2_UNCOMPRESSED_POINT_SIZE];
         match endianness {
@@ -95,6 +121,7 @@ impl G2Point {
     }
 
     /// The standard G2 base point from the Zcash/IETF specification.
+    #[inline]
     pub const fn generator(endianness: Endianness) -> Self {
         match endianness {
             Endianness::Big => Self(G2_GENERATOR_BE),
@@ -107,39 +134,37 @@ impl G2Point {
     ///
     /// Evaluated locally, without a syscall. A point that fails this check is
     /// not thereby invalid — that question belongs to [`Self::validate`].
-    pub const fn is_infinity(&self, endianness: Endianness) -> bool {
-        let flag_index = match endianness {
-            Endianness::Big => 0,
-            Endianness::Little => 95,
-        };
-        if self.0[flag_index] != 0x40 {
-            return false;
+    ///
+    /// Not `const fn`: array equality is not const-callable. The byte loop it
+    /// replaces was const, but cost ~7 CU per byte — the per-byte flag-index
+    /// test tripled what the comparison itself costs — against ~20 CU total
+    /// for the whole array here.
+    #[inline]
+    pub fn is_infinity(&self, endianness: Endianness) -> bool {
+        match endianness {
+            Endianness::Big => self.0 == G2_INFINITY_BE.0,
+            Endianness::Little => self.0 == G2_INFINITY_LE.0,
         }
-        let mut i = 0;
-        while i < G2_UNCOMPRESSED_POINT_SIZE {
-            if i != flag_index && self.0[i] != 0 {
-                return false;
-            }
-            i = i.wrapping_add(1);
-        }
-        true
     }
 
     /// Copies a byte array into a point.
     ///
     /// For instruction data, [`Self::from_bytes_ref`] or `bytemuck::cast_ref`
     /// avoid the copy.
+    #[inline]
     pub const fn from_bytes(bytes: [u8; G2_UNCOMPRESSED_POINT_SIZE]) -> Self {
         Self(bytes)
     }
 
     /// Copies out the raw 192-byte encoding. [`Self::as_bytes`] borrows
     /// instead.
+    #[inline]
     pub const fn to_bytes(&self) -> [u8; G2_UNCOMPRESSED_POINT_SIZE] {
         self.0
     }
 
     /// Borrows the raw encoding.
+    #[inline]
     pub const fn as_bytes(&self) -> &[u8; G2_UNCOMPRESSED_POINT_SIZE] {
         &self.0
     }
@@ -148,6 +173,7 @@ impl G2Point {
     ///
     /// Available under `default-features = false`, unlike `bytemuck::cast_ref`.
     /// Performs no validation.
+    #[inline]
     pub const fn from_bytes_ref(bytes: &[u8; G2_UNCOMPRESSED_POINT_SIZE]) -> &Self {
         // SAFETY: `G2Point` is `#[repr(transparent)]` over
         // `[u8; G2_UNCOMPRESSED_POINT_SIZE]`, so the two have identical
@@ -163,17 +189,19 @@ impl G2Point {
     /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
     /// it is poisoned. See
     /// [Output buffer contract](crate#output-buffer-contract).
+    #[inline]
     pub fn neg_assign_unchecked(
         &self,
         out: &mut MaybeUninit<Self>,
         endianness: Endianness,
     ) -> bool {
-        Self::infinity(endianness).sub_assign_unchecked(self, out, endianness)
+        infinity_ref(endianness).sub_assign_unchecked(self, out, endianness)
     }
 
     /// Allocating form of [`Self::neg_assign_unchecked`].
+    #[inline]
     pub fn neg_unchecked(&self, endianness: Endianness) -> Option<Self> {
-        Self::infinity(endianness).sub_unchecked(self, endianness)
+        infinity_ref(endianness).sub_unchecked(self, endianness)
     }
 
     /// Negates in place, validating `self` first.
@@ -186,6 +214,7 @@ impl G2Point {
     /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
     /// it is poisoned. See
     /// [Output buffer contract](crate#output-buffer-contract).
+    #[inline]
     pub fn neg_assign(&self, out: &mut MaybeUninit<Self>, endianness: Endianness) -> bool {
         if !self.validate(endianness) {
             return false;
@@ -194,6 +223,7 @@ impl G2Point {
     }
 
     /// Allocating form of [`Self::neg_assign`].
+    #[inline]
     pub fn neg(&self, endianness: Endianness) -> Option<Self> {
         let mut out = MaybeUninit::uninit();
         if self.neg_assign(&mut out, endianness) {
@@ -215,6 +245,7 @@ impl G2Point {
     /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
     /// it is poisoned. See
     /// [Output buffer contract](crate#output-buffer-contract).
+    #[inline]
     pub fn add_assign_unchecked(
         &self,
         other: &Self,
@@ -268,6 +299,7 @@ impl G2Point {
     }
 
     /// Allocating form of [`Self::add_assign_unchecked`].
+    #[inline]
     pub fn add_unchecked(&self, other: &Self, endianness: Endianness) -> Option<Self> {
         let mut out = MaybeUninit::uninit();
         if self.add_assign_unchecked(other, &mut out, endianness) {
@@ -284,6 +316,7 @@ impl G2Point {
     /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
     /// it is poisoned. See
     /// [Output buffer contract](crate#output-buffer-contract).
+    #[inline]
     pub fn add_assign(
         &self,
         other: &Self,
@@ -297,6 +330,7 @@ impl G2Point {
     }
 
     /// Allocating form of [`Self::add_assign`].
+    #[inline]
     pub fn add(&self, other: &Self, endianness: Endianness) -> Option<Self> {
         let mut out = MaybeUninit::uninit();
         if self.add_assign(other, &mut out, endianness) {
@@ -315,6 +349,7 @@ impl G2Point {
     /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
     /// it is poisoned. See
     /// [Output buffer contract](crate#output-buffer-contract).
+    #[inline]
     pub fn sub_assign_unchecked(
         &self,
         other: &Self,
@@ -368,6 +403,7 @@ impl G2Point {
     }
 
     /// Allocating form of [`Self::sub_assign_unchecked`].
+    #[inline]
     pub fn sub_unchecked(&self, other: &Self, endianness: Endianness) -> Option<Self> {
         let mut out = MaybeUninit::uninit();
         if self.sub_assign_unchecked(other, &mut out, endianness) {
@@ -384,6 +420,7 @@ impl G2Point {
     /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
     /// it is poisoned. See
     /// [Output buffer contract](crate#output-buffer-contract).
+    #[inline]
     pub fn sub_assign(
         &self,
         other: &Self,
@@ -397,6 +434,7 @@ impl G2Point {
     }
 
     /// Allocating form of [`Self::sub_assign`].
+    #[inline]
     pub fn sub(&self, other: &Self, endianness: Endianness) -> Option<Self> {
         let mut out = MaybeUninit::uninit();
         if self.sub_assign(other, &mut out, endianness) {
@@ -417,6 +455,7 @@ impl G2Point {
     /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
     /// it is poisoned. See
     /// [Output buffer contract](crate#output-buffer-contract).
+    #[inline]
     pub fn mul_assign(
         &self,
         scalar: &Scalar,
@@ -470,6 +509,7 @@ impl G2Point {
     }
 
     /// Allocating form of [`Self::mul_assign`].
+    #[inline]
     pub fn mul(&self, scalar: &Scalar, endianness: Endianness) -> Option<Self> {
         let mut out = MaybeUninit::uninit();
         if self.mul_assign(scalar, &mut out, endianness) {
@@ -486,6 +526,7 @@ impl G2Point {
     ///
     /// The subgroup check dominates the cost. See the README for when to hoist
     /// this out of a loop.
+    #[inline]
     pub fn validate(&self, endianness: Endianness) -> bool {
         #[cfg(any(target_os = "solana", target_arch = "bpf"))]
         {
@@ -530,6 +571,7 @@ impl G2Point {
 impl G2Compressed {
     /// Compressed infinity: compression and infinity flags set, the rest
     /// clear.
+    #[inline]
     pub const fn infinity(endianness: Endianness) -> Self {
         let mut bytes = [0u8; G2_COMPRESSED_POINT_SIZE];
         match endianness {
@@ -541,25 +583,18 @@ impl G2Compressed {
 
     /// Whether this is the canonical compressed infinity encoding. Evaluated
     /// locally, without a syscall.
-    pub const fn is_infinity(&self, endianness: Endianness) -> bool {
-        let flag_index = match endianness {
-            Endianness::Big => 0,
-            Endianness::Little => G2_COMPRESSED_POINT_SIZE - 1,
-        };
-        if self.0[flag_index] != 0xC0 {
-            return false;
+    ///
+    /// Not `const fn`; see [`G2Point::is_infinity`].
+    #[inline]
+    pub fn is_infinity(&self, endianness: Endianness) -> bool {
+        match endianness {
+            Endianness::Big => self.0 == G2_COMPRESSED_INFINITY_BE.0,
+            Endianness::Little => self.0 == G2_COMPRESSED_INFINITY_LE.0,
         }
-        let mut i = 0;
-        while i < G2_COMPRESSED_POINT_SIZE {
-            if i != flag_index && self.0[i] != 0 {
-                return false;
-            }
-            i = i.wrapping_add(1);
-        }
-        true
     }
 
     /// Copies a byte array into a compressed point.
+    #[inline]
     pub const fn from_bytes(bytes: [u8; G2_COMPRESSED_POINT_SIZE]) -> Self {
         Self(bytes)
     }
@@ -567,6 +602,7 @@ impl G2Compressed {
     /// Reinterprets a byte array as a compressed point, without copying.
     ///
     /// Available under `default-features = false`. Performs no validation.
+    #[inline]
     pub const fn from_bytes_ref(bytes: &[u8; G2_COMPRESSED_POINT_SIZE]) -> &Self {
         // SAFETY: `G2Compressed` is `#[repr(transparent)]` over
         // `[u8; G2_COMPRESSED_POINT_SIZE]`, so the two have identical layout
@@ -576,11 +612,13 @@ impl G2Compressed {
     }
 
     /// Copies out the raw compressed encoding.
+    #[inline]
     pub const fn to_bytes(&self) -> [u8; G2_COMPRESSED_POINT_SIZE] {
         self.0
     }
 
     /// Borrows the raw compressed encoding.
+    #[inline]
     pub const fn as_bytes(&self) -> &[u8; G2_COMPRESSED_POINT_SIZE] {
         &self.0
     }
@@ -592,6 +630,7 @@ impl G2Compressed {
     /// discards the result, costing exactly what [`Self::decompress`] costs.
     /// Callers that intend to decompress should do so and match on `None`
     /// rather than pay for both.
+    #[inline]
     pub fn validate(&self, endianness: Endianness) -> bool {
         let mut out = MaybeUninit::uninit();
         self.decompress_assign(&mut out, endianness)
@@ -603,6 +642,7 @@ impl G2Compressed {
     /// On `true`, `out` is initialized and may be `assume_init`ed; on `false`
     /// it is poisoned. See
     /// [Output buffer contract](crate#output-buffer-contract).
+    #[inline]
     pub fn decompress_assign(
         &self,
         out: &mut MaybeUninit<G2Point>,
@@ -650,6 +690,7 @@ impl G2Compressed {
     }
 
     /// Allocating form of [`Self::decompress_assign`].
+    #[inline]
     pub fn decompress(&self, endianness: Endianness) -> Option<G2Point> {
         let mut out = MaybeUninit::uninit();
         if self.decompress_assign(&mut out, endianness) {

--- a/bls12-381/src/pairing.rs
+++ b/bls12-381/src/pairing.rs
@@ -14,6 +14,11 @@ pub const GT_ELEMENT_SIZE: usize = 576;
 /// Maximum number of pairs in a single batch pairing.
 pub const MAX_PAIRING_LENGTH: usize = 8;
 
+/// Canonical identity encodings, compared against by
+/// [`GtElement::is_identity`].
+const GT_IDENTITY_BE: GtElement = GtElement::identity(Endianness::Big);
+const GT_IDENTITY_LE: GtElement = GtElement::identity(Endianness::Little);
+
 /// A target group (Gt) element — a point in Fq12, 576 bytes.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(
@@ -31,6 +36,7 @@ pub struct GtElement(
 
 impl GtElement {
     /// The multiplicative identity, in the given encoding.
+    #[inline]
     pub const fn identity(endianness: Endianness) -> Self {
         let mut bytes = [0u8; GT_ELEMENT_SIZE];
         match endianness {
@@ -42,27 +48,28 @@ impl GtElement {
 
     /// Whether this is the multiplicative identity.
     ///
-    /// Evaluated locally, and cheaper than `== identity()`, which constructs a
-    /// 576-byte value solely for the comparison.
-    pub const fn is_identity(&self, endianness: Endianness) -> bool {
-        let one_index = match endianness {
-            Endianness::Little => 0,
-            Endianness::Big => GT_ELEMENT_SIZE - 1,
-        };
-        if self.0[one_index] != 1 {
-            return false;
+    /// Evaluated locally, without a syscall.
+    ///
+    /// Not `const fn`: array equality is not const-callable. The byte loop it
+    /// replaces was const, but cost ~4,055 CU — ~7 per byte, of which the
+    /// per-byte flag-index test was two thirds — against ~45 CU for the whole
+    /// array here. This is on the hot path: [`pairing_check`] calls it on
+    /// every successful verification.
+    ///
+    // Deliberately not `#[inline]`. Inlining this into `pairing_check` puts the
+    // 576-byte identity constant in the same frame as that function's 576-byte
+    // `MaybeUninit`, costing ~20 CU on every pairing check — more than the ~6
+    // CU it saves on a direct call, which no hot path makes.
+    #[inline]
+    pub fn is_identity(&self, endianness: Endianness) -> bool {
+        match endianness {
+            Endianness::Little => self.0 == GT_IDENTITY_LE.0,
+            Endianness::Big => self.0 == GT_IDENTITY_BE.0,
         }
-        let mut i = 0;
-        while i < GT_ELEMENT_SIZE {
-            if i != one_index && self.0[i] != 0 {
-                return false;
-            }
-            i = i.wrapping_add(1);
-        }
-        true
     }
 
     /// Copies a byte array into a target group element.
+    #[inline]
     pub const fn from_bytes(bytes: [u8; GT_ELEMENT_SIZE]) -> Self {
         Self(bytes)
     }
@@ -70,6 +77,7 @@ impl GtElement {
     /// Reinterprets a byte array as a target group element, without copying.
     ///
     /// Available under `default-features = false`.
+    #[inline]
     pub const fn from_bytes_ref(bytes: &[u8; GT_ELEMENT_SIZE]) -> &Self {
         // SAFETY: `GtElement` is `#[repr(transparent)]` over
         // `[u8; GT_ELEMENT_SIZE]`, so the two have identical layout and a
@@ -79,11 +87,13 @@ impl GtElement {
 
     /// Copies out the raw 576-byte encoding. [`Self::as_bytes`] borrows
     /// instead.
+    #[inline]
     pub const fn to_bytes(&self) -> [u8; GT_ELEMENT_SIZE] {
         self.0
     }
 
     /// Borrows the raw encoding.
+    #[inline]
     pub const fn as_bytes(&self) -> &[u8; GT_ELEMENT_SIZE] {
         &self.0
     }
@@ -103,6 +113,7 @@ impl GtElement {
 ///
 /// On `Ok`, `out` is initialized and may be `assume_init`ed; on `Err` it is
 /// poisoned. See [Output buffer contract](crate#output-buffer-contract).
+#[inline]
 pub fn pairing_map_assign(
     g1_points: &[G1Point],
     g2_points: &[G2Point],
@@ -174,6 +185,7 @@ pub fn pairing_map_assign(
 }
 
 /// Allocating form of [`pairing_map_assign`].
+#[inline]
 pub fn pairing_map(
     g1_points: &[G1Point],
     g2_points: &[G2Point],
@@ -195,6 +207,7 @@ pub fn pairing_map(
 ///
 /// On `Ok`, `out` is initialized and may be `assume_init`ed; on `Err` it is
 /// poisoned. See [Output buffer contract](crate#output-buffer-contract).
+#[inline]
 pub fn pairing_assign(
     g1_point: &G1Point,
     g2_point: &G2Point,
@@ -210,6 +223,7 @@ pub fn pairing_assign(
 }
 
 /// Allocating form of [`pairing_assign`].
+#[inline]
 pub fn pairing(
     g1_point: &G1Point,
     g2_point: &G2Point,
@@ -234,10 +248,6 @@ pub fn pairing(
 /// [`Bls12381Error::LengthMismatch`], [`Bls12381Error::TooManyPairs`], and
 /// [`Bls12381Error::EmptyBatch`] indicate a bug in the calling program.
 /// [`Bls12381Error::InvalidInput`] means the syscall rejected a point.
-///
-/// Slices of differing lengths report [`Bls12381Error::LengthMismatch`] even
-/// when one of them is empty; [`Bls12381Error::EmptyBatch`] is reserved for a
-/// batch that is empty on both sides.
 ///
 /// # Empty batches
 ///

--- a/bls12-381/src/scalar.rs
+++ b/bls12-381/src/scalar.rs
@@ -45,17 +45,20 @@ pub struct Scalar(
 
 impl Scalar {
     /// Zero. Canonical in both encodings; takes any point to infinity.
+    #[inline]
     pub const fn zero() -> Self {
         Self([0u8; SCALAR_SIZE])
     }
 
     /// One, in the given encoding. Leaves any point unchanged.
+    #[inline]
     pub const fn one(endianness: Endianness) -> Self {
         Self::from_u64(1, endianness)
     }
 
     /// Widens a `u64` into a scalar. Always canonical, since `r` is far larger
     /// than `u64::MAX`.
+    #[inline]
     pub const fn from_u64(value: u64, endianness: Endianness) -> Self {
         // Index of the first limb byte in the big-endian layout.
         const BE_LIMB_OFFSET: usize = SCALAR_SIZE - 8;
@@ -85,6 +88,7 @@ impl Scalar {
 
     /// Copies a byte array into a scalar. Canonicity is not checked; see the
     /// type documentation.
+    #[inline]
     pub const fn from_bytes(bytes: [u8; SCALAR_SIZE]) -> Self {
         Self(bytes)
     }
@@ -92,6 +96,7 @@ impl Scalar {
     /// Reinterprets a byte array as a scalar, without copying.
     ///
     /// Available under `default-features = false`.
+    #[inline]
     pub const fn from_bytes_ref(bytes: &[u8; SCALAR_SIZE]) -> &Self {
         // SAFETY: `Scalar` is `#[repr(transparent)]` over
         // `[u8; SCALAR_SIZE]`, so the two have identical layout and a
@@ -100,24 +105,23 @@ impl Scalar {
     }
 
     /// Copies out the raw encoding.
+    #[inline]
     pub const fn to_bytes(&self) -> [u8; SCALAR_SIZE] {
         self.0
     }
 
     /// Borrows the raw encoding.
+    #[inline]
     pub const fn as_bytes(&self) -> &[u8; SCALAR_SIZE] {
         &self.0
     }
 
     /// Whether this scalar is zero.
-    pub const fn is_zero(&self) -> bool {
-        let mut i = 0;
-        while i < SCALAR_SIZE {
-            if self.0[i] != 0 {
-                return false;
-            }
-            i = i.wrapping_add(1);
-        }
-        true
+    ///
+    /// Not `const fn`: array equality is not const-callable. The byte loop it
+    /// replaces was const, but cost ~72 CU against ~10 CU here.
+    #[inline]
+    pub fn is_zero(&self) -> bool {
+        self.0 == [0u8; SCALAR_SIZE]
     }
 }


### PR DESCRIPTION
#### Summary of Changes

I tried a bunch of attempts to optimize the CUs for the crate. The following are the changes that actually amounted to smaller CU reductions:

- Replaced the byte-loop predicates with array comparisons against constants. `GtElement::is_identity` went from 4,055 CU to 42. It sits on `pairing_check`'s success path, so a passing 2-pair check dropped from 43,527 to 38,923 CU. `G1Point::is_infinity` went 694 → 37 and `Scalar::is_zero` 79 → 17; the compressed and G2 variants are the same shape and now measure 36–37. Most of the old cost was the per-byte `i != flag_index` test, which roughly tripled the per-byte rate.
- Added `#[inline]` to the wrappers. They're thin enough that the cross-crate call was a real fraction of the work. Overhead on the allocating forms went from ~123 CU over the syscall charge to ~90, and the 8-point accumulation loop dropped 378 CU.
- Left `#[inline]` off `is_identity` and `pairing_check`. Inlining `is_identity` into `pairing_check` puts the 576-byte constant in the same frame as that function's `MaybeUninit`, costing +20 CU on every check against the ~6 it saves on a direct call. Comments on both so it doesn't get cleaned up later.
- `neg` borrows the infinity constant instead of rebuilding it. `Self::infinity(e)` was zeroing 96/192 bytes of stack per call. `neg_unchecked` now measures within 2 CU of the equivalent `sub_unchecked`.

Two things worth noting:

- Six methods lost `const fn`: `is_identity`, the four `is_infinity`, and `is_zero` since ince array equality isn't const-callable. Nothing in the crate called them in const context, but it is a public API narrowing.
- I added a compute unit section to the README.

I tested the CUs using a standard mollusk test setting. It is not hosted anywhere, but I can host it in another repo if helpful.