### PR TITLE
instruction!: Don't re-export `InstructionError`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3763,7 +3763,6 @@ dependencies = [
  "serde_derive",
  "solana-define-syscall",
  "solana-instruction",
- "solana-instruction-error",
  "solana-pubkey",
  "wincode",
 ]
@@ -3876,6 +3875,7 @@ dependencies = [
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-instruction",
+ "solana-instruction-error",
  "solana-loader-v3-interface",
  "solana-pubkey",
  "solana-sdk-ids",
@@ -4648,6 +4648,7 @@ dependencies = [
  "solana-get-sysvar",
  "solana-hash",
  "solana-instruction",
+ "solana-instruction-error",
  "solana-last-restart-slot",
  "solana-msg",
  "solana-program-entrypoint",

--- a/instruction/Cargo.toml
+++ b/instruction/Cargo.toml
@@ -31,7 +31,6 @@ bincode = { workspace = true, optional = true }
 borsh = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-solana-instruction-error = { workspace = true, features = ["num-traits"] }
 solana-pubkey = { workspace = true, default-features = false }
 wincode = { workspace = true, features = ["alloc"], optional = true }
 

--- a/instruction/src/lib.rs
+++ b/instruction/src/lib.rs
@@ -20,7 +20,7 @@ pub mod account_meta;
 #[cfg(any(feature = "syscalls", target_os = "solana"))]
 pub mod syscalls;
 
-pub use {account_meta::AccountMeta, solana_instruction_error as error};
+pub use account_meta::AccountMeta;
 use {alloc::vec::Vec, solana_pubkey::Pubkey};
 
 /// A directive for a single invocation of a Solana program.

--- a/loader-v3-interface/Cargo.toml
+++ b/loader-v3-interface/Cargo.toml
@@ -40,6 +40,7 @@ serde_derive = { workspace = true, optional = true }
 solana-frozen-abi = { workspace = true, features = ["frozen-abi"], optional = true }
 solana-frozen-abi-macro = { workspace = true, features = ["frozen-abi"], optional = true }
 solana-instruction = { workspace = true, features = ["std"] }
+solana-instruction-error = { workspace = true }
 solana-pubkey = { workspace = true, features = ["curve25519"] }
 solana-sdk-ids = { workspace = true }
 solana-serde = { workspace = true, optional = true }

--- a/loader-v3-interface/src/instruction.rs
+++ b/loader-v3-interface/src/instruction.rs
@@ -4,7 +4,8 @@
 use {
     crate::{get_program_data_address, state::UpgradeableLoaderState},
     core::mem::MaybeUninit,
-    solana_instruction::{error::InstructionError, AccountMeta, Instruction},
+    solana_instruction::{AccountMeta, Instruction},
+    solana_instruction_error::InstructionError,
     solana_pubkey::Pubkey,
     solana_sdk_ids::{bpf_loader_upgradeable::id, sysvar},
     solana_system_interface::instruction as system_instruction,

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -1,6 +1,8 @@
-pub use solana_instruction::{
-    error::InstructionError, AccountMeta, Instruction, ProcessedSiblingInstruction,
-    TRANSACTION_LEVEL_STACK_HEIGHT,
+pub use {
+    solana_instruction::{
+        AccountMeta, Instruction, ProcessedSiblingInstruction, TRANSACTION_LEVEL_STACK_HEIGHT,
+    },
+    solana_instruction_error::InstructionError,
 };
 
 /// Returns a sibling instruction from the processed sibling instruction list.

--- a/sysvar/Cargo.toml
+++ b/sysvar/Cargo.toml
@@ -81,6 +81,7 @@ wincode = { workspace = true, optional = true }
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 base64 = { workspace = true }
 solana-instruction = { workspace = true, features = ["std"] }
+solana-instruction-error = { workspace = true }
 solana-program-memory = { workspace = true }
 
 [target.'cfg(target_os = "solana")'.dependencies]

--- a/sysvar/src/program_stubs.rs
+++ b/sysvar/src/program_stubs.rs
@@ -5,7 +5,8 @@
 use {
     base64::{prelude::BASE64_STANDARD, Engine},
     solana_account_info::AccountInfo,
-    solana_instruction::{error::UNSUPPORTED_SYSVAR, Instruction},
+    solana_instruction::Instruction,
+    solana_instruction_error::UNSUPPORTED_SYSVAR,
     solana_program_error::ProgramResult,
     solana_program_memory::stubs,
     solana_pubkey::Pubkey,

--- a/vote-interface/src/state/vote_state_v3.rs
+++ b/vote-interface/src/state/vote_state_v3.rs
@@ -231,7 +231,6 @@ mod tests {
         bincode::serialized_size,
         core::mem::MaybeUninit,
         rand::Rng,
-        solana_instruction::error::InstructionError,
     };
 
     #[test]

--- a/vote-interface/src/state/vote_state_v4.rs
+++ b/vote-interface/src/state/vote_state_v4.rs
@@ -9,7 +9,7 @@ use serde_with::serde_as;
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::{frozen_abi, AbiExample, StableAbi, StableAbiSample};
 #[cfg(any(target_os = "solana", feature = "bincode"))]
-use solana_instruction::error::InstructionError;
+use solana_instruction_error::InstructionError;
 use {
     super::{BlockTimestamp, LandedVote, VoteInit, VoteInitV2, BLS_PUBLIC_KEY_COMPRESSED_SIZE},
     crate::authorized_voters::AuthorizedVoters,
@@ -272,7 +272,6 @@ mod tests {
         bincode::serialized_size,
         core::mem::MaybeUninit,
         rand::Rng,
-        solana_instruction::error::InstructionError,
         test_case::test_matrix,
     };
 

--- a/vote-interface/src/state/vote_state_versions.rs
+++ b/vote-interface/src/state/vote_state_versions.rs
@@ -217,7 +217,6 @@ mod tests {
         crate::state::{VoteInit, BLS_PUBLIC_KEY_COMPRESSED_SIZE, DEFAULT_PRIOR_VOTERS_OFFSET},
         rand::Rng,
         solana_clock::Clock,
-        solana_instruction::error::InstructionError,
     };
 
     #[test]


### PR DESCRIPTION
#### Problem

`solana-instruction` currently re-exports `solana-instruction-error`, but `solana-instruction` doesn't use anything from `solana-instruction-error`.

#### Summary of changes

Remove the re-export, fix any callsites as needed.