### PR TITLE
vote-interface: Make solana-rent a dev dependency

### DIFF
--- a/vote-interface/Cargo.toml
+++ b/vote-interface/Cargo.toml
@@ -76,7 +76,6 @@ solana-hash = { workspace = true, features = ["decode"] }
 solana-instruction = { workspace = true, features = ["std"] }
 solana-instruction-error = { workspace = true, features = ["num-traits"] }
 solana-pubkey = { workspace = true }
-solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-serde-varint = { workspace = true, optional = true }
 solana-serialize-utils = { workspace = true, optional = true, features = ["std"] }
@@ -91,6 +90,7 @@ solana-serialize-utils = { workspace = true, features = ["std"] }
 [dev-dependencies]
 solana-epoch-schedule = { workspace = true }
 solana-pubkey = { workspace = true, features = ["dev-context-only-utils"] }
+solana-rent = { workspace = true }
 solana-vote-interface = { path = ".", features = ["dev-context-only-utils", "wincode"] }
 test-case = { workspace = true }
 


### PR DESCRIPTION
#### Problem

While removing a lot of dependencies, I missed that solana-rent is no longer directly required by vote-interface.

#### Summary of changes

Move solana-rent to a dev dependency.