### PR TITLE
account: export wincode config publicly

### DIFF
--- a/account/src/lib.rs
+++ b/account/src/lib.rs
@@ -15,11 +15,6 @@ mod serde;
 #[cfg(any(feature = "bincode", feature = "wincode"))]
 pub mod state_traits;
 
-// wincode config used by the `state_traits::wincode` trait. The wire format matches
-// bincode byte-for-byte; the only deliberate difference is raising the preallocation
-// guard to the max account data length so valid accounts are never rejected. This gates
-// only the prealloc check, not the encoded bytes.
-//
 // Mirrors `solana_system_interface::MAX_PERMITTED_DATA_LENGTH` (kept in sync by the
 // assertion below) so `solana-system-interface` stays a dev-only dependency.
 #[cfg(feature = "wincode")]
@@ -27,10 +22,22 @@ const WINCODE_PREALLOC_LIMIT: usize = 10 * 1024 * 1024;
 #[cfg(all(test, feature = "wincode"))]
 const _: () =
     assert!(WINCODE_PREALLOC_LIMIT as u64 == solana_system_interface::MAX_PERMITTED_DATA_LENGTH);
+
+/// Wincode configuration used to en/decode account state, see [`WINCODE_CONFIG`].
+///
+/// Exported so downstream generic helpers can spell out the `wincode::Schema*` bounds
+/// account state must satisfy, e.g.
+/// `T: SchemaWrite<WincodeConfig, Src = T> + for<'de> SchemaRead<'de, WincodeConfig, Dst = T>`.
 #[cfg(feature = "wincode")]
-pub(crate) type WincodeConfig = wincode::config::Configuration<true, WINCODE_PREALLOC_LIMIT>;
+pub type WincodeConfig = wincode::config::Configuration<true, WINCODE_PREALLOC_LIMIT>;
+
+/// The configuration used by [`state_traits::StateMutWincode`].
+///
+/// The wire format matches bincode byte-for-byte; the only deliberate difference is
+/// raising the preallocation guard to the max account data length so valid accounts are
+/// never rejected. This gates only the prealloc check, not the encoded bytes.
 #[cfg(feature = "wincode")]
-pub(crate) const WINCODE_CONFIG: WincodeConfig = wincode::config::Configuration::default()
+pub const WINCODE_CONFIG: WincodeConfig = wincode::config::Configuration::default()
     .with_preallocation_size_limit::<WINCODE_PREALLOC_LIMIT>(
 );
 


### PR DESCRIPTION
#### Problem
`WincodeConfig` and `WINCODE_CONFIG` are crate-private, so downstream users cannot write generic helpers over types implementing wincode's `Schema` traits for account state.

#### Summary of Changes
* make `WincodeConfig` and `WINCODE_CONFIG` pub
* move the config rationale into doc comments on the items themselves
