### PR TITLE
sanitized: deprecate unnecessary functions

### DIFF
--- a/message/src/sanitized.rs
+++ b/message/src/sanitized.rs
@@ -224,6 +224,10 @@ impl SanitizedMessage {
 
     /// Returns true if the account at the specified index is an input to some
     /// program instruction in this message.
+    #[deprecated(
+        since = "4.6.0",
+        note = "Use `solana_svm_transaction::svm_message::SVMStaticMessage::is_instruction_account()`"
+    )]
     pub fn is_instruction_account(&self, key_index: usize) -> bool {
         if let Ok(key_index) = u8::try_from(key_index) {
             self.instructions()
@@ -316,6 +320,10 @@ impl SanitizedMessage {
     }
 
     /// Get a list of signers for the instruction at the given index
+    #[deprecated(
+        since = "4.6.0",
+        note = "Use `solana_svm_transaction::svm_message::SVMStaticMessage::get_ix_signers()`"
+    )]
     pub fn get_ix_signers(&self, ix_index: usize) -> impl Iterator<Item = &Address> {
         self.instructions()
             .get(ix_index)
@@ -331,6 +339,10 @@ impl SanitizedMessage {
     }
 
     /// If the message uses a durable nonce, return the pubkey of the nonce account
+    #[deprecated(
+        since = "4.6.0",
+        note = "Use `solana_svm_transaction::svm_message::SVMMessage::get_durable_nonce()`"
+    )]
     pub fn get_durable_nonce(&self) -> Option<&Address> {
         self.instructions()
             .get(NONCED_TX_MARKER_IX_INDEX as usize)
@@ -526,6 +538,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_get_ix_signers() {
         let signer0 = Address::new_unique();
         let signer1 = Address::new_unique();

--- a/svm-transaction/src/tests.rs
+++ b/svm-transaction/src/tests.rs
@@ -16,6 +16,7 @@ use {
 };
 
 #[test]
+#[allow(deprecated)]
 fn test_get_durable_nonce() {
     fn create_message_for_test(
         num_signers: u8,

--- a/transaction/src/sanitized.rs
+++ b/transaction/src/sanitized.rs
@@ -263,7 +263,12 @@ impl SanitizedTransaction {
 
     /// If the transaction uses a durable nonce, return the pubkey of the nonce account
     #[cfg(feature = "wincode")]
+    #[deprecated(
+        since = "4.4.0",
+        note = "Use `solana_svm_transaction::svm_message::SVMMessage::get_durable_nonce()`"
+    )]
     pub fn get_durable_nonce(&self) -> Option<&Address> {
+        #[allow(deprecated)]
         self.message.get_durable_nonce()
     }
 


### PR DESCRIPTION
unless there is a reason to keep these im not aware of, i think we should remove them. while implementing my `get_durable_nonce()` replacement on `SVMStaticMessage`, i discovered there was another version of it, which behaves the same but is written somewhat differently

`get_durable_nonce()` is only used in rpc and the other two dont appear to be used at all