### PR TITLE
error types: Mark errors as non-exhaustive

### DIFF
--- a/message/src/compiled_keys.rs
+++ b/message/src/compiled_keys.rs
@@ -19,6 +19,7 @@ pub(crate) struct CompiledKeys {
 }
 
 #[derive(PartialEq, Debug, Eq, Clone)]
+#[non_exhaustive]
 pub enum CompileError {
     AccountIndexOverflow,
     AddressTableLookupIndexOverflow,

--- a/message/src/versions/v1/error.rs
+++ b/message/src/versions/v1/error.rs
@@ -2,6 +2,7 @@ use solana_sanitize::SanitizeError;
 
 /// Errors that can occur when working with V1 messages.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum MessageError {
     /// Input buffer is too small during deserialization.
     BufferTooSmall,

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -27,6 +27,7 @@ pub mod null_signer;
 pub mod signers;
 
 #[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum PresignerError {
     VerificationFailure,
 }
@@ -42,6 +43,7 @@ impl fmt::Display for PresignerError {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum SignerError {
     KeypairPubkeyMismatch,
     NotEnoughSigners,

--- a/vote-interface/src/error.rs
+++ b/vote-interface/src/error.rs
@@ -7,6 +7,7 @@ use {
 
 /// Reasons the vote might have had an error
 #[derive(Debug, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[non_exhaustive]
 pub enum VoteError {
     VoteTooOld,
     SlotsMismatch,


### PR DESCRIPTION
#### Problem

We've marked error types in instruction-error and transaction-error as non-exhaustive, which will cause many breaking changes in the rest of the SDK.

We still have many error types that could be non-exhaustive, but aren't.

#### Summary of changes

Make more errors non-exhaustive. Looking through Agave, none of these are being matched on, so it should be an unnoticeable change downstream.