### PR TITLE
ci: use tombi for TOML formatting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -300,26 +300,17 @@ jobs:
         run: ./scripts/check-doc.sh
 
   sort:
-    name: Check sorting of crate dependencies
+    name: Check TOML formatting and sorting
     runs-on: ubuntu-latest
     needs: [sanity]
     steps:
       - name: Git Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - name: Setup Environment
-        uses: ./.github/actions/setup
-        with:
-          nightly-toolchain: true
-          cargo-cache-key: cargo-nightly-sort
-          cargo-cache-fallback-key: cargo-nightly
+      - name: Install Tombi
+        uses: tombi-toml/setup-tombi@a440d8b4f102acf7963db4fd2a99ca02e17f88f6 # v1.5.0
 
-      - name: Install cargo-sort
-        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7  # v3.0.7
-        with:
-          tool: cargo-sort@2.1.1
-
-      - name: Check toml ordering
+      - name: Check TOML formatting and sorting
         run: ./scripts/check-sort.sh
 
   check-dcou:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ repository = "https://github.com/anza-xyz/solana-sdk"
 homepage = "https://anza.xyz/"
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.89.0"                          # solana platform-tools rust version
+rust-version = "1.89.0"  # solana platform-tools rust version
 
 [workspace.lints.rust.unexpected_cfgs]
 level = "warn"
@@ -187,7 +187,7 @@ group = "0.13.0"
 hex = "0.4.3"
 hmac = "0.12.1"
 im = "15.1.0"
-imbl = ">= 6.0.0, < 8.0.0" # agave needs v7 for perf, but sdk needs v6 for min rust version 1.81; change to "7.0.0" when sdk >= rust 1.85
+imbl = ">= 6.0.0, < 8.0.0"  # agave needs v7 for perf, but sdk needs v6 for min rust version 1.81; change to "7.0.0" when sdk >= rust 1.85
 indicatif = "0.18.4"
 itertools = "0.12.1"
 js-sys = "0.3.77"
@@ -215,11 +215,11 @@ rand_chacha = "0.9.0"
 rayon = "1.10.0"
 regex = "1.11"
 reqwest = { version = "0.13.2", default-features = false }
-serde = { version = "1.0.226", default-features = false } # must match the serde_derive version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
+serde = { version = "1.0.226", default-features = false }  # must match the serde_derive version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
 serde-big-array = "0.5.1"
 serde_bytes = "0.11.15"
 serde_core = { version = "1.0.226", default-features = false }  # must match the serde version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
-serde_derive = "1.0.226" # must match the serde version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
+serde_derive = "1.0.226"  # must match the serde version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
 serde_json = "1.0.139"
 serde_with = { version = "3.12.0", default-features = false }
 serial_test = "2.0.0"

--- a/bls-signatures/Cargo.toml
+++ b/bls-signatures/Cargo.toml
@@ -47,7 +47,7 @@ blst = { workspace = true }
 blstrs = { workspace = true }
 ff = { workspace = true }
 group = { workspace = true }
-rand = "0.8" # blstrs is still on rand_core v0.6, so pin this for now
+rand = "0.8"  # blstrs is still on rand_core v0.6, so pin this for now
 rayon = { workspace = true, optional = true }
 solana-signature = { workspace = true, optional = true }
 solana-signer = { workspace = true, optional = true }

--- a/keypair/Cargo.toml
+++ b/keypair/Cargo.toml
@@ -20,7 +20,7 @@ seed-derivable = ["dep:solana-derivation-path", "dep:solana-seed-derivable"]
 
 [dependencies]
 five8 = { workspace = true }
-five8_core = { workspace = true } # needed to force five8 to use the newest version with `core::error::Error` support
+five8_core = { workspace = true }  # needed to force five8 to use the newest version with `core::error::Error` support
 rand = { workspace = true }
 solana-address = { workspace = true, features = ["decode"] }
 solana-derivation-path = { workspace = true, optional = true }

--- a/scripts/check-sort.sh
+++ b/scripts/check-sort.sh
@@ -5,4 +5,4 @@ here="$(dirname "$0")"
 src_root="$(readlink -f "${here}/..")"
 cd "${src_root}"
 
-./cargo nightly sort --workspace --check
+tombi format --check --diff

--- a/scripts/cliff.toml
+++ b/scripts/cliff.toml
@@ -16,7 +16,8 @@ body = """
 trim = true
 footer = """
 """
-postprocessors = [ ]
+postprocessors = []
+
 [git]
 # parse the commits based on https://www.conventionalcommits.org
 conventional_commits = true

--- a/secp256k1-program/Cargo.toml
+++ b/secp256k1-program/Cargo.toml
@@ -34,7 +34,7 @@ solana-signature = { workspace = true, features = ["std"] }
 [dev-dependencies]
 anyhow = { workspace = true }
 hex = { workspace = true }
-rand = "0.8" # k256 still uses rand_core v0.6
+rand = "0.8"  # k256 still uses rand_core v0.6
 solana-account-info = { workspace = true }
 solana-example-mocks = { path = "../example-mocks" }
 solana-instruction = { workspace = true }

--- a/secp256k1-recover/Cargo.toml
+++ b/secp256k1-recover/Cargo.toml
@@ -33,7 +33,7 @@ k256 = { workspace = true }
 [dev-dependencies]
 anyhow = { workspace = true }
 borsh = { workspace = true }
-rand = "0.8" # k256 still uses rand_core v0.6
+rand = "0.8"  # k256 still uses rand_core v0.6
 solana-example-mocks = { workspace = true }
 solana-instruction = { workspace = true, features = ["borsh"] }
 solana-keccak-hasher = { workspace = true, features = ["sha3"] }

--- a/tombi.toml
+++ b/tombi.toml
@@ -1,0 +1,33 @@
+toml-version = "v1.1.0"
+
+[format.rules]
+comment-style = "preserve"
+date-time-delimiter = "preserve"
+indent-width = 4
+key-quote-style = "preserve"
+line-width = 200
+string-quote-style = "preserve"
+
+[[schemas]]
+path = "tombi://www.schemastore.org/cargo.json"
+include = ["Cargo.toml", "**/Cargo.toml"]
+
+[schemas.format.rules]
+array-values-order.enabled = false
+table-keys-order.enabled = false
+
+[[schemas.overrides]]
+targets = [
+    "dependencies",
+    "dev-dependencies",
+    "build-dependencies",
+    "workspace.dependencies",
+    "target.*.dependencies",
+    "target.*.dev-dependencies",
+    "target.*.build-dependencies",
+]
+format.rules.table-keys-order = "ascending"
+
+[[schemas.overrides]]
+targets = ["workspace.members"]
+format.rules.array-values-order = "ascending"


### PR DESCRIPTION
Replace cargo-sort with Tombi for TOML formatting and dependency ordering.

Same changes as https://github.com/anza-xyz/agave/pull/15062 and https://github.com/anza-xyz/agave-sdk/pull/62 for this repo.