### PR TITLE
deps: Bump num-derive for minimal-versions check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,7 +198,7 @@ light-poseidon = "0.4.0"
 log = "0.4.25"
 memmap2 = "0.5.10"
 num-bigint = "0.4.6"
-num-derive = "0.4"
+num-derive = "0.4.2"
 num-traits = { version = "0.2.18", default-features = false }
 num_enum = "0.7.3"
 openssl = "0.10.72"

--- a/scripts/check-minimal-versions.sh
+++ b/scripts/check-minimal-versions.sh
@@ -5,4 +5,4 @@ here="$(dirname "$0")"
 src_root="$(readlink -f "${here}/..")"
 cd "${src_root}"
 
-./cargo nightly minimal-versions check --direct
+RUSTFLAGS='-D warnings' ./cargo nightly minimal-versions check --direct


### PR DESCRIPTION
#### Problem

The minimal versions check currently has some warnings around the num-derive crate.

#### Summary of changes

Bump the num-derive dependency to the minimum version that doesn't trigger warnings, and deny warnings during the minimal-versions check.