### PR TITLE
account-info: Add comment to `assign`

### DIFF
--- a/account-info/src/lib.rs
+++ b/account-info/src/lib.rs
@@ -187,6 +187,13 @@ impl<'a> AccountInfo<'a> {
         Ok(())
     }
 
+    /// Changes the owner of the account.
+    ///
+    /// # Important
+    ///
+    /// The caller must ensure that there are no active references to the `owner` when
+    /// calling this method. This is because the `owner` is a shared read-only reference,
+    /// and changing it while there are active references can lead to undefined behavior.
     #[allow(invalid_reference_casting)]
     pub fn assign(&self, new_owner: &Address) {
         // Set the non-mut owner field


### PR DESCRIPTION
### Problem

The `assign` method currently unsafely writes to `self.owner` through a read-only shared reference. When the method is used with other active references, the compiler might generate arbitrarily incorrect code (UB).

### Solution

Add comments to highlight the potential footgun when using this method.