### PR TITLE
feat(bls-signatures): introduce granular parse and point-conversion error variants

### DIFF
--- a/bls-signatures/src/error.rs
+++ b/bls-signatures/src/error.rs
@@ -14,6 +14,22 @@ pub enum BlsError {
     ParseFromString, // TODO: update after more precise error handling
     #[error("Failed to parse from bytes")]
     ParseFromBytes,
+    #[error("Failed to decode base64 string")]
+    InvalidBase64,
+    #[error("Base64 string length exceeded: max {max}, got {actual}")]
+    StringLengthExceeded { max: usize, actual: usize },
+    #[error("Invalid encoded length: expected {expected}, got {actual}")]
+    InvalidEncodedLength { expected: usize, actual: usize },
+    #[error("Invalid encoded length: expected {expected_compressed} or {expected_uncompressed}, got {actual}")]
+    InvalidLengthMultiple {
+        expected_compressed: usize,
+        expected_uncompressed: usize,
+        actual: usize,
+    },
+    #[error("Invalid point encoding")]
+    InvalidPointEncoding,
+    #[error("Identity point rejected")]
+    IdentityPointRejected,
     #[error("The length of inputs do not match")]
     InputLengthMismatch,
     #[error("Cryptographic verification failed")]

--- a/bls-signatures/src/error.rs
+++ b/bls-signatures/src/error.rs
@@ -8,12 +8,8 @@ pub enum BlsError {
     EmptyAggregation,
     #[error("Key derivation failed")]
     KeyDerivation,
-    #[error("Point representation conversion failed")]
-    PointConversion, // TODO: could be more specific here
-    #[error("Failed to parse from string")]
-    ParseFromString, // TODO: update after more precise error handling
-    #[error("Failed to parse from bytes")]
-    ParseFromBytes,
+    #[error("Keypair mismatch: public key does not correspond to secret key")]
+    KeypairMismatch,
     #[error("Failed to decode base64 string")]
     InvalidBase64,
     #[error("Base64 string length exceeded: max {max}, got {actual}")]

--- a/bls-signatures/src/keypair.rs
+++ b/bls-signatures/src/keypair.rs
@@ -92,18 +92,24 @@ impl TryFrom<&[u8]> for Keypair {
     type Error = BlsError;
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
         if bytes.len() != BLS_KEYPAIR_SIZE {
-            return Err(BlsError::ParseFromBytes);
+            return Err(BlsError::InvalidEncodedLength {
+                expected: BLS_KEYPAIR_SIZE,
+                actual: bytes.len(),
+            });
         }
 
         let secret = SecretKey::try_from(&bytes[..BLS_SECRET_KEY_SIZE])?;
         let pubkey_bytes: &[u8; BLS_PUBLIC_KEY_AFFINE_SIZE] = bytes[BLS_SECRET_KEY_SIZE..]
             .try_into()
-            .map_err(|_| BlsError::ParseFromBytes)?;
+            .map_err(|_| BlsError::InvalidEncodedLength {
+                expected: BLS_PUBLIC_KEY_AFFINE_SIZE,
+                actual: bytes.len().saturating_sub(BLS_SECRET_KEY_SIZE),
+            })?;
         let public = PubkeyAffine::try_from(pubkey_bytes)?;
 
         let expected_public: PubkeyAffine = PubkeyProjective::from_secret(&secret).into();
         if expected_public != public {
-            return Err(BlsError::ParseFromBytes);
+            return Err(BlsError::KeypairMismatch);
         }
 
         Ok(Self {
@@ -194,6 +200,22 @@ impl Keypair {
 #[cfg(test)]
 mod tests {
     use {super::*, tempfile::NamedTempFile};
+
+    #[test]
+    fn test_keypair_mismatch() {
+        let keypair1 = Keypair::new();
+        let keypair2 = Keypair::new();
+
+        let mut bytes = Zeroizing::new([0u8; BLS_KEYPAIR_SIZE]);
+        let secret_bytes: Zeroizing<[u8; BLS_SECRET_KEY_SIZE]> = (&keypair1.secret).into();
+        bytes[..BLS_SECRET_KEY_SIZE].copy_from_slice(secret_bytes.as_slice());
+        bytes[BLS_SECRET_KEY_SIZE..].copy_from_slice(&keypair2.public.to_bytes_uncompressed());
+
+        assert_eq!(
+            Keypair::try_from(bytes.as_slice()).unwrap_err(),
+            BlsError::KeypairMismatch
+        );
+    }
 
     #[test]
     fn test_keygen_derive() {

--- a/bls-signatures/src/macros.rs
+++ b/bls-signatures/src/macros.rs
@@ -7,14 +7,20 @@ macro_rules! impl_from_str {
                 use base64::Engine;
 
                 if s.len() > $base64_len {
-                    return Err(Self::Err::ParseFromString);
+                    return Err(Self::Err::StringLengthExceeded {
+                        max: $base64_len,
+                        actual: s.len(),
+                    });
                 }
                 let mut bytes = [0u8; $bytes_len];
                 let decoded_len = base64::prelude::BASE64_STANDARD
                     .decode_slice(s, &mut bytes)
-                    .map_err(|_| Self::Err::ParseFromString)?;
+                    .map_err(|_| Self::Err::InvalidBase64)?;
                 if decoded_len != $bytes_len {
-                    Err(Self::Err::ParseFromString)
+                    Err(Self::Err::InvalidEncodedLength {
+                        expected: $bytes_len,
+                        actual: decoded_len,
+                    })
                 } else {
                     Ok($type(bytes))
                 }
@@ -122,11 +128,11 @@ macro_rules! impl_bls_conversions {
             fn try_from(bytes: &$uncompressed) -> Result<Self, Self::Error> {
                 let maybe_point: Option<$blstrs_affine> =
                     <$blstrs_affine>::from_uncompressed(&bytes.0).into();
-                let point = maybe_point.ok_or(crate::error::BlsError::PointConversion)?;
+                let point = maybe_point.ok_or(crate::error::BlsError::InvalidPointEncoding)?;
                 if $reject_identity
                     && bool::from(group::prime::PrimeCurveAffine::is_identity(&point))
                 {
-                    return Err(crate::error::BlsError::PointConversion);
+                    return Err(crate::error::BlsError::IdentityPointRejected);
                 }
                 Ok(Self(point))
             }
@@ -144,11 +150,11 @@ macro_rules! impl_bls_conversions {
             fn try_from(bytes: &$compressed) -> Result<Self, Self::Error> {
                 let maybe_point: Option<$blstrs_affine> =
                     <$blstrs_affine>::from_compressed(&bytes.0).into();
-                let point = maybe_point.ok_or(crate::error::BlsError::PointConversion)?;
+                let point = maybe_point.ok_or(crate::error::BlsError::InvalidPointEncoding)?;
                 if $reject_identity
                     && bool::from(group::prime::PrimeCurveAffine::is_identity(&point))
                 {
-                    return Err(crate::error::BlsError::PointConversion);
+                    return Err(crate::error::BlsError::IdentityPointRejected);
                 }
                 Ok(Self(point))
             }
@@ -391,19 +397,29 @@ macro_rules! impl_bls_conversions {
 
             fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
                 if bytes.len() == $uncompressed_size {
-                    let array: [u8; $uncompressed_size] = bytes
-                        .try_into()
-                        .map_err(|_| crate::error::BlsError::ParseFromBytes)?;
+                    let array: [u8; $uncompressed_size] = bytes.try_into().map_err(|_| {
+                        crate::error::BlsError::InvalidEncodedLength {
+                            expected: $uncompressed_size,
+                            actual: bytes.len(),
+                        }
+                    })?;
                     let wrapper = $uncompressed(array);
                     Self::try_from(&wrapper)
                 } else if bytes.len() == $compressed_size {
-                    let array: [u8; $compressed_size] = bytes
-                        .try_into()
-                        .map_err(|_| crate::error::BlsError::ParseFromBytes)?;
+                    let array: [u8; $compressed_size] = bytes.try_into().map_err(|_| {
+                        crate::error::BlsError::InvalidEncodedLength {
+                            expected: $compressed_size,
+                            actual: bytes.len(),
+                        }
+                    })?;
                     let wrapper = $compressed(array);
                     Self::try_from(&wrapper)
                 } else {
-                    Err(crate::error::BlsError::ParseFromBytes)
+                    Err(crate::error::BlsError::InvalidLengthMultiple {
+                        expected_compressed: $compressed_size,
+                        expected_uncompressed: $uncompressed_size,
+                        actual: bytes.len(),
+                    })
                 }
             }
         }
@@ -413,19 +429,29 @@ macro_rules! impl_bls_conversions {
 
             fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
                 if bytes.len() == $uncompressed_size {
-                    let array: [u8; $uncompressed_size] = bytes
-                        .try_into()
-                        .map_err(|_| crate::error::BlsError::ParseFromBytes)?;
+                    let array: [u8; $uncompressed_size] = bytes.try_into().map_err(|_| {
+                        crate::error::BlsError::InvalidEncodedLength {
+                            expected: $uncompressed_size,
+                            actual: bytes.len(),
+                        }
+                    })?;
                     let wrapper = $uncompressed(array);
                     Self::try_from(&wrapper)
                 } else if bytes.len() == $compressed_size {
-                    let array: [u8; $compressed_size] = bytes
-                        .try_into()
-                        .map_err(|_| crate::error::BlsError::ParseFromBytes)?;
+                    let array: [u8; $compressed_size] = bytes.try_into().map_err(|_| {
+                        crate::error::BlsError::InvalidEncodedLength {
+                            expected: $compressed_size,
+                            actual: bytes.len(),
+                        }
+                    })?;
                     let wrapper = $compressed(array);
                     Self::try_from(&wrapper)
                 } else {
-                    Err(crate::error::BlsError::ParseFromBytes)
+                    Err(crate::error::BlsError::InvalidLengthMultiple {
+                        expected_compressed: $compressed_size,
+                        expected_uncompressed: $uncompressed_size,
+                        actual: bytes.len(),
+                    })
                 }
             }
         }
@@ -491,7 +517,7 @@ macro_rules! impl_unchecked_conversions {
             type Error = crate::error::BlsError;
             fn try_from(bytes: $compressed_type) -> Result<Self, Self::Error> {
                 let point = Option::from(<$internal_type>::from_compressed_unchecked(&bytes.0))
-                    .ok_or(crate::error::BlsError::PointConversion)?;
+                    .ok_or(crate::error::BlsError::InvalidPointEncoding)?;
                 Ok(Self(point))
             }
         }
@@ -510,7 +536,7 @@ macro_rules! impl_unchecked_conversions {
             type Error = crate::error::BlsError;
             fn try_from(bytes: $uncompressed_type) -> Result<Self, Self::Error> {
                 let point = Option::from(<$internal_type>::from_uncompressed_unchecked(&bytes.0))
-                    .ok_or(crate::error::BlsError::PointConversion)?;
+                    .ok_or(crate::error::BlsError::InvalidPointEncoding)?;
                 Ok(Self(point))
             }
         }

--- a/bls-signatures/src/pubkey/mod.rs
+++ b/bls-signatures/src/pubkey/mod.rs
@@ -259,6 +259,52 @@ mod tests {
         assert_eq!(pubkey_compressed, pubkey_compressed_from_string);
     }
 
+    #[test]
+    fn test_invalid_base64() {
+        let invalid_b64 = "This is not valid base64!@#$";
+        assert_eq!(
+            Pubkey::from_str(invalid_b64).unwrap_err(),
+            BlsError::InvalidBase64
+        );
+    }
+
+    #[test]
+    fn test_invalid_base64_length() {
+        // A base64 string that is within string length bounds, but decodes to wrong byte length
+        let valid_bytes = [0u8; 47];
+        use base64::Engine;
+        let base64_str = base64::engine::general_purpose::STANDARD.encode(valid_bytes);
+        assert_eq!(
+            Pubkey::from_str(&base64_str).unwrap_err(),
+            BlsError::InvalidEncodedLength {
+                expected: BLS_PUBLIC_KEY_AFFINE_SIZE,
+                actual: 47
+            }
+        );
+    }
+
+    #[test]
+    fn test_string_length_exceeded() {
+        let overlong_b64 = "A".repeat(BLS_PUBLIC_KEY_AFFINE_BASE64_SIZE + 1);
+        assert_eq!(
+            Pubkey::from_str(&overlong_b64).unwrap_err(),
+            BlsError::StringLengthExceeded {
+                max: BLS_PUBLIC_KEY_AFFINE_BASE64_SIZE,
+                actual: BLS_PUBLIC_KEY_AFFINE_BASE64_SIZE + 1
+            }
+        );
+    }
+
+    #[test]
+    fn test_invalid_point_encoding() {
+        let invalid_bytes = [255u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE];
+        let pubkey_compressed = PubkeyCompressed(invalid_bytes);
+        assert_eq!(
+            PubkeyProjective::try_from(&pubkey_compressed).unwrap_err(),
+            BlsError::InvalidPointEncoding
+        );
+    }
+
     #[cfg(feature = "serde")]
     #[test]
     fn serialize_and_deserialize_pubkey() {
@@ -318,13 +364,21 @@ mod tests {
 
         assert_eq!(
             PubkeyProjective::try_from(pubkey_long_bytes.as_slice()).unwrap_err(),
-            BlsError::ParseFromBytes
+            BlsError::InvalidLengthMultiple {
+                expected_compressed: BLS_PUBLIC_KEY_COMPRESSED_SIZE,
+                expected_uncompressed: BLS_PUBLIC_KEY_AFFINE_SIZE,
+                actual: 49,
+            }
         );
 
         let pubkey_short_bytes = &pubkey_bytes[..47];
         assert_eq!(
             PubkeyProjective::try_from(pubkey_short_bytes).unwrap_err(),
-            BlsError::ParseFromBytes
+            BlsError::InvalidLengthMultiple {
+                expected_compressed: BLS_PUBLIC_KEY_COMPRESSED_SIZE,
+                expected_uncompressed: BLS_PUBLIC_KEY_AFFINE_SIZE,
+                actual: 47,
+            }
         );
     }
 
@@ -359,14 +413,14 @@ mod tests {
         // Assert compressed byte conversion fails
         let id_pk_compressed: PubkeyCompressed = (&id_pk_proj).into();
         let recovered = PubkeyProjective::try_from(&id_pk_compressed);
-        assert_eq!(recovered.unwrap_err(), BlsError::PointConversion);
+        assert_eq!(recovered.unwrap_err(), BlsError::IdentityPointRejected);
 
         // Assert uncompressed byte conversion fails
         let id_pk_uncompressed: Pubkey = (&id_pk_proj).into();
         let recovered_uncompressed = PubkeyProjective::try_from(&id_pk_uncompressed);
         assert_eq!(
             recovered_uncompressed.unwrap_err(),
-            BlsError::PointConversion
+            BlsError::IdentityPointRejected
         );
     }
 }

--- a/bls-signatures/src/secret_key.rs
+++ b/bls-signatures/src/secret_key.rs
@@ -129,7 +129,10 @@ impl TryFrom<&[u8]> for SecretKey {
     type Error = BlsError;
     fn try_from(src: &[u8]) -> Result<Self, Self::Error> {
         if src.len() != BLS_SECRET_KEY_SIZE {
-            return Err(BlsError::ParseFromBytes);
+            return Err(BlsError::InvalidEncodedLength {
+                expected: BLS_SECRET_KEY_SIZE,
+                actual: src.len(),
+            });
         }
         let mut bytes = Zeroizing::new([0u8; BLS_SECRET_KEY_SIZE]);
         bytes.copy_from_slice(src);
@@ -154,5 +157,22 @@ impl TryFrom<&[u8]> for SecretKey {
 impl From<&SecretKey> for Zeroizing<[u8; BLS_SECRET_KEY_SIZE]> {
     fn from(secret_key: &SecretKey) -> Self {
         Zeroizing::new(secret_key.0.to_bytes_le())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_secret_key_invalid_length() {
+        let invalid_bytes = [0u8; 31];
+        assert_eq!(
+            SecretKey::try_from(&invalid_bytes[..]).unwrap_err(),
+            BlsError::InvalidEncodedLength {
+                expected: BLS_SECRET_KEY_SIZE,
+                actual: 31,
+            }
+        );
     }
 }


### PR DESCRIPTION
- `BlsError` collapsed multiple distinct parse/point-validation failures into `ParseFromString`, `ParseFromBytes`, `PointConversion` (see TODOs in `error.rs`)
- Added granular variants: `InvalidBase64`, `StringLengthExceeded`, `InvalidEncodedLength`, `InvalidLengthMultiple`, `InvalidPointEncoding`, `IdentityPointRejected`, `KeypairMismatch`
- Removed the three legacy variants, now fully superseded
- Updated `impl_from_str!` / `impl_bls_conversions!` macros to preserve exact failure cause at decode and affine-conversion boundaries
- Updated `keypair.rs` to use `InvalidEncodedLength` for length mismatches and `KeypairMismatch` for public/secret key mismatch (previously misused `ParseFromBytes`)
- Updated `secret_key.rs` to use `InvalidEncodedLength` for length mismatches

## Breaking Change
`BlsError` is not `#[non_exhaustive]`   variants added, removed. Downstream exhaustive matches on `BlsError` will need updating.