### PR TITLE
svm-transaction: add get_durable_nonce_static()

### DIFF
--- a/svm-transaction/src/svm_message.rs
+++ b/svm-transaction/src/svm_message.rs
@@ -137,6 +137,16 @@ pub trait SVMStaticMessage: Debug {
                     .filter_map(|signer_index| self.static_account_keys().get(signer_index))
             })
     }
+
+    /// If the message uses a durable nonce, return the pubkey of the nonce account.
+    /// This is identical in behavior to `SVMMessage::get_durable_nonce()`, except
+    /// we cannot fully check whether the nonce account is writable based on program ID
+    /// demotion and reserved key demotion. When `ban_nonce_as_program_id` is active,
+    /// program ID demotion no longer can apply. Reserved keys are never valid nonce
+    /// accounts, so they will always be rejected by nonce account validation.
+    fn get_durable_nonce_static(&self, ban_nonce_as_program_id: bool) -> Option<&Pubkey> {
+        get_durable_nonce_internal(self, ban_nonce_as_program_id).map(|(key, _index)| key)
+    }
 }
 
 pub trait SVMMessage: SVMStaticMessage {
@@ -148,35 +158,9 @@ pub trait SVMMessage: SVMStaticMessage {
 
     /// If the message uses a durable nonce, return the pubkey of the nonce account
     fn get_durable_nonce(&self) -> Option<&Pubkey> {
-        let account_keys = self.account_keys();
-        self.instructions_iter()
-            .nth(usize::from(NONCED_TX_MARKER_IX_INDEX))
-            .filter(
-                |ix| match account_keys.get(usize::from(ix.program_id_index)) {
-                    Some(program_id) => system_program::check_id(program_id),
-                    _ => false,
-                },
-            )
-            .filter(|ix| {
-                /// Serialized value of [`SystemInstruction::AdvanceNonceAccount`].
-                const SERIALIZED_ADVANCE_NONCE_ACCOUNT: [u8; 4] = 4u32.to_le_bytes();
-                const SERIALIZED_SIZE: usize = SERIALIZED_ADVANCE_NONCE_ACCOUNT.len();
-
-                ix.data
-                    .get(..SERIALIZED_SIZE)
-                    .map(|data| data == SERIALIZED_ADVANCE_NONCE_ACCOUNT)
-                    .unwrap_or(false)
-            })
-            .and_then(|ix| {
-                ix.accounts.first().and_then(|idx| {
-                    let index = usize::from(*idx);
-                    if index >= self.static_account_keys().len() || !self.is_writable(index) {
-                        None
-                    } else {
-                        account_keys.get(index)
-                    }
-                })
-            })
+        get_durable_nonce_internal(self, false)
+            .filter(|(_key, index)| self.is_writable(*index))
+            .map(|(key, _index)| key)
     }
 }
 
@@ -188,4 +172,45 @@ fn default_precompile_signature_count<'a>(
         .filter(|(program_id, _)| *program_id == precompile)
         .map(|(_, ix)| u64::from(ix.data.first().copied().unwrap_or(0)))
         .sum()
+}
+
+// after SIMD-0602 activates, we may:
+// * delete SVMMessage::get_durable_nonce()
+// * rename SVMStaticMessage::get_durable_nonce_static() to get_durable_nonce()
+// * delete this helper and move its body into SVMStaticMessage
+fn get_durable_nonce_internal<T: SVMStaticMessage + ?Sized>(
+    msg: &T,
+    ban_nonce_as_program_id: bool,
+) -> Option<(&Pubkey, usize)> {
+    let account_keys = msg.static_account_keys();
+    msg.instructions_iter()
+        .nth(usize::from(NONCED_TX_MARKER_IX_INDEX))
+        .filter(
+            |ix| match account_keys.get(usize::from(ix.program_id_index)) {
+                Some(program_id) => system_program::check_id(program_id),
+                _ => false,
+            },
+        )
+        .filter(|ix| {
+            /// Serialized value of [`SystemInstruction::AdvanceNonceAccount`].
+            const SERIALIZED_ADVANCE_NONCE_ACCOUNT: [u8; 4] = 4u32.to_le_bytes();
+            const SERIALIZED_SIZE: usize = SERIALIZED_ADVANCE_NONCE_ACCOUNT.len();
+
+            ix.data
+                .get(..SERIALIZED_SIZE)
+                .map(|data| data == SERIALIZED_ADVANCE_NONCE_ACCOUNT)
+                .unwrap_or(false)
+        })
+        .and_then(|ix| {
+            ix.accounts.first().and_then(|idx| {
+                let index = usize::from(*idx);
+                if !msg.is_requested_writable(index)
+                    || (ban_nonce_as_program_id && msg.is_invoked(index))
+                {
+                    None
+                } else {
+                    account_keys.get(index).map(|key| (key, index))
+                }
+            })
+        })
 }

--- a/svm-transaction/src/tests.rs
+++ b/svm-transaction/src/tests.rs
@@ -10,7 +10,7 @@ use {
         VersionedMessage,
     },
     solana_pubkey::Pubkey,
-    solana_sdk_ids::system_program,
+    solana_sdk_ids::{bpf_loader_upgradeable, system_program},
     solana_system_interface::instruction::SystemInstruction,
     std::collections::HashSet,
 };
@@ -73,6 +73,7 @@ fn test_get_durable_nonce() {
     {
         let message = create_message_for_test(1, 1, vec![Pubkey::new_unique()], vec![], None);
         assert!(SVMMessage::get_durable_nonce(&message).is_none());
+        assert!(SVMStaticMessage::get_durable_nonce_static(&message, true).is_none());
     }
 
     // system program id instruction - invalid
@@ -85,6 +86,7 @@ fn test_get_durable_nonce() {
             None,
         );
         assert!(SVMMessage::get_durable_nonce(&message).is_none());
+        assert!(SVMStaticMessage::get_durable_nonce_static(&message, true).is_none());
     }
 
     // system program id instruction - not nonce
@@ -101,6 +103,7 @@ fn test_get_durable_nonce() {
             None,
         );
         assert!(SVMMessage::get_durable_nonce(&message).is_none());
+        assert!(SVMStaticMessage::get_durable_nonce_static(&message, true).is_none());
     }
 
     // system program id - nonce instruction (no accounts)
@@ -117,6 +120,7 @@ fn test_get_durable_nonce() {
             None,
         );
         assert!(SVMMessage::get_durable_nonce(&message).is_none());
+        assert!(SVMStaticMessage::get_durable_nonce_static(&message, true).is_none());
     }
 
     // system program id - nonce instruction (non-fee-payer, non-writable)
@@ -135,6 +139,7 @@ fn test_get_durable_nonce() {
             None,
         );
         assert!(SVMMessage::get_durable_nonce(&message).is_none());
+        assert!(SVMStaticMessage::get_durable_nonce_static(&message, true).is_none());
     }
 
     // system program id - nonce instruction fee-payer
@@ -152,6 +157,10 @@ fn test_get_durable_nonce() {
             None,
         );
         assert_eq!(SVMMessage::get_durable_nonce(&message), Some(&payer_nonce));
+        assert_eq!(
+            SVMStaticMessage::get_durable_nonce_static(&message, true),
+            Some(&payer_nonce)
+        );
     }
 
     // system program id - nonce instruction w/ trailing bytes fee-payer
@@ -171,6 +180,10 @@ fn test_get_durable_nonce() {
             None,
         );
         assert_eq!(SVMMessage::get_durable_nonce(&message), Some(&payer_nonce));
+        assert_eq!(
+            SVMStaticMessage::get_durable_nonce_static(&message, true),
+            Some(&payer_nonce)
+        );
     }
 
     // system program id - nonce instruction (non-fee-payer)
@@ -189,6 +202,10 @@ fn test_get_durable_nonce() {
             None,
         );
         assert_eq!(SVMMessage::get_durable_nonce(&message), Some(&nonce));
+        assert_eq!(
+            SVMStaticMessage::get_durable_nonce_static(&message, true),
+            Some(&nonce)
+        );
     }
 
     // system program id - nonce instruction (non-fee-payer, multiple accounts)
@@ -208,6 +225,10 @@ fn test_get_durable_nonce() {
             None,
         );
         assert_eq!(SVMMessage::get_durable_nonce(&message), Some(&nonce));
+        assert_eq!(
+            SVMStaticMessage::get_durable_nonce_static(&message, true),
+            Some(&nonce)
+        );
     }
 
     // system program id - nonce instruction (non-fee-payer, loaded account)
@@ -229,6 +250,59 @@ fn test_get_durable_nonce() {
             }),
         );
         assert_eq!(SVMMessage::get_durable_nonce(&message), None);
+        assert_eq!(
+            SVMStaticMessage::get_durable_nonce_static(&message, true),
+            None
+        );
+    }
+
+    // system program id - nonce instruction (nonce is program id, write-demoted)
+    {
+        let payer = Pubkey::new_unique();
+        let nonce = Pubkey::new_unique();
+        let message = create_message_for_test(
+            1,
+            2,
+            vec![payer, nonce, system_program::id()],
+            vec![
+                CompiledInstruction::new(2, &SystemInstruction::AdvanceNonceAccount, vec![1]),
+                CompiledInstruction::new_from_raw_parts(1, vec![], vec![]),
+            ],
+            None,
+        );
+        assert!(SVMMessage::get_durable_nonce(&message).is_none());
+        assert!(SVMStaticMessage::get_durable_nonce_static(&message, true).is_none());
+        assert_eq!(
+            SVMStaticMessage::get_durable_nonce_static(&message, false),
+            Some(&nonce)
+        );
+    }
+
+    // system program id - nonce instruction (nonce is program id, upgradeable loader present)
+    {
+        let payer = Pubkey::new_unique();
+        let nonce = Pubkey::new_unique();
+        let message = create_message_for_test(
+            1,
+            2,
+            vec![
+                payer,
+                nonce,
+                system_program::id(),
+                bpf_loader_upgradeable::id(),
+            ],
+            vec![
+                CompiledInstruction::new(2, &SystemInstruction::AdvanceNonceAccount, vec![1]),
+                CompiledInstruction::new_from_raw_parts(1, vec![], vec![]),
+            ],
+            None,
+        );
+        assert_eq!(SVMMessage::get_durable_nonce(&message), Some(&nonce));
+        assert!(SVMStaticMessage::get_durable_nonce_static(&message, true).is_none());
+        assert_eq!(
+            SVMStaticMessage::get_durable_nonce_static(&message, false),
+            Some(&nonce)
+        );
     }
 }
 


### PR DESCRIPTION
add a durable nonce function to SVMStaticMessage that applies the [SIMD-0602](https://github.com/solana-foundation/solana-improvement-documents/pull/602) rule to exclude program ids, to be used under feature gate in agave. we will delete the SVMMessage version and rename the new one after 602 goes live. pleasingly, since SVMMessage is a subtype of SVMStaticMessage, that change would be non-breaking

my plan in agave is:
* use `get_durable_nonce_static()` with `ban_nonce_as_program_id` as `true` without a feature gate for all the helpers that do strict nonce checks ie that are not in consensus, most notably the ingress precheck
* use `get_durable_nonce_static()` with `ban_nonce_as_program_id` as `false` (or, when SIMD-0602 moves forward, with the feature gate) in `check_transactions_before_execution()`. move the `is_writable()` check into svm

this allows relaxing `check_transactions()` and all its wrappers to `StaticTransactionWithMeta`, unblocking further development on ALT relaxation without waiting for SIMD-0602, which only matters when we actually _do_ SIMD-0192

most of the upcoming work is refactoring the banking/runtime/svm/runtime flow to tolerate unresolved transactions; we only need SIMD-0602 when it comes time to introduce fee-only ALT resolution failures