### PR TITLE
[bls-signatures] Reduce allocation size in pairing computation

### DIFF
--- a/bls-signatures/Cargo.toml
+++ b/bls-signatures/Cargo.toml
@@ -65,6 +65,11 @@ tempfile = { workspace = true }
 [lints]
 workspace = true
 
+[[test]]
+name = "allocation_regression"
+path = "tests/allocation_regression.rs"
+harness = false
+
 [[bench]]
 name = "bls_signatures"
 harness = false

--- a/bls-signatures/Cargo.toml
+++ b/bls-signatures/Cargo.toml
@@ -73,3 +73,7 @@ harness = false
 [[bench]]
 name = "bls_signatures"
 harness = false
+
+[[bench]]
+name = "verification_paths"
+harness = false

--- a/bls-signatures/benches/verification_paths.rs
+++ b/bls-signatures/benches/verification_paths.rs
@@ -1,0 +1,119 @@
+// Run with the verification_paths Cargo bench target (harness = false).
+// Preparation benchmarks include destruction of the temporary preparation.
+// Prepared verification reuses a preparation created outside the timed loop.
+
+use {
+    criterion::{criterion_group, criterion_main, Criterion},
+    solana_bls_signatures::{
+        error::BlsError,
+        hash::{HashedMessage, PreparedHashedMessage},
+        keypair::Keypair,
+        pubkey::VerifySignature,
+        signature::{SignatureAffine, SignatureCompressed},
+    },
+    std::{hint::black_box, time::Duration},
+};
+
+fn verification_paths(c: &mut Criterion) {
+    // Use the same fixtures as the allocation regression test.
+    let keypair = Keypair::derive(&[42u8; 32]).expect("derive fixture key");
+    let message: &[u8] = b"solana-bls-signatures allocation baseline";
+    let valid: SignatureCompressed = keypair.sign(message).into();
+    let wrong: SignatureCompressed = keypair.sign(b"a different message").into();
+    let hashed = HashedMessage::new(message);
+    let prepared = PreparedHashedMessage::from_hashed_message(&hashed);
+
+    let mut setup = c.benchmark_group("bls_setup");
+    setup.bench_function("hash_message", |b| {
+        b.iter(|| black_box(HashedMessage::new(black_box(message))));
+    });
+    setup.bench_function("prepare_from_hashed", |b| {
+        b.iter(|| {
+            drop(black_box(PreparedHashedMessage::from_hashed_message(
+                black_box(&hashed),
+            )));
+        });
+    });
+    setup.bench_function("prepare_from_raw", |b| {
+        b.iter(|| {
+            drop(black_box(PreparedHashedMessage::new(black_box(message))));
+        });
+    });
+    setup.finish();
+
+    let mut verify = c.benchmark_group("bls_verify");
+    for (status, encoded, expected) in [
+        ("valid", &valid, Ok(())),
+        ("wrong_message", &wrong, Err(BlsError::VerificationFailed)),
+    ] {
+        let affine = SignatureAffine::try_from(encoded).expect("decode fixture signature");
+
+        // Validate all four paths before timing them. The wrong-message
+        // signature is correctly encoded and belongs to the prime-order group.
+        assert_eq!(
+            keypair.public.verify_signature(&affine, message),
+            expected,
+            "raw/{status}",
+        );
+        assert_eq!(
+            keypair.public.verify_signature_pre_hashed(&affine, &hashed),
+            expected,
+            "pre_hashed/{status}",
+        );
+        assert_eq!(
+            keypair.public.verify_signature_prepared(&affine, &prepared),
+            expected,
+            "prepared/{status}",
+        );
+        assert_eq!(
+            keypair.public.verify_signature(encoded, message),
+            expected,
+            "raw_compressed/{status}",
+        );
+
+        verify.bench_function(format!("raw/{status}"), |b| {
+            b.iter(|| {
+                black_box(
+                    black_box(&keypair.public)
+                        .verify_signature(black_box(&affine), black_box(message)),
+                )
+            });
+        });
+        verify.bench_function(format!("pre_hashed/{status}"), |b| {
+            b.iter(|| {
+                black_box(
+                    black_box(&keypair.public)
+                        .verify_signature_pre_hashed(black_box(&affine), black_box(&hashed)),
+                )
+            });
+        });
+        verify.bench_function(format!("prepared/{status}"), |b| {
+            b.iter(|| {
+                black_box(
+                    black_box(&keypair.public)
+                        .verify_signature_prepared(black_box(&affine), black_box(&prepared)),
+                )
+            });
+        });
+        verify.bench_function(format!("raw_compressed/{status}"), |b| {
+            b.iter(|| {
+                black_box(
+                    black_box(&keypair.public)
+                        .verify_signature(black_box(encoded), black_box(message)),
+                )
+            });
+        });
+    }
+    verify.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(3))
+        .sample_size(100);
+    targets = verification_paths
+}
+criterion_main!(benches);
+

--- a/bls-signatures/benches/verification_paths.rs
+++ b/bls-signatures/benches/verification_paths.rs
@@ -9,7 +9,7 @@ use {
         hash::{HashedMessage, PreparedHashedMessage},
         keypair::Keypair,
         pubkey::VerifySignature,
-        signature::{SignatureAffine, SignatureCompressed},
+        signature::{SignatureAffine, SignatureCompressed, SignatureProjective},
     },
     std::{hint::black_box, time::Duration},
 };
@@ -105,6 +105,88 @@ fn verification_paths(c: &mut Criterion) {
         });
     }
     verify.finish();
+
+    // Match the allocation test: aggregate two affine keys and signatures
+    // inside each timed operation. Message preparation stays outside the
+    // timed loop for the prepared path.
+    let other_keypair = Keypair::derive(&[43u8; 32]).expect("derive second aggregate key");
+    let aggregate_pubkeys = [keypair.public, other_keypair.public];
+    let other_signature: SignatureAffine = other_keypair.sign(message).into();
+    let aggregate_valid = [
+        SignatureAffine::try_from(&valid).expect("decode first aggregate signature"),
+        other_signature,
+    ];
+    let aggregate_wrong = [
+        SignatureAffine::try_from(&wrong).expect("decode wrong-message aggregate signature"),
+        other_signature,
+    ];
+
+    let mut aggregate = c.benchmark_group("bls_aggregate");
+    for (status, signatures, expected) in [
+        ("valid", &aggregate_valid, Ok(())),
+        (
+            "wrong_message",
+            &aggregate_wrong,
+            Err(BlsError::VerificationFailed),
+        ),
+    ] {
+        assert_eq!(
+            SignatureProjective::verify_aggregate(
+                aggregate_pubkeys.iter(),
+                signatures.iter(),
+                message,
+            ),
+            expected,
+            "aggregate/raw/{status}",
+        );
+        assert_eq!(
+            SignatureProjective::verify_aggregate_pre_hashed(
+                aggregate_pubkeys.iter(),
+                signatures.iter(),
+                &hashed,
+            ),
+            expected,
+            "aggregate/pre_hashed/{status}",
+        );
+        assert_eq!(
+            SignatureProjective::verify_aggregate_prepared(
+                aggregate_pubkeys.iter(),
+                signatures.iter(),
+                &prepared,
+            ),
+            expected,
+            "aggregate/prepared/{status}",
+        );
+
+        aggregate.bench_function(format!("raw/{status}"), |b| {
+            b.iter(|| {
+                black_box(SignatureProjective::verify_aggregate(
+                    black_box(&aggregate_pubkeys).iter(),
+                    black_box(signatures).iter(),
+                    black_box(message),
+                ))
+            });
+        });
+        aggregate.bench_function(format!("pre_hashed/{status}"), |b| {
+            b.iter(|| {
+                black_box(SignatureProjective::verify_aggregate_pre_hashed(
+                    black_box(&aggregate_pubkeys).iter(),
+                    black_box(signatures).iter(),
+                    black_box(&hashed),
+                ))
+            });
+        });
+        aggregate.bench_function(format!("prepared/{status}"), |b| {
+            b.iter(|| {
+                black_box(SignatureProjective::verify_aggregate_prepared(
+                    black_box(&aggregate_pubkeys).iter(),
+                    black_box(signatures).iter(),
+                    black_box(&prepared),
+                ))
+            });
+        });
+    }
+    aggregate.finish();
 }
 
 criterion_group! {

--- a/bls-signatures/benches/verification_paths.rs
+++ b/bls-signatures/benches/verification_paths.rs
@@ -15,6 +15,9 @@ use {
 };
 
 fn verification_paths(c: &mut Criterion) {
+    #[cfg(feature = "parallel")]
+    parallel_aggregate_paths(c);
+
     // Use the same fixtures as the allocation regression test.
     let keypair = Keypair::derive(&[42u8; 32]).expect("derive fixture key");
     let message: &[u8] = b"solana-bls-signatures allocation baseline";
@@ -189,6 +192,124 @@ fn verification_paths(c: &mut Criterion) {
     aggregate.finish();
 }
 
+#[cfg(feature = "parallel")]
+fn time_on_worker(
+    pool: &rayon::ThreadPool,
+    iterations: u64,
+    mut operation: impl FnMut() -> Result<(), BlsError> + Send,
+) -> Duration {
+    pool.install(move || {
+        let start = std::time::Instant::now();
+        for _ in 0..iterations {
+            let _ = black_box(operation());
+        }
+        start.elapsed()
+    })
+}
+
+#[cfg(feature = "parallel")]
+fn parallel_aggregate_paths(c: &mut Criterion) {
+    let keypair = Keypair::derive(&[42u8; 32]).expect("derive fixture key");
+    let other_keypair = Keypair::derive(&[43u8; 32]).expect("derive second fixture key");
+    let message: &[u8] = b"solana-bls-signatures allocation baseline";
+    let hashed = HashedMessage::new(message);
+    let prepared = PreparedHashedMessage::from_hashed_message(&hashed);
+
+    let public_keys = [keypair.public, other_keypair.public];
+    let other_signature: SignatureAffine = other_keypair.sign(message).into();
+    let valid_signatures: [SignatureAffine; 2] = [keypair.sign(message).into(), other_signature];
+    let wrong_signatures: [SignatureAffine; 2] =
+        [keypair.sign(b"a different message").into(), other_signature];
+
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(2)
+        .build()
+        .expect("build parallel benchmark pool");
+
+    // Match the allocation test's pool warm-up, outside the timed region.
+    drop(pool.broadcast(|_| ()));
+    std::thread::sleep(Duration::from_millis(100));
+
+    println!("parallel aggregate timing: inside a private two-worker Rayon pool");
+    println!("timing includes aggregation and verification; preparations are reused");
+
+    let mut group = c.benchmark_group("bls_par_aggregate_worker");
+
+    for (status, signatures, expected) in [
+        ("valid", &valid_signatures, Ok(())),
+        (
+            "wrong_message",
+            &wrong_signatures,
+            Err(BlsError::VerificationFailed),
+        ),
+    ] {
+        // Validate each path in the same worker context before timing it.
+        pool.install(|| {
+            assert_eq!(
+                SignatureProjective::par_verify_aggregate(&public_keys, signatures, message,),
+                expected,
+                "parallel raw/{status}",
+            );
+            assert_eq!(
+                SignatureProjective::par_verify_aggregate_pre_hashed(
+                    &public_keys,
+                    signatures,
+                    &hashed,
+                ),
+                expected,
+                "parallel pre_hashed/{status}",
+            );
+            assert_eq!(
+                SignatureProjective::par_verify_aggregate_prepared(
+                    &public_keys,
+                    signatures,
+                    &prepared,
+                ),
+                expected,
+                "parallel prepared/{status}",
+            );
+        });
+
+        group.bench_function(format!("raw/{status}"), |b| {
+            b.iter_custom(|iterations| {
+                time_on_worker(&pool, iterations, || {
+                    SignatureProjective::par_verify_aggregate(
+                        black_box(&public_keys),
+                        black_box(signatures),
+                        black_box(message),
+                    )
+                })
+            });
+        });
+
+        group.bench_function(format!("pre_hashed/{status}"), |b| {
+            b.iter_custom(|iterations| {
+                time_on_worker(&pool, iterations, || {
+                    SignatureProjective::par_verify_aggregate_pre_hashed(
+                        black_box(&public_keys),
+                        black_box(signatures),
+                        black_box(&hashed),
+                    )
+                })
+            });
+        });
+
+        group.bench_function(format!("prepared/{status}"), |b| {
+            b.iter_custom(|iterations| {
+                time_on_worker(&pool, iterations, || {
+                    SignatureProjective::par_verify_aggregate_prepared(
+                        black_box(&public_keys),
+                        black_box(signatures),
+                        black_box(&prepared),
+                    )
+                })
+            });
+        });
+    }
+
+    group.finish();
+}
+
 criterion_group! {
     name = benches;
     config = Criterion::default()
@@ -198,4 +319,3 @@ criterion_group! {
     targets = verification_paths
 }
 criterion_main!(benches);
-

--- a/bls-signatures/src/hash.rs
+++ b/bls-signatures/src/hash.rs
@@ -1,7 +1,7 @@
 use {
-    crate::proof_of_possession::POP_DST,
+    crate::{prepared_g2::PreparedG2, proof_of_possession::POP_DST},
     alloc::vec::Vec,
-    blstrs::{G2Affine, G2Prepared, G2Projective},
+    blstrs::{G2Affine, G2Projective},
 };
 
 /// Domain separation tag used for hashing messages to curve points to prevent
@@ -41,13 +41,13 @@ impl HashedMessage {
 /// representation. It is useful when the same message is verified repeatedly
 /// against many signatures because it skips the pairing preparation step.
 ///
-/// Memory note: each `PreparedHashedMessage` includes a `G2Prepared`, which is
-/// significantly larger than a plain `HashedMessage` (roughly ~19 KiB per
-/// element in current `blstrs` implementations).
+/// Memory note: each `PreparedHashedMessage` owns a heap-allocated pairing
+/// preparation table (19,584 bytes for a nonidentity point), in addition to
+/// the hashed point. Cloning duplicates the table.
 #[derive(Clone, Debug)]
 pub struct PreparedHashedMessage {
     pub(crate) hashed_message: HashedMessage,
-    pub(crate) prepared: G2Prepared,
+    pub(crate) prepared: PreparedG2,
 }
 
 impl PreparedHashedMessage {
@@ -60,7 +60,7 @@ impl PreparedHashedMessage {
     pub fn from_hashed_message(hashed_message: &HashedMessage) -> Self {
         Self {
             hashed_message: *hashed_message,
-            prepared: G2Prepared::from(hashed_message.0),
+            prepared: PreparedG2::from(hashed_message.0),
         }
     }
 }

--- a/bls-signatures/src/lib.rs
+++ b/bls-signatures/src/lib.rs
@@ -42,6 +42,8 @@ pub mod keypair;
 pub(crate) mod macros;
 #[cfg(not(target_os = "solana"))]
 pub mod hash;
+#[cfg(not(target_os = "solana"))]
+mod prepared_g2;
 pub mod proof_of_possession;
 pub mod pubkey;
 #[cfg(not(target_os = "solana"))]

--- a/bls-signatures/src/macros.rs
+++ b/bls-signatures/src/macros.rs
@@ -476,6 +476,7 @@ macro_rules! impl_add_to_accumulator {
     };
 }
 
+#[cfg(not(target_os = "solana"))]
 macro_rules! impl_unchecked_conversions {
     (
         $unchecked_type:ident,     // e.g. SignatureAffineUnchecked

--- a/bls-signatures/src/macros.rs
+++ b/bls-signatures/src/macros.rs
@@ -561,7 +561,20 @@ macro_rules! impl_pubkey_wrapper_delegations {
         #[cfg(not(target_os = "solana"))]
         // `VerifySignature` remains public, but this crate only implements it for
         // wrappers whose construction represents the PoP-verified safety boundary.
-        impl<T: AsPubkeyAffine + ?Sized> VerifySignature for $wrapper<T> {}
+        impl<T: AsPubkeyAffine + ?Sized> VerifySignature for $wrapper<T> {
+            fn verify_signature_pre_hashed<S: crate::signature::AsSignatureAffine>(
+                &self,
+                signature: &S,
+                hashed_message: &crate::hash::HashedMessage,
+            ) -> Result<(), crate::error::BlsError> {
+                let pubkey_affine = self.try_as_affine()?;
+                let signature_affine = signature.try_as_affine()?;
+                pubkey_affine
+                    ._verify_signature(&signature_affine, hashed_message)
+                    .then_some(())
+                    .ok_or(crate::error::BlsError::VerificationFailed)
+            }
+        }
 
         #[cfg(not(target_os = "solana"))]
         impl<T: AsPubkeyAffine + ?Sized> AsPubkeyAffine for $wrapper<T> {

--- a/bls-signatures/src/prepared_g2.rs
+++ b/bls-signatures/src/prepared_g2.rs
@@ -1,0 +1,64 @@
+//! G2 pairing preparation owned by this crate.
+
+use {
+    alloc::{vec, vec::Vec},
+    blst::{blst_fp12, blst_fp6, blst_miller_loop_lines, blst_precompute_lines},
+    blstrs::{G1Affine, G2Affine},
+    group::prime::PrimeCurveAffine,
+};
+
+// The buffer length required by blst_precompute_lines and blst_miller_loop_lines.
+const MILLER_LOOP_LINES: usize = 68;
+
+#[derive(Clone, Debug)]
+pub(crate) struct PreparedG2 {
+    // Empty for the identity; otherwise exactly 68 initialized coefficients.
+    lines: Vec<blst_fp6>,
+}
+
+impl From<G2Affine> for PreparedG2 {
+    fn from(affine: G2Affine) -> Self {
+        if bool::from(affine.is_identity()) {
+            return Self { lines: Vec::new() };
+        }
+
+        let mut lines = vec![blst_fp6::default(); MILLER_LOOP_LINES];
+        // SAFETY: The output has space for all 68 coefficients. Both buffers
+        // remain valid for the call, and blst retains neither pointer.
+        unsafe {
+            blst_precompute_lines(lines.as_mut_ptr(), affine.as_ref());
+        }
+        Self { lines }
+    }
+}
+
+impl PreparedG2 {
+    pub(crate) fn miller_loop(&self, point: &G1Affine) -> blst_fp12 {
+        let mut result = blst_fp12::default();
+        if self.lines.is_empty() || bool::from(point.is_identity()) {
+            return result;
+        }
+
+        // SAFETY: Nonempty storage contains all 68 initialized coefficients
+        // from blst_precompute_lines. The inputs remain valid and immutable,
+        // and result is a separate writable blst_fp12.
+        unsafe {
+            blst_miller_loop_lines(&mut result, self.lines.as_ptr(), point.as_ref());
+        }
+        result
+    }
+}
+
+#[allow(clippy::arithmetic_side_effects)]
+pub(crate) fn multi_miller_loop(terms: &[(&G1Affine, &PreparedG2)]) -> blst_fp12 {
+    let mut result = blst_fp12::default();
+    for (index, (point, prepared)) in terms.iter().enumerate() {
+        let term = prepared.miller_loop(point);
+        if index == 0 {
+            result = term;
+        } else {
+            result *= term;
+        }
+    }
+    result
+}

--- a/bls-signatures/src/prepared_g2.rs
+++ b/bls-signatures/src/prepared_g2.rs
@@ -1,7 +1,7 @@
 //! G2 pairing preparation owned by this crate.
 
 use {
-    alloc::{vec, vec::Vec},
+    alloc::vec::Vec,
     blst::{blst_fp12, blst_fp6, blst_miller_loop_lines, blst_precompute_lines},
     blstrs::{G1Affine, G2Affine},
     group::prime::PrimeCurveAffine,
@@ -22,11 +22,15 @@ impl From<G2Affine> for PreparedG2 {
             return Self { lines: Vec::new() };
         }
 
-        let mut lines = vec![blst_fp6::default(); MILLER_LOOP_LINES];
-        // SAFETY: The output has space for all 68 coefficients. Both buffers
-        // remain valid for the call, and blst retains neither pointer.
+        let mut lines = Vec::<blst_fp6>::with_capacity(MILLER_LOOP_LINES);
+        // SAFETY: The allocation has space for all 68 coefficients.
+        // blst_precompute_lines initializes every coefficient without reading
+        // the previous contents. Both buffers remain valid for the call,
+        // and blst retains neither pointer. Set the length only after
+        // the entire table has been initialized.
         unsafe {
             blst_precompute_lines(lines.as_mut_ptr(), affine.as_ref());
+            lines.set_len(MILLER_LOOP_LINES);
         }
         Self { lines }
     }

--- a/bls-signatures/src/pubkey/verify.rs
+++ b/bls-signatures/src/pubkey/verify.rs
@@ -4,6 +4,7 @@ use {
     crate::{
         error::BlsError,
         hash::{HashedMessage, HashedPoPPayload, PreparedHashedMessage},
+        prepared_g2::PreparedG2,
         proof_of_possession::{AsProofOfPossessionAffine, ProofOfPossessionAffine},
         pubkey::points::{AsPubkeyAffine, PopVerified, PubkeyAffine},
         signature::{AsSignatureAffine, SignatureAffine},
@@ -130,31 +131,22 @@ impl PubkeyAffine {
     pub(crate) fn _verify_signature_prepared(
         &self,
         signature: &SignatureAffine,
-        hashed_message_prepared: &G2Prepared,
+        hashed_message_prepared: &PreparedG2,
     ) -> bool {
         if bool::from(self.0.is_identity()) {
             return false;
         }
 
-        // The verification equation is e(pubkey, H(m)) = e(g1, signature).
-        // This can be rewritten as e(pubkey, H(m)) * e(-g1, signature) = 1, which
-        // allows for a more efficient verification using a multi-miller loop.
-        let signature_prepared = G2Prepared::from(signature.0);
+        // Reuse the message's prepared table.
+        let message_pairing = hashed_message_prepared.miller_loop(&self.0);
 
-        // use the static valud if `std` is available, otherwise compute it
-        #[cfg(feature = "std")]
-        let neg_g1_generator = &*NEG_G1_GENERATOR_AFFINE;
-        #[cfg(not(feature = "std"))]
-        #[allow(clippy::arithmetic_side_effects)]
-        let neg_g1_generator_val: G1Affine = (-G1Projective::generator()).into();
-        #[cfg(not(feature = "std"))]
-        let neg_g1_generator = &neg_g1_generator_val;
+        // Compute the signature term directly, without a preparation table.
+        let generator = G1Affine::generator();
+        let signature_pairing =
+            blst::blst_fp12::miller_loop(signature.0.as_ref(), generator.as_ref());
 
-        let miller_loop_result = Bls12::multi_miller_loop(&[
-            (&self.0, hashed_message_prepared),
-            (neg_g1_generator, &signature_prepared),
-        ]);
-        miller_loop_result.final_exponentiation() == Gt::identity()
+        // Check e(pubkey, H(m)) = e(g1, signature) with one final exponentiation.
+        blst::blst_fp12::finalverify(&message_pairing, &signature_pairing)
     }
 
     /// Verify a proof of possession against a public key

--- a/bls-signatures/src/pubkey/verify.rs
+++ b/bls-signatures/src/pubkey/verify.rs
@@ -111,8 +111,20 @@ impl PubkeyAffine {
         signature: &SignatureAffine,
         hashed_message: &HashedMessage,
     ) -> bool {
-        let hashed_message_prepared = G2Prepared::from(hashed_message.0);
-        self._verify_signature_prepared(signature, &hashed_message_prepared)
+        if bool::from(self.0.is_identity()) {
+            return false;
+        }
+
+        // Check e(pubkey, H(m)) = e(g1, signature) without preparing
+        // either G2 point.
+        let generator = G1Affine::generator();
+        let message_pairing =
+            blst::blst_fp12::miller_loop(hashed_message.0.as_ref(), self.0.as_ref());
+        let signature_pairing =
+            blst::blst_fp12::miller_loop(signature.0.as_ref(), generator.as_ref());
+
+        // Compare the pairings using one final exponentiation.
+        blst::blst_fp12::finalverify(&message_pairing, &signature_pairing)
     }
 
     pub(crate) fn _verify_signature_prepared(

--- a/bls-signatures/src/signature/verify.rs
+++ b/bls-signatures/src/signature/verify.rs
@@ -47,8 +47,10 @@ impl SignatureProjective {
         signatures: impl Iterator<Item = &'a S>,
         hashed_message: &HashedMessage,
     ) -> Result<(), BlsError> {
-        let prepared_hashed_message = PreparedHashedMessage::from_hashed_message(hashed_message);
-        Self::verify_aggregate_prepared(public_keys, signatures, &prepared_hashed_message)
+        let aggregate_pubkey = PubkeyProjective::aggregate(public_keys)?;
+        let aggregate_signature = SignatureProjective::aggregate(signatures)?;
+
+        aggregate_pubkey.verify_signature_pre_hashed(&aggregate_signature, hashed_message)
     }
 
     /// Verify a list of signatures against a pre-hashed and prepared message and

--- a/bls-signatures/src/signature/verify.rs
+++ b/bls-signatures/src/signature/verify.rs
@@ -96,8 +96,14 @@ impl SignatureProjective {
         signatures: &[S],
         hashed_message: &HashedMessage,
     ) -> Result<(), BlsError> {
-        let prepared_hashed_message = PreparedHashedMessage::from_hashed_message(hashed_message);
-        Self::par_verify_aggregate_prepared(public_keys, signatures, &prepared_hashed_message)
+        let (aggregate_pubkey_res, aggregate_signature_res) = rayon::join(
+            || PubkeyProjective::par_aggregate(public_keys.into_par_iter()),
+            || SignatureProjective::par_aggregate(signatures.into_par_iter()),
+        );
+
+        let aggregate_pubkey = aggregate_pubkey_res?;
+        let aggregate_signature = aggregate_signature_res?;
+        aggregate_pubkey.verify_signature_pre_hashed(&aggregate_signature, hashed_message)
     }
 
     /// Verify a list of signatures against a pre-hashed and prepared message and

--- a/bls-signatures/src/signature/verify_distinct.rs
+++ b/bls-signatures/src/signature/verify_distinct.rs
@@ -604,7 +604,8 @@ impl SignatureProjective {
         #[cfg(not(feature = "std"))]
         let neg_g1_generator = &neg_g1_generator_val;
 
-        let mut terms = alloc::vec::Vec::with_capacity(grouped_pubkeys_affine.len() + 1);
+        let mut terms =
+            alloc::vec::Vec::with_capacity(grouped_pubkeys_affine.len().saturating_add(1));
         for (pubkey, prepared_hash) in grouped_pubkeys_affine
             .iter()
             .zip(grouped_prepared_hashes.iter())

--- a/bls-signatures/src/signature/verify_distinct.rs
+++ b/bls-signatures/src/signature/verify_distinct.rs
@@ -22,6 +22,7 @@ use {
     crate::{
         error::BlsError,
         hash::{HashedMessage, PreparedHashedMessage},
+        prepared_g2::{multi_miller_loop, PreparedG2},
         pubkey::{AsPubkeyAffine, PopVerified},
         signature::points::{AddToSignatureProjective, AsSignatureAffine, SignatureProjective},
     },
@@ -76,7 +77,7 @@ impl SignatureProjective {
     fn group_prepared_terms<'b>(
         pairs: impl Iterator<Item = (G1Affine, &'b PreparedHashedMessage)>,
         capacity: usize,
-    ) -> (alloc::vec::Vec<G1Affine>, alloc::vec::Vec<&'b G2Prepared>) {
+    ) -> (alloc::vec::Vec<G1Affine>, alloc::vec::Vec<&'b PreparedG2>) {
         let mut entries = alloc::vec::Vec::with_capacity(capacity);
         for (pubkey_affine, prepared) in pairs {
             entries.push((
@@ -363,7 +364,7 @@ impl SignatureProjective {
         }
 
         let aggregate_signature_affine = aggregate_signature.try_as_affine()?;
-        let signature_prepared = G2Prepared::from(aggregate_signature_affine.0);
+        let signature_prepared = PreparedG2::from(aggregate_signature_affine.0);
 
         #[cfg(feature = "std")]
         let neg_g1_generator = &*NEG_G1_GENERATOR_AFFINE;
@@ -391,8 +392,8 @@ impl SignatureProjective {
         }
         terms.push((neg_g1_generator, &signature_prepared));
 
-        let miller_loop_result = Bls12::multi_miller_loop(&terms);
-        (miller_loop_result.final_exponentiation() == Gt::identity())
+        let miller_loop_result = multi_miller_loop(&terms);
+        (miller_loop_result.final_exp() == blst::blst_fp12::default())
             .then_some(())
             .ok_or(BlsError::VerificationFailed)
     }

--- a/bls-signatures/tests/allocation_regression.rs
+++ b/bls-signatures/tests/allocation_regression.rs
@@ -1,0 +1,237 @@
+// Run: cargo test -p solana-bls-signatures --release --test allocation_regression
+// Standalone Cargo test: register this target with harness = false.
+// This keeps libtest activity out of the process-wide allocation counter.
+// Counts successful Rust global-allocator requests through System, not C malloc.
+// Reallocations are separate calls; their full new size contributes to bytes.
+// BLS budgets are upper bounds: reductions pass; tighten after measuring them.
+
+use {
+    solana_bls_signatures::{
+        error::BlsError,
+        hash::{HashedMessage, PreparedHashedMessage},
+        keypair::Keypair,
+        pubkey::VerifySignature,
+        signature::{SignatureAffine, SignatureCompressed},
+    },
+    std::{
+        alloc::{GlobalAlloc, Layout, System},
+        hint::black_box,
+        sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+};
+
+struct CountingAllocator;
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+static COUNTING: AtomicBool = AtomicBool::new(false);
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+static BYTES: AtomicUsize = AtomicUsize::new(0);
+static REALLOCS: AtomicUsize = AtomicUsize::new(0);
+static DEALLOCS: AtomicUsize = AtomicUsize::new(0);
+static FREED_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+// SAFETY: Every request is forwarded unchanged to System. The bookkeeping
+// uses only atomics: it does not allocate, dereference pointers, or unwind.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: The caller supplies the layout required by GlobalAlloc.
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() && COUNTING.load(Ordering::Relaxed) {
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+            BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+        }
+        ptr
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: The caller supplies the layout required by GlobalAlloc.
+        let ptr = unsafe { System.alloc_zeroed(layout) };
+        if !ptr.is_null() && COUNTING.load(Ordering::Relaxed) {
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+            BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+        }
+        ptr
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: Forward the caller's valid allocation and resize request.
+        let new_ptr = unsafe { System.realloc(ptr, layout, new_size) };
+        if !new_ptr.is_null() && COUNTING.load(Ordering::Relaxed) {
+            REALLOCS.fetch_add(1, Ordering::Relaxed);
+            BYTES.fetch_add(new_size, Ordering::Relaxed);
+        }
+        new_ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if COUNTING.load(Ordering::Relaxed) {
+            DEALLOCS.fetch_add(1, Ordering::Relaxed);
+            FREED_BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+        }
+        // SAFETY: Allocations handled by this allocator come from System.
+        unsafe { System.dealloc(ptr, layout) };
+    }
+}
+
+const ITERATIONS: usize = 100;
+const WARMUP: usize = 8;
+
+// These ceilings were measured with blstrs 0.7.1 and blst 0.3.17.
+// Keep the control allocation exact so a disabled counter cannot pass.
+fn check_budget(
+    label: &str,
+    allocs: usize,
+    bytes: usize,
+    reallocs: usize,
+    deallocs: usize,
+    freed_bytes: usize,
+) {
+    let (max_allocs, max_bytes) = match label {
+        "control/empty" | "hash_message" => (0, 0),
+        "control/box64" => (1, 64),
+        "prepare/from_hashed" | "prepare/from_raw" => (1, 19_584),
+        name if name.starts_with("verify/prepared/") => (1, 19_584),
+        name if name.starts_with("verify/raw/")
+            || name.starts_with("verify/pre_hashed/")
+            || name.starts_with("verify/raw_compressed/") =>
+        {
+            (2, 39_168)
+        }
+        _ => panic!("missing allocation budget for {label}"),
+    };
+
+    assert_eq!(reallocs, 0, "unexpected reallocation in {label}");
+    assert_eq!(
+        deallocs, allocs,
+        "unbalanced allocation/free calls in {label}"
+    );
+    assert_eq!(
+        freed_bytes, bytes,
+        "unbalanced allocated/freed bytes in {label}"
+    );
+    assert!(
+        allocs <= max_allocs * ITERATIONS,
+        "{label}: {allocs} allocations exceed the limit of {max_allocs} per operation",
+    );
+    assert!(
+        bytes <= max_bytes * ITERATIONS,
+        "{label}: {bytes} requested bytes exceed the limit of {max_bytes} per operation",
+    );
+
+    if label == "control/box64" {
+        assert_eq!(allocs, ITERATIONS, "allocation counter control failed");
+        assert_eq!(bytes, 64 * ITERATIONS, "byte counter control failed");
+    }
+}
+
+fn measure(label: &str, mut operation: impl FnMut() -> bool) {
+    for _ in 0..WARMUP {
+        assert!(black_box(operation()), "unexpected result in {label}");
+    }
+
+    ALLOCS.store(0, Ordering::Relaxed);
+    BYTES.store(0, Ordering::Relaxed);
+    REALLOCS.store(0, Ordering::Relaxed);
+    DEALLOCS.store(0, Ordering::Relaxed);
+    FREED_BYTES.store(0, Ordering::Relaxed);
+
+    let mut matching_results = 0usize;
+    COUNTING.store(true, Ordering::SeqCst);
+    for _ in 0..ITERATIONS {
+        matching_results += usize::from(black_box(operation()));
+    }
+    COUNTING.store(false, Ordering::SeqCst);
+
+    let allocs = ALLOCS.load(Ordering::Relaxed);
+    let bytes = BYTES.load(Ordering::Relaxed);
+    let reallocs = REALLOCS.load(Ordering::Relaxed);
+    let deallocs = DEALLOCS.load(Ordering::Relaxed);
+    let freed_bytes = FREED_BYTES.load(Ordering::Relaxed);
+
+    assert_eq!(matching_results, ITERATIONS, "unexpected result in {label}");
+    let n = ITERATIONS as f64;
+    println!(
+        "{label:<38} {:>10.2} {:>12.2} {:>10.2} {:>10.2}",
+        allocs as f64 / n,
+        bytes as f64 / n,
+        reallocs as f64 / n,
+        deallocs as f64 / n,
+    );
+    check_budget(label, allocs, bytes, reallocs, deallocs, freed_bytes);
+}
+
+fn main() {
+    // All fixture creation happens while counting is disabled.
+    let keypair = Keypair::derive(&[42u8; 32]).expect("derive fixture key");
+    let message: &[u8] = b"solana-bls-signatures allocation baseline";
+    let valid: SignatureCompressed = keypair.sign(message).into();
+    let wrong: SignatureCompressed = keypair.sign(b"a different message").into();
+    let hashed = HashedMessage::new(message);
+    let prepared = PreparedHashedMessage::from_hashed_message(&hashed);
+
+    println!("allocation regression v1; {ITERATIONS} operations per row; 3 passes");
+    println!("parallel feature enabled: {}", cfg!(feature = "parallel"));
+    println!("raw/pre_hashed/prepared use affine keys and affine signatures.");
+    println!("raw_compressed also decodes the compressed signature each time.");
+    println!("Counts include destruction of temporaries within each operation.");
+
+    for pass in 1..=3 {
+        println!("\npass {pass}");
+        println!(
+            "{:<38} {:>10} {:>12} {:>10} {:>10}",
+            "operation", "alloc/op", "bytes/op", "realloc/op", "free/op",
+        );
+
+        measure("control/empty", || black_box(true));
+        measure("control/box64", || {
+            drop(black_box(Box::new(black_box([0u8; 64]))));
+            true
+        });
+        measure("hash_message", || {
+            black_box(HashedMessage::new(black_box(message)));
+            true
+        });
+        measure("prepare/from_hashed", || {
+            drop(black_box(PreparedHashedMessage::from_hashed_message(
+                black_box(&hashed),
+            )));
+            true
+        });
+        measure("prepare/from_raw", || {
+            drop(black_box(PreparedHashedMessage::new(black_box(message))));
+            true
+        });
+
+        for (status, encoded, expected) in [
+            ("valid", &valid, Ok(())),
+            ("wrong_message", &wrong, Err(BlsError::VerificationFailed)),
+        ] {
+            // Both encodings must decode successfully. The second signature
+            // is a valid group point, signed for a different message.
+            let affine = SignatureAffine::try_from(encoded).expect("decode fixture signature");
+
+            measure(&format!("verify/raw/{status}"), || {
+                black_box(&keypair.public).verify_signature(black_box(&affine), black_box(message))
+                    == expected
+            });
+            measure(&format!("verify/pre_hashed/{status}"), || {
+                black_box(&keypair.public)
+                    .verify_signature_pre_hashed(black_box(&affine), black_box(&hashed))
+                    == expected
+            });
+            measure(&format!("verify/prepared/{status}"), || {
+                black_box(&keypair.public)
+                    .verify_signature_prepared(black_box(&affine), black_box(&prepared))
+                    == expected
+            });
+            measure(&format!("verify/raw_compressed/{status}"), || {
+                black_box(&keypair.public).verify_signature(black_box(encoded), black_box(message))
+                    == expected
+            });
+        }
+    }
+
+    println!("\nAllocation budgets and verification outcomes passed.");
+}

--- a/bls-signatures/tests/allocation_regression.rs
+++ b/bls-signatures/tests/allocation_regression.rs
@@ -89,7 +89,7 @@ fn check_budget(
     freed_bytes: usize,
 ) {
     let (max_allocs, max_bytes) = match label {
-        "control/empty" | "hash_message" => (0, 0),
+        "control/empty" | "control/rayon_join" | "hash_message" => (0, 0),
         "control/box64" => (1, 64),
         "prepare/from_hashed" | "prepare/from_raw" => (1, 19_584),
         name if name.starts_with("verify/prepared/") => (0, 0),
@@ -103,6 +103,12 @@ fn check_budget(
             (0, 0)
         }
         name if name.starts_with("aggregate/prepared/") => (0, 0),
+        name if name.starts_with("par_aggregate/raw/")
+            || name.starts_with("par_aggregate/pre_hashed/") =>
+        {
+            (1, 19_584)
+        }
+        name if name.starts_with("par_aggregate/prepared/") => (0, 0),
         _ => panic!("missing allocation budget for {label}"),
     };
 
@@ -167,6 +173,30 @@ fn measure(label: &str, mut operation: impl FnMut() -> bool) {
 }
 
 fn main() {
+    #[cfg(feature = "parallel")]
+    {
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(2)
+            .build()
+            .expect("build allocation regression pool");
+
+        // Visit every worker, then give the idle pool time to initialize
+        // Rayon's sleep machinery before allocation counting begins.
+        drop(pool.broadcast(|_| ()));
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        // These measurements cover calls made inside the pool.
+        // Allocations on all threads still contribute while counting is enabled.
+        println!("measurement context: worker in a private two-worker Rayon pool");
+        println!("pool warm-up: broadcast completed, followed by a 100 ms caller sleep");
+        pool.install(run_allocation_regression);
+    }
+
+    #[cfg(not(feature = "parallel"))]
+    run_allocation_regression();
+}
+
+fn run_allocation_regression() {
     // All fixture creation happens while counting is disabled.
     let keypair = Keypair::derive(&[42u8; 32]).expect("derive fixture key");
     let message: &[u8] = b"solana-bls-signatures allocation baseline";
@@ -193,6 +223,8 @@ fn main() {
     println!("raw_compressed also decodes the compressed signature each time.");
     println!("Counts include destruction of temporaries within each operation.");
     println!("aggregate rows include aggregation of two affine keys and signatures.");
+    #[cfg(feature = "parallel")]
+    println!("par_aggregate rows call the parallel helpers with the same two inputs.");
 
     for pass in 1..=3 {
         println!("\npass {pass}");
@@ -205,6 +237,11 @@ fn main() {
         measure("control/box64", || {
             drop(black_box(Box::new(black_box([0u8; 64]))));
             true
+        });
+        #[cfg(feature = "parallel")]
+        measure("control/rayon_join", || {
+            let (a, b) = rayon::join(|| black_box(1u8), || black_box(2u8));
+            a == 1 && b == 2
         });
         measure("hash_message", || {
             black_box(HashedMessage::new(black_box(message)));
@@ -278,6 +315,31 @@ fn main() {
                     black_box(&prepared),
                 ) == expected
             });
+
+            #[cfg(feature = "parallel")]
+            {
+                measure(&format!("par_aggregate/raw/{status}"), || {
+                    SignatureProjective::par_verify_aggregate(
+                        black_box(&aggregate_pubkeys),
+                        black_box(signatures),
+                        black_box(message),
+                    ) == expected
+                });
+                measure(&format!("par_aggregate/pre_hashed/{status}"), || {
+                    SignatureProjective::par_verify_aggregate_pre_hashed(
+                        black_box(&aggregate_pubkeys),
+                        black_box(signatures),
+                        black_box(&hashed),
+                    ) == expected
+                });
+                measure(&format!("par_aggregate/prepared/{status}"), || {
+                    SignatureProjective::par_verify_aggregate_prepared(
+                        black_box(&aggregate_pubkeys),
+                        black_box(signatures),
+                        black_box(&prepared),
+                    ) == expected
+                });
+            }
         }
     }
 

--- a/bls-signatures/tests/allocation_regression.rs
+++ b/bls-signatures/tests/allocation_regression.rs
@@ -99,10 +99,8 @@ fn check_budget(
         {
             (0, 0)
         }
-        name if name.starts_with("aggregate/raw/")
-            || name.starts_with("aggregate/pre_hashed/") =>
-        {
-            (1, 19_584)
+        name if name.starts_with("aggregate/raw/") || name.starts_with("aggregate/pre_hashed/") => {
+            (0, 0)
         }
         name if name.starts_with("aggregate/prepared/") => (0, 0),
         _ => panic!("missing allocation budget for {label}"),

--- a/bls-signatures/tests/allocation_regression.rs
+++ b/bls-signatures/tests/allocation_regression.rs
@@ -11,7 +11,7 @@ use {
         hash::{HashedMessage, PreparedHashedMessage},
         keypair::Keypair,
         pubkey::VerifySignature,
-        signature::{SignatureAffine, SignatureCompressed},
+        signature::{SignatureAffine, SignatureCompressed, SignatureProjective},
     },
     std::{
         alloc::{GlobalAlloc, Layout, System},
@@ -78,7 +78,7 @@ unsafe impl GlobalAlloc for CountingAllocator {
 const ITERATIONS: usize = 100;
 const WARMUP: usize = 8;
 
-// These ceilings were measured with blstrs 0.7.1 and blst 0.3.17.
+// Allocation ceilings for blstrs 0.7.1 and blst 0.3.17.
 // Keep the control allocation exact so a disabled counter cannot pass.
 fn check_budget(
     label: &str,
@@ -99,6 +99,12 @@ fn check_budget(
         {
             (0, 0)
         }
+        name if name.starts_with("aggregate/raw/")
+            || name.starts_with("aggregate/pre_hashed/") =>
+        {
+            (1, 19_584)
+        }
+        name if name.starts_with("aggregate/prepared/") => (0, 0),
         _ => panic!("missing allocation budget for {label}"),
     };
 
@@ -171,11 +177,24 @@ fn main() {
     let hashed = HashedMessage::new(message);
     let prepared = PreparedHashedMessage::from_hashed_message(&hashed);
 
+    let other_keypair = Keypair::derive(&[43u8; 32]).expect("derive second aggregate key");
+    let aggregate_pubkeys = [keypair.public, other_keypair.public];
+    let other_signature: SignatureAffine = other_keypair.sign(message).into();
+    let aggregate_valid = [
+        SignatureAffine::try_from(&valid).expect("decode first aggregate signature"),
+        other_signature,
+    ];
+    let aggregate_wrong = [
+        SignatureAffine::try_from(&wrong).expect("decode wrong-message aggregate signature"),
+        other_signature,
+    ];
+
     println!("allocation regression v1; {ITERATIONS} operations per row; 3 passes");
     println!("parallel feature enabled: {}", cfg!(feature = "parallel"));
     println!("raw/pre_hashed/prepared use affine keys and affine signatures.");
     println!("raw_compressed also decodes the compressed signature each time.");
     println!("Counts include destruction of temporaries within each operation.");
+    println!("aggregate rows include aggregation of two affine keys and signatures.");
 
     for pass in 1..=3 {
         println!("\npass {pass}");
@@ -229,6 +248,37 @@ fn main() {
             measure(&format!("verify/raw_compressed/{status}"), || {
                 black_box(&keypair.public).verify_signature(black_box(encoded), black_box(message))
                     == expected
+            });
+        }
+
+        for (status, signatures, expected) in [
+            ("valid", &aggregate_valid, Ok(())),
+            (
+                "wrong_message",
+                &aggregate_wrong,
+                Err(BlsError::VerificationFailed),
+            ),
+        ] {
+            measure(&format!("aggregate/raw/{status}"), || {
+                SignatureProjective::verify_aggregate(
+                    black_box(&aggregate_pubkeys).iter(),
+                    black_box(signatures).iter(),
+                    black_box(message),
+                ) == expected
+            });
+            measure(&format!("aggregate/pre_hashed/{status}"), || {
+                SignatureProjective::verify_aggregate_pre_hashed(
+                    black_box(&aggregate_pubkeys).iter(),
+                    black_box(signatures).iter(),
+                    black_box(&hashed),
+                ) == expected
+            });
+            measure(&format!("aggregate/prepared/{status}"), || {
+                SignatureProjective::verify_aggregate_prepared(
+                    black_box(&aggregate_pubkeys).iter(),
+                    black_box(signatures).iter(),
+                    black_box(&prepared),
+                ) == expected
             });
         }
     }

--- a/bls-signatures/tests/allocation_regression.rs
+++ b/bls-signatures/tests/allocation_regression.rs
@@ -106,7 +106,7 @@ fn check_budget(
         name if name.starts_with("par_aggregate/raw/")
             || name.starts_with("par_aggregate/pre_hashed/") =>
         {
-            (1, 19_584)
+            (0, 0)
         }
         name if name.starts_with("par_aggregate/prepared/") => (0, 0),
         _ => panic!("missing allocation budget for {label}"),

--- a/bls-signatures/tests/allocation_regression.rs
+++ b/bls-signatures/tests/allocation_regression.rs
@@ -97,7 +97,7 @@ fn check_budget(
             || name.starts_with("verify/pre_hashed/")
             || name.starts_with("verify/raw_compressed/") =>
         {
-            (2, 39_168)
+            (0, 0)
         }
         _ => panic!("missing allocation budget for {label}"),
     };

--- a/bls-signatures/tests/allocation_regression.rs
+++ b/bls-signatures/tests/allocation_regression.rs
@@ -121,12 +121,20 @@ fn check_budget(
         freed_bytes, bytes,
         "unbalanced allocated/freed bytes in {label}"
     );
+
+    let allocation_limit = ITERATIONS
+        .checked_mul(max_allocs)
+        .expect("allocation budget overflow");
+    let byte_limit = ITERATIONS
+        .checked_mul(max_bytes)
+        .expect("byte budget overflow");
+
     assert!(
-        allocs <= max_allocs * ITERATIONS,
+        allocs <= allocation_limit,
         "{label}: {allocs} allocations exceed the limit of {max_allocs} per operation",
     );
     assert!(
-        bytes <= max_bytes * ITERATIONS,
+        bytes <= byte_limit,
         "{label}: {bytes} requested bytes exceed the limit of {max_bytes} per operation",
     );
 
@@ -150,7 +158,9 @@ fn measure(label: &str, mut operation: impl FnMut() -> bool) {
     let mut matching_results = 0usize;
     COUNTING.store(true, Ordering::SeqCst);
     for _ in 0..ITERATIONS {
-        matching_results += usize::from(black_box(operation()));
+        matching_results = matching_results
+            .checked_add(usize::from(black_box(operation())))
+            .expect("verification result counter overflow");
     }
     COUNTING.store(false, Ordering::SeqCst);
 

--- a/bls-signatures/tests/allocation_regression.rs
+++ b/bls-signatures/tests/allocation_regression.rs
@@ -92,7 +92,7 @@ fn check_budget(
         "control/empty" | "hash_message" => (0, 0),
         "control/box64" => (1, 64),
         "prepare/from_hashed" | "prepare/from_raw" => (1, 19_584),
-        name if name.starts_with("verify/prepared/") => (1, 19_584),
+        name if name.starts_with("verify/prepared/") => (0, 0),
         name if name.starts_with("verify/raw/")
             || name.starts_with("verify/pre_hashed/")
             || name.starts_with("verify/raw_compressed/") =>

--- a/bls-signatures/tests/prepared_verification.rs
+++ b/bls-signatures/tests/prepared_verification.rs
@@ -1,0 +1,166 @@
+#![cfg(not(target_os = "solana"))]
+
+use solana_bls_signatures::{
+    error::BlsError,
+    hash::{HashedMessage, PreparedHashedMessage},
+    keypair::Keypair,
+    pubkey::VerifySignature,
+    signature::{SignatureAffine, SignatureCompressed, SignatureProjective},
+};
+
+#[test]
+fn reused_and_cloned_preparations_match_direct_verification() {
+    let keypairs = [
+        Keypair::derive(&[42u8; 32]).unwrap(),
+        Keypair::derive(&[43u8; 32]).unwrap(),
+    ];
+    let messages: [&[u8]; 3] = [
+        b"",
+        b"prepared verification regression",
+        b"\x00\xff\x80\x00",
+    ];
+    let hashes = messages.map(HashedMessage::new);
+
+    let originals: Vec<_> = hashes
+        .iter()
+        .map(PreparedHashedMessage::from_hashed_message)
+        .collect();
+    let preparations = originals.clone();
+    drop(originals);
+
+    // Reuse each surviving clone across different keys and signatures.
+    for (signer_index, signer) in keypairs.iter().enumerate() {
+        for (signed_index, message) in messages.iter().enumerate() {
+            let encoded: SignatureCompressed = signer.sign(message).into();
+            let affine = SignatureAffine::try_from(&encoded).unwrap();
+
+            for (verifier_index, verifier) in keypairs.iter().enumerate() {
+                for (checked_index, hashed) in hashes.iter().enumerate() {
+                    let expected = if signer_index == verifier_index
+                        && signed_index == checked_index
+                    {
+                        Ok(())
+                    } else {
+                        Err(BlsError::VerificationFailed)
+                    };
+
+                    assert_eq!(
+                        verifier
+                            .public
+                            .verify_signature_pre_hashed(&encoded, hashed),
+                        expected,
+                        "direct verification",
+                    );
+                    assert_eq!(
+                        verifier.public.verify_signature_prepared(
+                            &encoded,
+                            &preparations[checked_index],
+                        ),
+                        expected,
+                        "prepared verification with compressed signature",
+                    );
+                    assert_eq!(
+                        verifier.public.verify_signature_prepared(
+                            &affine,
+                            &preparations[checked_index],
+                        ),
+                        expected,
+                        "prepared verification with affine signature",
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn prepared_verification_preserves_signature_errors() {
+    let keypair = Keypair::derive(&[44u8; 32]).unwrap();
+    let hashed = HashedMessage::new(b"signature error regression");
+    let prepared = PreparedHashedMessage::from_hashed_message(&hashed);
+
+    let identity: SignatureCompressed = SignatureProjective::identity().into();
+    SignatureAffine::try_from(&identity)
+        .expect("identity signatures must remain decodable");
+
+    let malformed = SignatureCompressed([0u8; 96]);
+    let malformed_error = SignatureAffine::try_from(&malformed)
+        .expect_err("all-zero bytes must not decode as a signature");
+
+    for (label, signature, error) in [
+        ("identity", identity, BlsError::VerificationFailed),
+        ("malformed", malformed, malformed_error),
+    ] {
+        let expected = Err(error);
+
+        assert_eq!(
+            keypair
+                .public
+                .verify_signature_pre_hashed(&signature, &hashed),
+            expected,
+            "{label}: direct verification",
+        );
+        assert_eq!(
+            keypair
+                .public
+                .verify_signature_prepared(&signature, &prepared),
+            expected,
+            "{label}: prepared verification",
+        );
+    }
+}
+
+#[test]
+fn prepared_screening_preserves_duplicate_message_grouping() {
+    let keypairs = [
+        Keypair::derive(&[45u8; 32]).unwrap(),
+        Keypair::derive(&[46u8; 32]).unwrap(),
+        Keypair::derive(&[47u8; 32]).unwrap(),
+    ];
+    let public_keys = [
+        keypairs[0].public,
+        keypairs[1].public,
+        keypairs[2].public,
+    ];
+
+    // Equal messages deliberately occupy nonadjacent positions.
+    let messages: [&[u8]; 3] = [b"shared", b"unique", b"shared"];
+    let signatures = [
+        keypairs[0].sign(messages[0]),
+        keypairs[1].sign(messages[1]),
+        keypairs[2].sign(messages[2]),
+    ];
+    let aggregate_signature =
+        SignatureProjective::aggregate(signatures.iter()).unwrap();
+
+    let wrong_messages: [&[u8]; 3] = [b"shared", b"unique", b"wrong"];
+    for (checked_messages, expected) in [
+        (messages, Ok(())),
+        (wrong_messages, Err(BlsError::VerificationFailed)),
+    ] {
+        let hashes = checked_messages.map(HashedMessage::new);
+        let preparations: Vec<_> = hashes
+            .iter()
+            .map(PreparedHashedMessage::from_hashed_message)
+            .collect();
+
+        assert_eq!(
+            SignatureProjective::verify_distinct_aggregated_pre_hashed(
+                public_keys.iter(),
+                &aggregate_signature,
+                hashes.iter(),
+            ),
+            expected,
+            "pre-hashed aggregate screening",
+        );
+        assert_eq!(
+            SignatureProjective::verify_distinct_aggregated_prepared(
+                public_keys.iter(),
+                &aggregate_signature,
+                preparations.iter(),
+            ),
+            expected,
+            "prepared aggregate screening",
+        );
+    }
+}

--- a/bls-signatures/tests/prepared_verification.rs
+++ b/bls-signatures/tests/prepared_verification.rs
@@ -36,13 +36,12 @@ fn reused_and_cloned_preparations_match_direct_verification() {
 
             for (verifier_index, verifier) in keypairs.iter().enumerate() {
                 for (checked_index, hashed) in hashes.iter().enumerate() {
-                    let expected = if signer_index == verifier_index
-                        && signed_index == checked_index
-                    {
-                        Ok(())
-                    } else {
-                        Err(BlsError::VerificationFailed)
-                    };
+                    let expected =
+                        if signer_index == verifier_index && signed_index == checked_index {
+                            Ok(())
+                        } else {
+                            Err(BlsError::VerificationFailed)
+                        };
 
                     assert_eq!(
                         verifier
@@ -52,18 +51,16 @@ fn reused_and_cloned_preparations_match_direct_verification() {
                         "direct verification",
                     );
                     assert_eq!(
-                        verifier.public.verify_signature_prepared(
-                            &encoded,
-                            &preparations[checked_index],
-                        ),
+                        verifier
+                            .public
+                            .verify_signature_prepared(&encoded, &preparations[checked_index],),
                         expected,
                         "prepared verification with compressed signature",
                     );
                     assert_eq!(
-                        verifier.public.verify_signature_prepared(
-                            &affine,
-                            &preparations[checked_index],
-                        ),
+                        verifier
+                            .public
+                            .verify_signature_prepared(&affine, &preparations[checked_index],),
                         expected,
                         "prepared verification with affine signature",
                     );
@@ -80,8 +77,7 @@ fn prepared_verification_preserves_signature_errors() {
     let prepared = PreparedHashedMessage::from_hashed_message(&hashed);
 
     let identity: SignatureCompressed = SignatureProjective::identity().into();
-    SignatureAffine::try_from(&identity)
-        .expect("identity signatures must remain decodable");
+    SignatureAffine::try_from(&identity).expect("identity signatures must remain decodable");
 
     let malformed = SignatureCompressed([0u8; 96]);
     let malformed_error = SignatureAffine::try_from(&malformed)
@@ -117,11 +113,7 @@ fn prepared_screening_preserves_duplicate_message_grouping() {
         Keypair::derive(&[46u8; 32]).unwrap(),
         Keypair::derive(&[47u8; 32]).unwrap(),
     ];
-    let public_keys = [
-        keypairs[0].public,
-        keypairs[1].public,
-        keypairs[2].public,
-    ];
+    let public_keys = [keypairs[0].public, keypairs[1].public, keypairs[2].public];
 
     // Equal messages deliberately occupy nonadjacent positions.
     let messages: [&[u8]; 3] = [b"shared", b"unique", b"shared"];
@@ -130,8 +122,7 @@ fn prepared_screening_preserves_duplicate_message_grouping() {
         keypairs[1].sign(messages[1]),
         keypairs[2].sign(messages[2]),
     ];
-    let aggregate_signature =
-        SignatureProjective::aggregate(signatures.iter()).unwrap();
+    let aggregate_signature = SignatureProjective::aggregate(signatures.iter()).unwrap();
 
     let wrong_messages: [&[u8]; 3] = [b"shared", b"unique", b"wrong"];
     for (checked_messages, expected) in [


### PR DESCRIPTION
#### Summary of Changes

I made some optimizations to minimize heap allocations. I removed temporary pairing-preparation allocations from single-signature verification and sequential/parallel same-message aggregate verification. I retained reusable message preparations and added correctness tests, allocation counters, and timing benchmarks to check each optimization.

Most of the code line changes are on the test harnesses, not core logic changes.

##### Additional test and benchmark harnesses

[a809da22]: I established the initial allocation budgets with a standalone counter, allocating and nonallocating controls, and valid/wrong-message verification fixtures.
[3ee601f3]: I added Criterion benchmarks that separated hashing and preparation costs from verification of individual signatures.
[d511b810]: I added regression tests for prepared-message reuse, cloning, signature errors, and duplicate-message grouping before changing the preparation storage.
[08162631]: I added sequential same-message aggregate allocation coverage, which exposed one remaining 19,584-byte allocation in the raw and pre-hashed helpers.
[d7fb6a6f]: I added matching sequential aggregate timing benchmarks that included both public-key and signature aggregation.
[78230e7e]: I added parallel aggregate allocation coverage and a Rayon control, using a warmed two-worker pool after tracing intermittent allocations to lazy initialization of Rayon’s sleep machinery.
[233cf7f3]: I added parallel aggregate timing benchmarks that started the clock inside a worker, measuring aggregation and verification while excluding the outer pool-submission overhead.

##### Core logic changes

[f6ae8f52]: Previously, raw and pre-hashed verification created temporary G2 preparation tables for both the hashed message and the signature, costing two heap allocations totaling 39,168 bytes per operation. I replaced those preparations with direct Miller loops and one final exponentiation, and updated the crate’s public-key wrappers to use that path while preserving validation and the public trait’s defaults. The raw, pre-hashed, and compressed-signature cases then measured zero allocations. Pre-hashed latency stayed essentially flat; the small raw and compressed-path gains coincided with a faster unchanged hashing control, so the clearest result was the allocation reduction.
[3e40b4c8]: Previously, prepared verification reused the message table but still built and discarded a 19,584-byte preparation table for every signature. Because blstrs kept its prepared coefficients private, I introduced a crate-private wrapper that owned the coefficients and called the existing blst dependency directly. This let verification reuse the message preparation and compute the signature Miller loop directly, reducing measured verification allocations from one to zero. I also adapted prepared distinct-message screening to the new storage. Prepared verification stayed around 503 µs, while constructing a prepared message continued to allocate its reusable table.
[4550c982]: After the earlier changes, sequential raw and pre-hashed aggregate verification still constructed a PreparedHashedMessage solely to call the prepared aggregate helper. This allocated a 19,584-byte message table for a single verification, even though the direct verification path was already allocation-free. I routed both paths through direct pre-hashed verification after aggregating the public keys and signatures, preserving error-propagation order. Measured allocations fell from one to zero, with no material timing change.
[e9d89d32]: The parallel raw and pre-hashed aggregate helpers also constructed a temporary prepared message before calling the prepared aggregate helper, adding one 19,584-byte allocation per operation. I retained the existing Rayon aggregation and error ordering, then passed the aggregated public key and signature directly to pre-hashed verification. In the warmed two-worker pool, measured allocations fell from one to zero, and the tightened budgets passed all three measurement passes. The timing comparison showed no material latency change.

##### Measured allocation reductions

Operation | Allocations/op: before → after | Requested bytes/op: before → after
-- | -- | --
Single verification: raw, pre-hashed, compressed signature | 2 → 0 | 39,168 → 0
Single verification: prepared message | 1 → 0 | 19,584 → 0
Sequential aggregate: raw and pre-hashed* | 1 → 0 | 19,584 → 0
Parallel aggregate: raw and pre-hashed* | 1 → 0 | 19,584 → 0
Creating a reusable message preparation | 1 → 1 | 19,584 → 19,584

##### Trying the allocation measurements

To try these measurements yourself, run the appropriate command from the workspace root.

Apple Silicon macOS:

```
cargo test \
    --locked \
    --release \
    --target aarch64-apple-darwin \
    -p solana-bls-signatures \
    --no-default-features \
    --features std,parallel \
    --test allocation_regression
```

x86-64 Linux:

```
cargo test \
    --locked \
    --release \
    --target x86_64-unknown-linux-gnu \
    -p solana-bls-signatures \
    --no-default-features \
    --features std,parallel \
    --test allocation_regression
```