### PR TITLE
reward-info: add a RewardType for VAT

### DIFF
--- a/reward-info/src/lib.rs
+++ b/reward-info/src/lib.rs
@@ -18,6 +18,9 @@ pub enum RewardType {
     Staking,
     Voting,
     DeactivatedStake,
+    /// The burn associated with the validator admission ticket
+    /// The accompanying RewardInfo will have a negative lamports value
+    VATDebit,
 }
 
 impl fmt::Display for RewardType {
@@ -31,6 +34,7 @@ impl fmt::Display for RewardType {
                 RewardType::Staking => "staking",
                 RewardType::Voting => "voting",
                 RewardType::DeactivatedStake => "deactivated-stake",
+                RewardType::VATDebit => "validator-admission-ticket-debit",
             }
         )
     }


### PR DESCRIPTION
We have no observability around VAT burns.

This adds a new `RewardType` for the VAT for use in https://github.com/anza-xyz/agave/pull/15095