### PR TITLE
transaction: guard versioned tx verify against signature/key length mismatch

### DIFF
--- a/transaction/src/versioned/mod.rs
+++ b/transaction/src/versioned/mod.rs
@@ -318,9 +318,20 @@ impl VersionedTransaction {
 
     #[cfg(feature = "verify")]
     fn _verify_with_results(&self, message_bytes: &[u8]) -> Vec<bool> {
+        let num_required_signatures = self.message.header().num_required_signatures as usize;
+        let static_account_keys = self.message.static_account_keys();
+        if self.signatures.len() != num_required_signatures
+            || static_account_keys.len() < num_required_signatures
+        {
+            // Mismatched lengths mean this transaction was never sanitized: zipping
+            // signatures against static keys would silently truncate to the shorter
+            // side and pair signatures with the wrong keys instead of catching this.
+            return alloc::vec![false; self.signatures.len()];
+        }
+
         self.signatures
             .iter()
-            .zip(self.message.static_account_keys().iter())
+            .zip(static_account_keys.iter())
             .map(|(signature, pubkey)| signature.verify(pubkey.as_ref(), message_bytes))
             .collect()
     }
@@ -528,6 +539,32 @@ mod tests {
             Ok(tx) => assert_eq!(tx.verify_with_results(), vec![true; 2]),
             Err(err) => assert_eq!(Some(err), None),
         }
+    }
+
+    #[test]
+    fn test_verify_with_results_signature_key_length_mismatch() {
+        let keypair0 = Keypair::new();
+        let keypair1 = Keypair::new();
+
+        let message = VersionedMessage::Legacy(LegacyMessage::new(
+            &[Instruction::new_with_bytes(
+                Pubkey::new_unique(),
+                &[],
+                vec![AccountMeta::new_readonly(keypair1.pubkey(), true)],
+            )],
+            Some(&keypair0.pubkey()),
+        ));
+
+        let mut tx = VersionedTransaction::try_new(message, &[&keypair0, &keypair1]).unwrap();
+        // Directly construct a transaction with more signatures than static
+        // account keys, bypassing sanitize().
+        tx.signatures.push(Signature::default());
+
+        assert_eq!(tx.verify_with_results(), vec![false; 3]);
+        assert_eq!(
+            tx.verify_and_hash_message(),
+            Err(solana_transaction_error::TransactionError::SignatureFailure)
+        );
     }
 
     fn nonced_transfer_tx() -> (Pubkey, Pubkey, VersionedTransaction) {


### PR DESCRIPTION
## Summary

Fixes #908.

`VersionedTransaction::verify_and_hash_message` and `verify_with_results` (`transaction/src/versioned/mod.rs`) pair `signatures` with `static_account_keys()` via `zip` without first checking the lengths agree with `num_required_signatures`. A transaction constructed directly (bypassing `sanitize()`) with mismatched `signatures`/`static_account_keys()` lengths gets silently truncated by `zip` instead of failing verification — earlier signatures can end up verified against the wrong key positions instead of the mismatch being caught explicitly.

Note on #908's specific repro: a required signer resolved through an address lookup table can't actually occur — `Message::sanitize()` requires `num_required_signatures + num_readonly_unsigned_accounts <= static_account_keys.len()`, and `is_signer(i) = i < num_required_signatures`, so every signer is always a static key and lookup tables only ever supply non-signer accounts. `SanitizedVersionedTransaction` is unaffected for the same reason: `try_new` enforces `signatures.len() == num_required_signatures` via `sanitize_signatures()`, so the invariant always holds there. The real, narrower gap is that the *unsanitized* `VersionedTransaction` path trusts caller-supplied lengths.

## Fix

Add a length check in the shared `_verify_with_results` helper (used by both public methods) that returns explicit verification failure when `signatures.len() != num_required_signatures` or `static_account_keys().len() < num_required_signatures`, instead of relying on `zip`'s silent truncation.

## Test plan

- [x] Added `test_verify_with_results_signature_key_length_mismatch` covering a directly-constructed transaction with more signatures than static account keys.
- [x] `cargo test -p solana-transaction --lib versioned::`
- [x] `cargo build -p solana-transaction` and `--no-default-features` (no warnings)
- [x] `cargo clippy -p solana-transaction --tests`