### PR TITLE
rent!: Remove deprecated fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4187,6 +4187,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_derive",
+ "solana-account",
  "solana-clock",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",

--- a/rent/Cargo.toml
+++ b/rent/Cargo.toml
@@ -33,8 +33,9 @@ wincode = { workspace = true, optional = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
+solana-account = { workspace = true }
 solana-clock = { workspace = true }
-solana-rent = { path = ".", features = ["wincode"] }
+solana-rent = { path = ".", features = ["sysvar", "wincode"] }
 static_assertions = { workspace = true }
 
 [lints]

--- a/rent/Cargo.toml
+++ b/rent/Cargo.toml
@@ -33,7 +33,7 @@ wincode = { workspace = true, optional = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
-solana-account = { workspace = true }
+solana-account = { path = "../account" }
 solana-clock = { workspace = true }
 solana-rent = { path = ".", features = ["sysvar", "wincode"] }
 static_assertions = { workspace = true }

--- a/rent/src/lib.rs
+++ b/rent/src/lib.rs
@@ -335,12 +335,12 @@ mod tests {
         #[test]
         fn test_minimum_balance(bytes in 0usize..=MAX_PERMITTED_DATA_LENGTH as usize) {
             let default_rent = Rent::default();
-            #[allow(deprecated)]
-            let previous_rent = Rent {
-                lamports_per_byte: DEFAULT_LAMPORTS_PER_BYTE / 2,
-            };
             let default_calc = default_rent.minimum_balance(bytes);
-            assert_eq!(default_calc, previous_rent.minimum_balance(bytes));
+
+            // check that the calculation gives the same result using floats
+            let float_calc = (((ACCOUNT_STORAGE_OVERHEAD + bytes as u64) * GENESIS_LAMPORTS_PER_BYTE_YEAR) as f64
+                * f64::from_le_bytes(GENESIS_EXEMPTION_THRESHOLD)) as u64;
+            assert_eq!(default_calc, float_calc);
         }
     }
 

--- a/rent/src/lib.rs
+++ b/rent/src/lib.rs
@@ -12,6 +12,8 @@ extern crate std;
 #[cfg(feature = "sysvar")]
 pub mod sysvar;
 
+#[cfg(feature = "serde")]
+use serde::ser::SerializeStruct;
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::{AbiExample, StableAbi, StableAbiSample};
 use solana_sdk_macro::CloneZeroed;
@@ -25,10 +27,6 @@ use wincode::{config::ConfigCore, io::Writer, SchemaWrite, WriteResult};
 /// account is still `17` bytes, which is the size of the `Rent` sysvar account.
 #[repr(C)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Deserialize, serde_derive::Serialize)
-)]
 #[cfg_attr(feature = "wincode", derive(wincode::SchemaRead))]
 #[derive(PartialEq, CloneZeroed, Debug)]
 pub struct Rent {
@@ -62,6 +60,17 @@ const MAX_LAMPORTS_PER_BYTE: u64 = 1_759_197_129_867;
 /// - $0.01 per megabyte day
 /// - $7.30 per megabyte
 pub const DEFAULT_LAMPORTS_PER_BYTE: u64 = 6_960;
+
+/// The `f64::to_le_bytes` representation of the SIMD-0194 exemption threshold.
+///
+/// This value is equivalent to `1.0f64`. It is only used to check whether
+/// the exemption threshold is the deprecated value to avoid performing
+/// floating-point operations on-chain.
+#[cfg(any(feature = "serde", feature = "wincode"))]
+const SIMD0194_EXEMPTION_THRESHOLD: [u8; 8] = [0, 0, 0, 0, 0, 0, 240, 63];
+
+#[cfg(any(feature = "serde", feature = "wincode"))]
+const DEFAULT_BURN_PERCENT: u8 = 50;
 
 /// Account storage overhead for calculation of base rent.
 ///
@@ -177,6 +186,31 @@ impl Rent {
     }
 }
 
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Rent {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let lamports_per_byte = u64::deserialize(deserializer)?;
+        Ok(Self { lamports_per_byte })
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Rent {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("Rent", 3)?;
+        state.serialize_field("lamports_per_byte", &self.lamports_per_byte)?;
+        state.serialize_field("exemption_threshold", &SIMD0194_EXEMPTION_THRESHOLD)?;
+        state.serialize_field("burn_percent", &DEFAULT_BURN_PERCENT)?;
+        state.end()
+    }
+}
+
 #[cfg(feature = "wincode")]
 unsafe impl<C: ConfigCore> SchemaWrite<C> for Rent {
     type Src = Self;
@@ -188,10 +222,12 @@ unsafe impl<C: ConfigCore> SchemaWrite<C> for Rent {
     }
 
     fn write(mut writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
-        // SAFETY: `size_of::<Rent>() < SIZE` always holds, so we can safely write
-        // `size_of::<Rent>()` bytes.
+        // SAFETY: `SIZE` is the serialized size of the `Rent` sysvar account,
+        // which is 17 bytes.
         let mut writer = unsafe { writer.as_trusted_for(SIZE) }?;
         writer.write(&src.lamports_per_byte.to_le_bytes())?;
+        writer.write(&SIMD0194_EXEMPTION_THRESHOLD)?;
+        writer.write(&DEFAULT_BURN_PERCENT.to_le_bytes())?;
         writer.finish()?;
 
         Ok(())

--- a/rent/src/lib.rs
+++ b/rent/src/lib.rs
@@ -28,18 +28,15 @@ use solana_sdk_macro::CloneZeroed;
 pub struct Rent {
     /// Rental rate in lamports/byte.
     pub lamports_per_byte: u64,
-
-    /// Formerly, the amount of time (in years) a balance must include rent for
-    /// the account to be rent exempt. Now it's just empty space.
-    #[deprecated(since = "4.1.0", note = "Use `Rent::minimum_balance()` directly")]
-    pub exemption_threshold: [u8; 8],
-
-    /// Formerly, the percentage of collected rent that is burned.
-    #[deprecated(since = "4.1.0", note = "Rent no longer exists")]
-    pub burn_percent: u8,
 }
 
 /// Serialized size of the `Rent` sysvar account.
+///
+/// Note that this size represents the serialized size of the `Rent` sysvar,
+/// which is 17 bytes. This includes:
+///  - 8 bytes for `lamports_per_byte`
+///  - 8 bytes for `exemption_threshold` (removed, but still counted in the size)
+///  - 1 byte for `burn_percent` (removed, but still counted in the size)
 pub const SIZE: usize = size_of::<u64>() // lamports_per_byte
     + size_of::<[u8; 8]>() // exemption_threshold
     + size_of::<u8>(); // burn_percent
@@ -47,6 +44,9 @@ const _: () = assert!(SIZE == 17);
 
 /// Maximum permitted size of account data (10 MiB).
 const MAX_PERMITTED_DATA_LENGTH: u64 = 10 * 1024 * 1024;
+
+/// Maximum lamports per byte value.
+const MAX_LAMPORTS_PER_BYTE: u64 = 1_759_197_129_867;
 
 /// Default rental rate in lamports/byte.
 ///
@@ -56,28 +56,6 @@ const MAX_PERMITTED_DATA_LENGTH: u64 = 10 * 1024 * 1024;
 /// - $0.01 per megabyte day
 /// - $7.30 per megabyte
 pub const DEFAULT_LAMPORTS_PER_BYTE: u64 = 6_960;
-
-/// The `f64::to_le_bytes` representation of the SIMD-0194 exemption threshold.
-///
-/// This value is equivalent to `1.0f64`. It is only used to check whether
-/// the exemption threshold is the deprecated value to avoid performing
-/// floating-point operations on-chain.
-const SIMD0194_EXEMPTION_THRESHOLD: [u8; 8] = [0, 0, 0, 0, 0, 0, 240, 63];
-
-/// The `f64::to_le_bytes` representation of the default exemption threshold.
-///
-/// This value is equivalent to `2.0f64`. It is only used to check whether
-/// the exemption threshold is the default value to avoid performing
-/// floating-point operations on-chain.
-const CURRENT_EXEMPTION_THRESHOLD: [u8; 8] = [0, 0, 0, 0, 0, 0, 0, 64];
-
-/// Maximum lamports per byte for the SIMD-0194 exemption threshold.
-const SIMD0194_MAX_LAMPORTS_PER_BYTE: u64 = 1_759_197_129_867;
-
-/// Maximum lamports per byte for the current exemption threshold.
-const CURRENT_MAX_LAMPORTS_PER_BYTE: u64 = 879_598_564_933;
-
-const DEFAULT_BURN_PERCENT: u8 = 50;
 
 /// Account storage overhead for calculation of base rent.
 ///
@@ -90,8 +68,6 @@ impl Default for Rent {
         #[allow(deprecated)]
         Self {
             lamports_per_byte: DEFAULT_LAMPORTS_PER_BYTE,
-            exemption_threshold: SIMD0194_EXEMPTION_THRESHOLD,
-            burn_percent: DEFAULT_BURN_PERCENT,
         }
     }
 }
@@ -141,31 +117,7 @@ impl Rent {
     /// The minimum balance in lamports for rent exemption.
     #[inline(always)]
     pub fn minimum_balance_unchecked(&self, data_len: usize) -> u64 {
-        let bytes = data_len as u64;
-
-        // There are two cases where it is possible to avoid floating-point
-        // operations:
-        //
-        //   1)  exemption threshold is `1.0` (the SIMD-0194 default)
-        //   2)  exemption threshold is `2.0` (the current default)
-        //
-        // In all other cases, perform the full calculation using floating-point
-        // operations. Note that on BPF targets, floating-point operations are
-        // not supported, so panic in that case.
-        #[allow(deprecated)]
-        if self.exemption_threshold == SIMD0194_EXEMPTION_THRESHOLD {
-            (ACCOUNT_STORAGE_OVERHEAD + bytes) * self.lamports_per_byte
-        } else if self.exemption_threshold == CURRENT_EXEMPTION_THRESHOLD {
-            2 * (ACCOUNT_STORAGE_OVERHEAD + bytes) * self.lamports_per_byte
-        } else {
-            #[cfg(not(target_arch = "bpf"))]
-            {
-                (((ACCOUNT_STORAGE_OVERHEAD + bytes) * self.lamports_per_byte) as f64
-                    * f64::from_le_bytes(self.exemption_threshold)) as u64
-            }
-            #[cfg(target_arch = "bpf")]
-            panic!("Floating-point operations are not supported on BPF targets");
-        }
+        (ACCOUNT_STORAGE_OVERHEAD + data_len as u64) * self.lamports_per_byte
     }
 
     /// Calculates the minimum balance for rent exemption.
@@ -192,12 +144,7 @@ impl Rent {
         // Validate `lamports_per_byte` based on `exemption_threshold`
         // to prevent overflow.
 
-        #[allow(deprecated)]
-        if (self.lamports_per_byte > CURRENT_MAX_LAMPORTS_PER_BYTE
-            && self.exemption_threshold == CURRENT_EXEMPTION_THRESHOLD)
-            || (self.lamports_per_byte > SIMD0194_MAX_LAMPORTS_PER_BYTE
-                && self.exemption_threshold == SIMD0194_EXEMPTION_THRESHOLD)
-        {
+        if self.lamports_per_byte > MAX_LAMPORTS_PER_BYTE {
             return None;
         }
 
@@ -215,16 +162,12 @@ impl Rent {
     pub fn free() -> Self {
         Self {
             lamports_per_byte: 0,
-            ..Rent::default()
         }
     }
 
     /// Creates a `Rent` with lamports per byte
     pub fn with_lamports_per_byte(lamports_per_byte: u64) -> Self {
-        Self {
-            lamports_per_byte,
-            ..Self::default()
-        }
+        Self { lamports_per_byte }
     }
 }
 
@@ -245,18 +188,10 @@ mod tests {
         #[allow(deprecated)]
         let rent = Rent {
             lamports_per_byte: 1,
-            exemption_threshold: 2.2f64.to_le_bytes(),
-            burn_percent: 3,
         };
         #[allow(clippy::clone_on_copy)]
         let cloned_rent = rent.clone();
         assert_eq!(cloned_rent, rent);
-    }
-
-    #[test]
-    fn test_exemption_threshold() {
-        assert_eq!(1f64.to_le_bytes(), SIMD0194_EXEMPTION_THRESHOLD);
-        assert_eq!(2f64.to_le_bytes(), CURRENT_EXEMPTION_THRESHOLD);
     }
 
     proptest! {
@@ -266,17 +201,9 @@ mod tests {
             #[allow(deprecated)]
             let previous_rent = Rent {
                 lamports_per_byte: DEFAULT_LAMPORTS_PER_BYTE / 2,
-                exemption_threshold: 2.0f64.to_le_bytes(),
-                ..Default::default()
             };
             let default_calc = default_rent.minimum_balance(bytes);
             assert_eq!(default_calc, previous_rent.minimum_balance(bytes));
-
-            // check that the calculation gives the same result using floats
-            #[allow(deprecated)]
-            let float_calc = (((ACCOUNT_STORAGE_OVERHEAD + bytes as u64) * previous_rent.lamports_per_byte) as f64
-                * f64::from_le_bytes(previous_rent.exemption_threshold)) as u64;
-            assert_eq!(default_calc, float_calc);
         }
     }
 }

--- a/rent/src/lib.rs
+++ b/rent/src/lib.rs
@@ -15,6 +15,8 @@ pub mod sysvar;
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::{AbiExample, StableAbi, StableAbiSample};
 use solana_sdk_macro::CloneZeroed;
+#[cfg(feature = "wincode")]
+use wincode::{config::ConfigCore, io::Writer, SchemaWrite, WriteResult};
 
 /// Configuration of network rent.
 #[repr(C)]
@@ -23,7 +25,7 @@ use solana_sdk_macro::CloneZeroed;
     feature = "serde",
     derive(serde_derive::Deserialize, serde_derive::Serialize)
 )]
-#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
+#[cfg_attr(feature = "wincode", derive(wincode::SchemaRead))]
 #[derive(PartialEq, CloneZeroed, Debug)]
 pub struct Rent {
     /// Rental rate in lamports/byte.
@@ -171,9 +173,37 @@ impl Rent {
     }
 }
 
+#[cfg(feature = "wincode")]
+unsafe impl<C: ConfigCore> SchemaWrite<C> for Rent {
+    type Src = Self;
+
+    #[inline(always)]
+    fn size_of(_src: &Self::Src) -> WriteResult<usize> {
+        // The reported size of the `Rent` struct is 17 bytes, which the size of the
+        // serialized sysvar account.
+        Ok(SIZE)
+    }
+
+    fn write(mut writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
+        // SAFETY: `size_of::<Rent>() < SIZE` always holds, so we can safely write
+        // `size_of::<Rent>()` bytes.
+        let mut writer = unsafe { writer.as_trusted_for(SIZE) }?;
+        writer.write(&src.lamports_per_byte.to_le_bytes())?;
+        writer.finish()?;
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use {super::*, proptest::proptest};
+    use {
+        super::{sysvar, *},
+        core::assert_eq,
+        proptest::proptest,
+        solana_account::{AccountSharedData, WritableAccount},
+        wincode::{io::WriteError::WriteSizeLimit, WriteError},
+    };
 
     #[test]
     fn test_size_of() {
@@ -205,5 +235,57 @@ mod tests {
             let default_calc = default_rent.minimum_balance(bytes);
             assert_eq!(default_calc, previous_rent.minimum_balance(bytes));
         }
+    }
+
+    #[test]
+    fn test_deserialize() {
+        let data = [1u8; 17];
+        let rent: Rent = wincode::deserialize(&data).unwrap();
+        assert_eq!(
+            rent,
+            Rent::with_lamports_per_byte(u64::from_le_bytes([1; 8]))
+        );
+    }
+
+    #[test]
+    fn test_serialize() {
+        let rent = Rent::with_lamports_per_byte(1);
+        let serialized_len =
+            wincode::serialized_size(&rent).expect("failed to get serialized sysvar size") as usize;
+
+        let mut account = AccountSharedData::new(
+            rent.minimum_balance(serialized_len),
+            serialized_len,
+            &sysvar::id(),
+        );
+        wincode::serialize_into(account.data_as_mut_slice(), &rent).unwrap();
+
+        assert_eq!(serialized_len, SIZE);
+        assert_eq!(account.data_as_mut_slice().len(), serialized_len);
+        assert_eq!(
+            account.data_as_mut_slice()[..8],
+            rent.lamports_per_byte.to_le_bytes()
+        );
+    }
+
+    #[test]
+    fn test_fail_serialize() {
+        let rent = Rent::with_lamports_per_byte(1);
+        // Wrongly using `size_of::<Rent>()` instead of `wincode::serialized_size(&rent)`
+        // to get the serialized length
+        let serialized_len = size_of::<Rent>();
+
+        let mut account = AccountSharedData::new(
+            rent.minimum_balance(serialized_len),
+            serialized_len,
+            &sysvar::id(),
+        );
+        let result = wincode::serialize_into(account.data_as_mut_slice(), &rent);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            WriteError::Io(WriteSizeLimit(SIZE))
+        ));
     }
 }

--- a/rent/src/lib.rs
+++ b/rent/src/lib.rs
@@ -28,9 +28,9 @@ use wincode::{
 
 /// Configuration of network rent.
 ///
-/// The `Rent` sysvar used to include `exemption_threshold` and `burn_percent` fields, but
-/// these were deprecated and have been removed. The serialized size of the `Rent` sysvar
-/// account is still `17` bytes, which is the size of the `Rent` sysvar account.
+/// The `Rent` struct used to include `exemption_threshold` and `burn_percent` fields, but
+/// these were deprecated and have been removed. The serialized size of the `Rent` struct
+/// is still `17` bytes, which is the size of the `Rent` sysvar account.
 #[repr(C)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(PartialEq, CloneZeroed, Debug)]
@@ -68,14 +68,44 @@ pub const DEFAULT_LAMPORTS_PER_BYTE: u64 = 6_960;
 
 /// The `f64::to_le_bytes` representation of the SIMD-0194 exemption threshold.
 ///
-/// This value is equivalent to `1.0f64`. It is only used to check whether
-/// the exemption threshold is the deprecated value to avoid performing
-/// floating-point operations on-chain.
+/// This value is equivalent to `1.0f64`. It is only used when serializing the
+/// `Rent` sysvar to maintain compatibility with the serialized representation.
 #[cfg(any(feature = "serde", feature = "wincode"))]
 const SIMD0194_EXEMPTION_THRESHOLD: [u8; 8] = [0, 0, 0, 0, 0, 0, 240, 63];
 
+/// The `burn_percent` value of SIMD-0194.
+///
+/// The `burn_percent` value is deprecated and has been removed from the `Rent` struct.
+/// It is only used when serializing the `Rent` sysvar to maintain compatibility with
+/// the serialized representation.
 #[cfg(any(feature = "serde", feature = "wincode"))]
-const DEFAULT_BURN_PERCENT: u8 = 50;
+const SIMD0194_BURN_PERCENT: u8 = 50;
+
+/// Initial rental rate in lamports/byte-year. It is only used when serializing
+/// the `Rent` sysvar to maintain compatibility with the serialized representation.
+///
+/// This calculation is based on:
+/// - 10^9 lamports per SOL
+/// - $1 per SOL
+/// - $0.01 per megabyte day
+/// - $3.65 per megabyte year
+#[cfg(any(feature = "serde", feature = "wincode"))]
+pub const GENESIS_LAMPORTS_PER_BYTE_YEAR: u64 = 1_000_000_000 / 100 * 365 / (1024 * 1024);
+
+/// The `f64::to_le_bytes` representation of the initial exemption threshold.
+///
+/// This value is equivalent to `2.0f64`. It is only used when serializing the
+/// `Rent` sysvar to maintain compatibility with the serialized representation.
+#[cfg(any(feature = "serde", feature = "wincode"))]
+const GENESIS_EXEMPTION_THRESHOLD: [u8; 8] = [0, 0, 0, 0, 0, 0, 0, 64];
+
+/// The initial `burn_percent` value.
+///
+/// The `burn_percent` value is deprecated and has been removed from the `Rent` struct.
+/// It is only used when serializing the `Rent` sysvar to maintain compatibility with
+/// the serialized representation.
+#[cfg(any(feature = "serde", feature = "wincode"))]
+const GENESIS_BURN_PERCENT: u8 = 100;
 
 /// Account storage overhead for calculation of base rent.
 ///
@@ -85,7 +115,6 @@ pub const ACCOUNT_STORAGE_OVERHEAD: u64 = 128;
 
 impl Default for Rent {
     fn default() -> Self {
-        #[allow(deprecated)]
         Self {
             lamports_per_byte: DEFAULT_LAMPORTS_PER_BYTE,
         }
@@ -94,9 +123,6 @@ impl Default for Rent {
 
 impl Rent {
     /// Calculates the minimum balance for rent exemption.
-    ///
-    /// This method avoids floating-point operations when the `exemption_threshold`
-    /// is the default value.
     ///
     /// # Arguments
     ///
@@ -109,7 +135,7 @@ impl Rent {
     /// # Panics
     ///
     /// Panics if `data_len` exceeds the maximum permitted data length or if the
-    /// `lamports_per_byte` is too large based on the `exemption_threshold`.
+    /// `lamports_per_byte` is too large.
     #[inline(always)]
     pub fn minimum_balance(&self, data_len: usize) -> u64 {
         self.try_minimum_balance(data_len)
@@ -119,14 +145,10 @@ impl Rent {
     /// Calculates the minimum balance for rent exemption without performing
     /// any validation.
     ///
-    /// This method avoids floating-point operations when the `exemption_threshold`
-    /// is the default value.
-    ///
     /// # Important
     ///
     /// The caller must ensure that `data_len` is within the permitted limit
-    /// and the `lamports_per_byte` is within the permitted limit based on
-    /// the `exemption_threshold` to avoid overflow.
+    /// and the `lamports_per_byte` is within the permitted limit to avoid overflow.
     ///
     /// # Arguments
     ///
@@ -142,9 +164,6 @@ impl Rent {
 
     /// Calculates the minimum balance for rent exemption.
     ///
-    /// This method avoids floating-point operations when the `exemption_threshold`
-    /// is the default value.
-    ///
     /// # Arguments
     ///
     /// * `data_len` - The number of bytes in the account
@@ -152,17 +171,15 @@ impl Rent {
     /// # Returns
     ///
     /// * `Some(u64)` - The minimum balance in lamports for rent exemption, if all checks pass.
-    /// * `None` - If `data_len` exceeds the maximum permitted data length, or if the
-    ///   `lamports_per_byte` is too large based on the `exemption_threshold`, which
-    ///   would cause an overflow.
+    /// * `None` - If `data_len` exceeds the maximum permitted data length, or if
+    ///   `lamports_per_byte` is too large to safely support every permitted data length.
     #[inline(always)]
     pub fn try_minimum_balance(&self, data_len: usize) -> Option<u64> {
         if data_len as u64 > MAX_PERMITTED_DATA_LENGTH {
             return None;
         }
 
-        // Validate `lamports_per_byte` based on `exemption_threshold`
-        // to prevent overflow.
+        // Validate `lamports_per_byte` to prevent overflow.
 
         if self.lamports_per_byte > MAX_LAMPORTS_PER_BYTE {
             return None;
@@ -222,8 +239,15 @@ impl serde::Serialize for Rent {
     {
         let mut state = serializer.serialize_struct("Rent", 3)?;
         state.serialize_field("lamports_per_byte", &self.lamports_per_byte)?;
-        state.serialize_field("exemption_threshold", &SIMD0194_EXEMPTION_THRESHOLD)?;
-        state.serialize_field("burn_percent", &DEFAULT_BURN_PERCENT)?;
+
+        if self.lamports_per_byte == GENESIS_LAMPORTS_PER_BYTE_YEAR {
+            state.serialize_field("exemption_threshold", &GENESIS_EXEMPTION_THRESHOLD)?;
+            state.serialize_field("burn_percent", &GENESIS_BURN_PERCENT)?;
+        } else {
+            state.serialize_field("exemption_threshold", &SIMD0194_EXEMPTION_THRESHOLD)?;
+            state.serialize_field("burn_percent", &SIMD0194_BURN_PERCENT)?;
+        }
+
         state.end()
     }
 }
@@ -263,8 +287,15 @@ unsafe impl<C: ConfigCore> SchemaWrite<C> for Rent {
         // which is 17 bytes.
         let mut writer = unsafe { writer.as_trusted_for(SIZE) }?;
         writer.write(&src.lamports_per_byte.to_le_bytes())?;
-        writer.write(&SIMD0194_EXEMPTION_THRESHOLD)?;
-        writer.write(&DEFAULT_BURN_PERCENT.to_le_bytes())?;
+
+        if src.lamports_per_byte == GENESIS_LAMPORTS_PER_BYTE_YEAR {
+            writer.write(&GENESIS_EXEMPTION_THRESHOLD)?;
+            writer.write(&GENESIS_BURN_PERCENT.to_le_bytes())?;
+        } else {
+            writer.write(&SIMD0194_EXEMPTION_THRESHOLD)?;
+            writer.write(&SIMD0194_BURN_PERCENT.to_le_bytes())?;
+        }
+
         writer.finish()?;
 
         Ok(())

--- a/rent/src/lib.rs
+++ b/rent/src/lib.rs
@@ -12,13 +12,19 @@ extern crate std;
 #[cfg(feature = "sysvar")]
 pub mod sysvar;
 
+#[cfg(feature = "wincode")]
+use core::mem::MaybeUninit;
 #[cfg(feature = "serde")]
 use serde::ser::SerializeStruct;
 #[cfg(feature = "frozen-abi")]
 use solana_frozen_abi_macro::{AbiExample, StableAbi, StableAbiSample};
 use solana_sdk_macro::CloneZeroed;
 #[cfg(feature = "wincode")]
-use wincode::{config::ConfigCore, io::Writer, SchemaWrite, WriteResult};
+use wincode::{
+    config::ConfigCore,
+    io::{Reader, Writer},
+    ReadResult, SchemaRead, SchemaWrite, WriteResult,
+};
 
 /// Configuration of network rent.
 ///
@@ -27,7 +33,6 @@ use wincode::{config::ConfigCore, io::Writer, SchemaWrite, WriteResult};
 /// account is still `17` bytes, which is the size of the `Rent` sysvar account.
 #[repr(C)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-#[cfg_attr(feature = "wincode", derive(wincode::SchemaRead))]
 #[derive(PartialEq, CloneZeroed, Debug)]
 pub struct Rent {
     /// Rental rate in lamports/byte.
@@ -192,7 +197,19 @@ impl<'de> serde::Deserialize<'de> for Rent {
     where
         D: serde::Deserializer<'de>,
     {
-        let lamports_per_byte = u64::deserialize(deserializer)?;
+        #[derive(serde_derive::Deserialize)]
+        struct RentWithDeprecatedFields {
+            lamports_per_byte: u64,
+            _exemption_threshold: [u8; 8],
+            _burn_percent: u8,
+        }
+
+        let RentWithDeprecatedFields {
+            lamports_per_byte,
+            _exemption_threshold,
+            _burn_percent,
+        } = serde::Deserialize::deserialize(deserializer)?;
+
         Ok(Self { lamports_per_byte })
     }
 }
@@ -208,6 +225,26 @@ impl serde::Serialize for Rent {
         state.serialize_field("exemption_threshold", &SIMD0194_EXEMPTION_THRESHOLD)?;
         state.serialize_field("burn_percent", &DEFAULT_BURN_PERCENT)?;
         state.end()
+    }
+}
+
+#[cfg(feature = "wincode")]
+unsafe impl<'de, C: ConfigCore> SchemaRead<'de, C> for Rent {
+    type Dst = Rent;
+
+    fn read(mut reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        // SAFETY: `SIZE` is the serialized size of the `Rent` sysvar account,
+        // which is 17 bytes.
+        let mut reader = unsafe { reader.as_trusted_for(SIZE)? };
+        let lamports_per_byte = <u64 as SchemaRead<C>>::get(reader.by_ref())?;
+        // Consume the deprecated fields to maintain compatibility with the serialized
+        // size of the `Rent` sysvar account.
+        const DEPRECATED_FIELDS_SIZE: usize = SIZE - size_of::<u64>();
+        let _ = reader.take_array::<DEPRECATED_FIELDS_SIZE>()?;
+
+        dst.write(Rent { lamports_per_byte });
+
+        Ok(())
     }
 }
 

--- a/rent/src/lib.rs
+++ b/rent/src/lib.rs
@@ -19,6 +19,10 @@ use solana_sdk_macro::CloneZeroed;
 use wincode::{config::ConfigCore, io::Writer, SchemaWrite, WriteResult};
 
 /// Configuration of network rent.
+///
+/// The `Rent` sysvar used to include `exemption_threshold` and `burn_percent` fields, but
+/// these were deprecated and have been removed. The serialized size of the `Rent` sysvar
+/// account is still `17` bytes, which is the size of the `Rent` sysvar account.
 #[repr(C)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[cfg_attr(
@@ -179,8 +183,7 @@ unsafe impl<C: ConfigCore> SchemaWrite<C> for Rent {
 
     #[inline(always)]
     fn size_of(_src: &Self::Src) -> WriteResult<usize> {
-        // The reported size of the `Rent` struct is 17 bytes, which the size of the
-        // serialized sysvar account.
+        // The serialized `Rent` sysvar account is 17 bytes.
         Ok(SIZE)
     }
 

--- a/rent/src/sysvar.rs
+++ b/rent/src/sysvar.rs
@@ -7,5 +7,5 @@ pub use {
 impl_sysvar_id!(Rent);
 
 impl GetSysvar for Rent {
-    impl_get_sysvar!(ID, 7);
+    impl_get_sysvar!(ID);
 }


### PR DESCRIPTION
### Problem

The `Rent` struct includes 2 deprecated fields, which makes the memory requirement be `24` bytes (`17` bytes serialized + `7` padding bytes). Therefore it is not possible load the struct using zero-copy directly from the rent sysvar account.

### Solution

This PR removes the deprecated fields and adds a custom serializer that still requires `17` bytes. This way the struct only requires `8` bytes of memory, but still serializes into `17` bytes.