### PR TITLE
{transaction,instruction}-error!: Mark enums non-exhaustive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3779,6 +3779,8 @@ dependencies = [
  "solana-frozen-abi-macro",
  "solana-instruction-error",
  "solana-program-error",
+ "strum",
+ "strum_macros",
  "wincode",
 ]
 
@@ -4728,6 +4730,8 @@ dependencies = [
  "solana-instruction-error",
  "solana-sanitize",
  "solana-transaction-error",
+ "strum",
+ "strum_macros",
  "wincode",
 ]
 

--- a/instruction-error/Cargo.toml
+++ b/instruction-error/Cargo.toml
@@ -34,6 +34,8 @@ wincode = { workspace = true, optional = true }
 # Self-dependency enabling `wincode` so the `frozen_abi` wincode digest test can
 # serialize `InstructionError` during unit tests.
 solana-instruction-error = { path = ".", features = ["wincode"] }
+strum = { workspace = true }
+strum_macros = { workspace = true }
 
 [lints]
 workspace = true

--- a/instruction-error/src/lib.rs
+++ b/instruction-error/src/lib.rs
@@ -576,16 +576,18 @@ mod tests {
     };
 
     #[test]
-    fn test_instruction_error_variants_exhaustive() {
-        for variant in InstructionError::iter() {
-            assert!(InstructionError::VARIANTS.contains(&variant));
+    fn test_lamports_error_variants_exhaustive() {
+        for variant in LamportsError::iter() {
+            assert!(LamportsError::VARIANTS.contains(&variant));
         }
     }
 
     #[test]
-    fn test_lamports_error_variants_exhaustive() {
-        for variant in LamportsError::iter() {
-            assert!(LamportsError::VARIANTS.contains(&variant));
+    fn test_instruction_error_variants_exhaustive() {
+        extern crate std;
+        for variant in InstructionError::iter() {
+            std::println!("{variant}");
+            assert!(InstructionError::VARIANTS.contains(&variant));
         }
     }
 }

--- a/instruction-error/src/lib.rs
+++ b/instruction-error/src/lib.rs
@@ -49,7 +49,9 @@ mod instruction_error_module {
         derive(serde_derive::Serialize, serde_derive::Deserialize)
     )]
     #[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
+    #[cfg_attr(test, derive(strum_macros::EnumIter))]
     #[derive(Debug, PartialEq, Eq, Clone)]
+    #[non_exhaustive]
     pub enum InstructionError {
         /// Deprecated! Use CustomError instead!
         /// The program instruction returned an error
@@ -227,6 +229,72 @@ mod instruction_error_module {
         BailOut,
         // Note: For any new error added here an equivalent ProgramError and its
         // conversions must also be added
+    }
+}
+
+impl InstructionError {
+    #[allow(deprecated)]
+    pub const VARIANTS: [Self; 54] = [
+        Self::GenericError,
+        Self::InvalidArgument,
+        Self::InvalidInstructionData,
+        Self::InvalidAccountData,
+        Self::AccountDataTooSmall,
+        Self::InsufficientFunds,
+        Self::IncorrectProgramId,
+        Self::MissingRequiredSignature,
+        Self::AccountAlreadyInitialized,
+        Self::UninitializedAccount,
+        Self::UnbalancedInstruction,
+        Self::ModifiedProgramId,
+        Self::ExternalAccountLamportSpend,
+        Self::ExternalAccountDataModified,
+        Self::ReadonlyLamportChange,
+        Self::ReadonlyDataModified,
+        Self::DuplicateAccountIndex,
+        Self::ExecutableModified,
+        Self::RentEpochModified,
+        Self::NotEnoughAccountKeys,
+        Self::AccountDataSizeChanged,
+        Self::AccountNotExecutable,
+        Self::AccountBorrowFailed,
+        Self::AccountBorrowOutstanding,
+        Self::DuplicateAccountOutOfSync,
+        Self::Custom(0),
+        Self::InvalidError,
+        Self::ExecutableDataModified,
+        Self::ExecutableLamportChange,
+        Self::ExecutableAccountNotRentExempt,
+        Self::UnsupportedProgramId,
+        Self::CallDepth,
+        Self::MissingAccount,
+        Self::ReentrancyNotAllowed,
+        Self::MaxSeedLengthExceeded,
+        Self::InvalidSeeds,
+        Self::InvalidRealloc,
+        Self::ComputationalBudgetExceeded,
+        Self::PrivilegeEscalation,
+        Self::ProgramEnvironmentSetupFailure,
+        Self::ProgramFailedToComplete,
+        Self::ProgramFailedToCompile,
+        Self::Immutable,
+        Self::IncorrectAuthority,
+        Self::BorshIoError,
+        Self::AccountNotRentExempt,
+        Self::InvalidAccountOwner,
+        Self::ArithmeticOverflow,
+        Self::UnsupportedSysvar,
+        Self::IllegalOwner,
+        Self::MaxAccountsDataAllocationsExceeded,
+        Self::MaxAccountsExceeded,
+        Self::MaxInstructionTraceLengthExceeded,
+        Self::BuiltinProgramsMustConsumeComputeUnits,
+    ];
+}
+
+impl core::default::Default for InstructionError {
+    fn default() -> Self {
+        Self::Custom(0)
     }
 }
 
@@ -423,11 +491,17 @@ where
 }
 
 #[derive(Debug)]
+#[cfg_attr(test, derive(strum_macros::EnumIter, PartialEq))]
+#[non_exhaustive]
 pub enum LamportsError {
     /// arithmetic underflowed
     ArithmeticUnderflow,
     /// arithmetic overflowed
     ArithmeticOverflow,
+}
+
+impl LamportsError {
+    pub const VARIANTS: [Self; 2] = [Self::ArithmeticUnderflow, Self::ArithmeticOverflow];
 }
 
 impl core::error::Error for LamportsError {}
@@ -490,6 +564,28 @@ impl TryFrom<InstructionError> for ProgramError {
             Self::Error::Immutable => Ok(Self::Immutable),
             Self::Error::IncorrectAuthority => Ok(Self::IncorrectAuthority),
             _ => Err(error),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::{InstructionError, LamportsError},
+        strum::IntoEnumIterator,
+    };
+
+    #[test]
+    fn test_instruction_error_variants_exhaustive() {
+        for variant in InstructionError::iter() {
+            assert!(InstructionError::VARIANTS.contains(&variant));
+        }
+    }
+
+    #[test]
+    fn test_lamports_error_variants_exhaustive() {
+        for variant in LamportsError::iter() {
+            assert!(LamportsError::VARIANTS.contains(&variant));
         }
     }
 }

--- a/instruction-error/src/lib.rs
+++ b/instruction-error/src/lib.rs
@@ -234,7 +234,7 @@ mod instruction_error_module {
 
 impl InstructionError {
     #[allow(deprecated)]
-    pub const VARIANTS: [Self; 54] = [
+    pub const VARIANTS: [Self; 55] = [
         Self::GenericError,
         Self::InvalidArgument,
         Self::InvalidInstructionData,
@@ -289,6 +289,7 @@ impl InstructionError {
         Self::MaxAccountsExceeded,
         Self::MaxInstructionTraceLengthExceeded,
         Self::BuiltinProgramsMustConsumeComputeUnits,
+        Self::BailOut,
     ];
 }
 
@@ -584,9 +585,7 @@ mod tests {
 
     #[test]
     fn test_instruction_error_variants_exhaustive() {
-        extern crate std;
         for variant in InstructionError::iter() {
-            std::println!("{variant}");
             assert!(InstructionError::VARIANTS.contains(&variant));
         }
     }

--- a/transaction-error/Cargo.toml
+++ b/transaction-error/Cargo.toml
@@ -38,6 +38,8 @@ wincode = { workspace = true, optional = true }
 # Self-dependency enabling `wincode` so the `frozen_abi` wincode digest test can
 # serialize `TransactionError` during unit tests.
 solana-transaction-error = { path = ".", features = ["wincode"] }
+strum = { workspace = true }
+strum_macros = { workspace = true }
 
 [lints]
 workspace = true

--- a/transaction-error/src/lib.rs
+++ b/transaction-error/src/lib.rs
@@ -165,7 +165,7 @@ pub enum TransactionError {
 }
 
 impl TransactionError {
-    pub const VARIANTS: [Self; 39] = [
+    pub const VARIANTS: [Self; 40] = [
         Self::AccountInUse,
         Self::AccountLoadedTwice,
         Self::AccountNotFound,
@@ -205,6 +205,7 @@ impl TransactionError {
         Self::UnbalancedTransaction,
         Self::ProgramCacheHitMaxLimit,
         Self::CommitCancelled,
+        Self::BailOut,
     ];
 }
 

--- a/transaction-error/src/lib.rs
+++ b/transaction-error/src/lib.rs
@@ -26,7 +26,9 @@ pub type TransactionResult<T> = Result<T, TransactionError>;
 )]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
+#[cfg_attr(test, derive(strum_macros::EnumIter))]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum TransactionError {
     /// An account is already being processed in another transaction in a way
     /// that does not support parallelism
@@ -162,6 +164,50 @@ pub enum TransactionError {
     BailOut,
 }
 
+impl TransactionError {
+    pub const VARIANTS: [Self; 39] = [
+        Self::AccountInUse,
+        Self::AccountLoadedTwice,
+        Self::AccountNotFound,
+        Self::ProgramAccountNotFound,
+        Self::InsufficientFundsForFee,
+        Self::InvalidAccountForFee,
+        Self::AlreadyProcessed,
+        Self::BlockhashNotFound,
+        Self::InstructionError(0, InstructionError::Custom(0)),
+        Self::CallChainTooDeep,
+        Self::MissingSignatureForFee,
+        Self::InvalidAccountIndex,
+        Self::SignatureFailure,
+        Self::InvalidProgramForExecution,
+        Self::SanitizeFailure,
+        Self::ClusterMaintenance,
+        Self::AccountBorrowOutstanding,
+        Self::WouldExceedMaxBlockCostLimit,
+        Self::UnsupportedVersion,
+        Self::InvalidWritableAccount,
+        Self::WouldExceedMaxAccountCostLimit,
+        Self::WouldExceedAccountDataBlockLimit,
+        Self::TooManyAccountLocks,
+        Self::AddressLookupTableNotFound,
+        Self::InvalidAddressLookupTableOwner,
+        Self::InvalidAddressLookupTableData,
+        Self::InvalidAddressLookupTableIndex,
+        Self::InvalidRentPayingAccount,
+        Self::WouldExceedMaxVoteCostLimit,
+        Self::WouldExceedAccountDataTotalLimit,
+        Self::DuplicateInstruction(0),
+        Self::InsufficientFundsForRent { account_index: 0 },
+        Self::MaxLoadedAccountsDataSizeExceeded,
+        Self::InvalidLoadedAccountsDataSizeLimit,
+        Self::ResanitizationNeeded,
+        Self::ProgramExecutionTemporarilyRestricted { account_index: 0 },
+        Self::UnbalancedTransaction,
+        Self::ProgramCacheHitMaxLimit,
+        Self::CommitCancelled,
+    ];
+}
+
 impl core::error::Error for TransactionError {}
 
 impl fmt::Display for TransactionError {
@@ -269,8 +315,11 @@ impl From<SanitizeMessageError> for TransactionError {
 
 #[cfg(not(target_os = "solana"))]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(test, derive(strum_macros::EnumIter, Default))]
+#[non_exhaustive]
 pub enum AddressLoaderError {
     /// Address loading from lookup tables is disabled
+    #[cfg_attr(test, default)]
     Disabled,
 
     /// Failed to load slot hashes sysvar
@@ -287,6 +336,18 @@ pub enum AddressLoaderError {
 
     /// Address lookup contains an invalid index
     InvalidLookupIndex,
+}
+
+#[cfg(not(target_os = "solana"))]
+impl AddressLoaderError {
+    pub const VARIANTS: [Self; 6] = [
+        Self::Disabled,
+        Self::SlotHashesSysvarNotFound,
+        Self::LookupTableAccountNotFound,
+        Self::InvalidAccountOwner,
+        Self::InvalidAccountData,
+        Self::InvalidLookupIndex,
+    ];
 }
 
 #[cfg(not(target_os = "solana"))]
@@ -328,11 +389,23 @@ impl From<AddressLoaderError> for TransactionError {
 
 #[cfg(not(target_os = "solana"))]
 #[derive(PartialEq, Debug, Eq, Clone)]
+#[cfg_attr(test, derive(strum_macros::EnumIter))]
+#[non_exhaustive]
 pub enum SanitizeMessageError {
     IndexOutOfBounds,
     ValueOutOfBounds,
     InvalidValue,
     AddressLoaderError(AddressLoaderError),
+}
+
+#[cfg(not(target_os = "solana"))]
+impl SanitizeMessageError {
+    pub const VARIANTS: [Self; 4] = [
+        Self::IndexOutOfBounds,
+        Self::ValueOutOfBounds,
+        Self::InvalidValue,
+        Self::AddressLoaderError(AddressLoaderError::Disabled),
+    ];
 }
 
 #[cfg(not(target_os = "solana"))]
@@ -437,3 +510,32 @@ impl TransportError {
 
 #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
 pub type TransportResult<T> = std::result::Result<T, TransportError>;
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::{AddressLoaderError, SanitizeMessageError, TransactionError},
+        strum::IntoEnumIterator,
+    };
+
+    #[test]
+    fn test_transaction_error_variants_exhaustive() {
+        for variant in TransactionError::iter() {
+            assert!(TransactionError::VARIANTS.contains(&variant));
+        }
+    }
+
+    #[test]
+    fn test_address_loader_error_variants_exhaustive() {
+        for variant in AddressLoaderError::iter() {
+            assert!(AddressLoaderError::VARIANTS.contains(&variant));
+        }
+    }
+
+    #[test]
+    fn test_sanitize_message_error_variants_exhaustive() {
+        for variant in SanitizeMessageError::iter() {
+            assert!(SanitizeMessageError::VARIANTS.contains(&variant));
+        }
+    }
+}


### PR DESCRIPTION
#### Problem

It has been historically difficult to add new variants to `InstructionError` and `TransactionError`, since new enum variants constitute a breaking change. We avoided marking the enums as non-exhaustive in the past for fear of breaking places in Agave that do require exhaustive matching.

#### Summary of changes

In the end, there are very few call-sites in Agave that require exhaustive matching, so let's do ourselves a favor, and mark the enums non-exhaustive.

To go with this, introduce a `VARIANTS` constant, so that places that do require exhaustive matching can add a test to make sure they never forget new variants.

NOTE: `TransportError` is excluded from the change. We can mark it non-exhaustive, but it wraps `std::io::Error`, which has no const constructors without nightly Rust. That means we wouldn't be able to create a const `VARIANTS` array. There's only one call-site in Agave that converts from `TransportError` to RPC client error, so this seems acceptable.