### PR TITLE
system-interface: Specify nonce init must happen with account creation

### DIFF
--- a/system-interface/src/instruction.rs
+++ b/system-interface/src/instruction.rs
@@ -180,7 +180,12 @@ pub enum SystemInstruction {
     /// instruction on the account
     ///
     /// No signatures are required to execute this instruction, enabling derived
-    /// nonce account addresses
+    /// nonce account addresses.
+    ///
+    /// This instruction MUST be included within the same Transaction as the
+    /// system program's `CreateAccount` instruction that creates the account
+    /// being initialized. Otherwise another party can acquire ownership of the
+    /// uninitialized account.
     InitializeNonceAccount(Address),
 
     /// Change the entity authorized to execute nonce instructions on the account


### PR DESCRIPTION
#### Problem

The initialize nonce instruction is meant to be bundled in the same transaction that creates the account, but it's not specified in the interface, as it is in other programs, ie:
https://github.com/solana-program/token/blob/eb074cf0874d3037df77b6e6b7d1f286193096b8/interface/src/instruction.rs#L27-L31

#### Summary of changes

Call out that creation and initialization must happen in the same transaction.