### PR TITLE
[bls-signature] remove foreign types

### DIFF
--- a/bls-signatures/Cargo.toml
+++ b/bls-signatures/Cargo.toml
@@ -56,7 +56,6 @@ subtle = { workspace = true, optional = true }
 [dev-dependencies]
 bincode = { workspace = true }
 criterion = { workspace = true }
-ff = { workspace = true }
 hex = { workspace = true }
 solana-bls-signatures = { path = ".", features = ["std"] }
 solana-keypair = { workspace = true }

--- a/bls-signatures/benches/bls_signatures.rs
+++ b/bls-signatures/benches/bls_signatures.rs
@@ -1,11 +1,10 @@
 use {
-    blstrs::Scalar,
     criterion::{criterion_group, criterion_main, Criterion},
-    ff::Field,
     solana_bls_signatures::{
         hash::{HashedMessage, PreparedHashedMessage},
         keypair::Keypair,
         pubkey::{PopVerified, Pubkey, PubkeyProjective, VerifyPop, VerifySignature},
+        scalar::Scalar,
         signature::{Signature, SignatureAffineUnchecked, SignatureProjective},
     },
     std::hint::black_box,
@@ -47,9 +46,7 @@ fn bench_aggregate(c: &mut Criterion) {
             .collect();
 
         // Generate random scalars for MSM benchmark
-        let scalars: Vec<Scalar> = (0..*num_validators)
-            .map(|_| Scalar::random(&mut rand::thread_rng()))
-            .collect();
+        let scalars: Vec<Scalar> = (0..*num_validators).map(|_| Scalar::random()).collect();
 
         // Benchmark for aggregating multiple signatures
         group.bench_function(format!("{num_validators} signature aggregation"), |b| {

--- a/bls-signatures/benches/bls_signatures.rs
+++ b/bls-signatures/benches/bls_signatures.rs
@@ -63,7 +63,7 @@ fn bench_aggregate(c: &mut Criterion) {
                         .map(|bytes| SignatureAffineUnchecked::try_from(bytes).expect("valid sig"))
                         .collect();
 
-                    let aggregated_proj = SignatureProjective::aggregate_with_scalars(
+                    let aggregated_proj = SignatureProjective::aggregate_with_weights(
                         unchecked_sigs.iter(),
                         scalars.iter(),
                     )

--- a/bls-signatures/src/keypair.rs
+++ b/bls-signatures/src/keypair.rs
@@ -9,9 +9,9 @@ use {
         fs::{self, File, OpenOptions},
         io::{Read, Write},
         path::Path,
+        string::String,
         vec::Vec,
     },
-    zeroize::Zeroizing,
 };
 use {
     crate::{
@@ -25,7 +25,7 @@ use {
         secret_key::{SecretKey, BLS_SECRET_KEY_SIZE},
         signature::{AsSignatureAffine, SignatureProjective},
     },
-    zeroize::{Zeroize, ZeroizeOnDrop},
+    zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing},
 };
 
 /// Size of BLS keypair in bytes
@@ -139,6 +139,20 @@ impl From<&Keypair> for SecretBytes<BLS_KEYPAIR_SIZE> {
     }
 }
 
+/// Converts a keypair into a zeroizing byte buffer.
+///
+/// Prefer the [`SecretBytes`] conversion above, which does not require a direct
+/// dependency on `zeroize`. This impl is retained for backward compatibility.
+impl From<&Keypair> for Zeroizing<[u8; BLS_KEYPAIR_SIZE]> {
+    fn from(keypair: &Keypair) -> Self {
+        let mut bytes = Zeroizing::new([0u8; BLS_KEYPAIR_SIZE]);
+        let secret_bytes: SecretBytes<BLS_SECRET_KEY_SIZE> = (&keypair.secret).into();
+        bytes[..BLS_SECRET_KEY_SIZE].copy_from_slice(secret_bytes.as_slice());
+        bytes[BLS_SECRET_KEY_SIZE..].copy_from_slice(&keypair.public.to_bytes_uncompressed());
+        bytes
+    }
+}
+
 #[cfg(feature = "std")]
 impl Keypair {
     pub fn read_json<R: Read>(reader: &mut R) -> Result<Self, Box<dyn error::Error>> {
@@ -153,7 +167,23 @@ impl Keypair {
         Self::read_json(&mut file)
     }
 
+    #[deprecated(
+        since = "3.5.0",
+        note = "Please use `Keypair::write_json_secret` instead"
+    )]
     pub fn write_json<W: Write>(
+        &self,
+        writer: &mut W,
+    ) -> Result<Zeroizing<String>, Box<dyn error::Error>> {
+        let json = self.write_json_secret(writer)?;
+        Ok(Zeroizing::new(String::from(json.as_str())))
+    }
+
+    /// Writes the keypair as JSON, returning what was written.
+    ///
+    /// The returned string holds raw secret-key material and clears itself on
+    /// drop.
+    pub fn write_json_secret<W: Write>(
         &self,
         writer: &mut W,
     ) -> Result<SecretString, Box<dyn error::Error>> {
@@ -163,7 +193,24 @@ impl Keypair {
         Ok(json)
     }
 
+    #[deprecated(
+        since = "3.5.0",
+        note = "Please use `Keypair::write_json_file_secret` instead"
+    )]
     pub fn write_json_file<F: AsRef<Path>>(
+        &self,
+        outfile: F,
+    ) -> Result<Zeroizing<String>, Box<dyn core::error::Error>> {
+        let json = self.write_json_file_secret(outfile)?;
+        Ok(Zeroizing::new(String::from(json.as_str())))
+    }
+
+    /// Writes the keypair as JSON to a newly created file, returning what was
+    /// written.
+    ///
+    /// On unix the file is created with mode `0o600`. The returned string holds
+    /// raw secret-key material and clears itself on drop.
+    pub fn write_json_file_secret<F: AsRef<Path>>(
         &self,
         outfile: F,
     ) -> Result<SecretString, Box<dyn core::error::Error>> {
@@ -191,7 +238,7 @@ impl Keypair {
         .create_new(true)
         .open(outfile)?;
 
-        self.write_json(&mut f)
+        self.write_json_secret(&mut f)
     }
 }
 
@@ -227,10 +274,38 @@ mod tests {
         let temp_keypair_file = NamedTempFile::new().unwrap();
         let original_keypair = Keypair::new();
         original_keypair
+            .write_json_file_secret(&temp_keypair_file)
+            .unwrap();
+        let read_keypair = Keypair::read_json_file(&temp_keypair_file).unwrap();
+        assert_eq!(original_keypair, read_keypair);
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    #[allow(deprecated)]
+    fn test_keypair_file_deprecated() {
+        let temp_keypair_file = NamedTempFile::new().unwrap();
+        let original_keypair = Keypair::new();
+        let json = original_keypair
             .write_json_file(&temp_keypair_file)
             .unwrap();
         let read_keypair = Keypair::read_json_file(&temp_keypair_file).unwrap();
         assert_eq!(original_keypair, read_keypair);
+
+        // The deprecated writers return the same JSON as their replacements.
+        let mut buffer = Vec::new();
+        let secret_json = original_keypair.write_json_secret(&mut buffer).unwrap();
+        assert_eq!(json.as_str(), secret_json.as_str());
+        assert_eq!(buffer.as_slice(), secret_json.as_bytes());
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn test_keypair_zeroizing_bytes_match_secret_bytes() {
+        let keypair = Keypair::new();
+        let secret_bytes: SecretBytes<BLS_KEYPAIR_SIZE> = (&keypair).into();
+        let zeroizing_bytes: Zeroizing<[u8; BLS_KEYPAIR_SIZE]> = (&keypair).into();
+        assert_eq!(secret_bytes.as_slice(), zeroizing_bytes.as_slice());
     }
 
     #[test]

--- a/bls-signatures/src/keypair.rs
+++ b/bls-signatures/src/keypair.rs
@@ -1,14 +1,17 @@
 #[cfg(feature = "solana-signer-derive")]
 use solana_signer::Signer;
 #[cfg(feature = "std")]
-use std::{
-    boxed::Box,
-    error,
-    fs::{self, File, OpenOptions},
-    io::{Read, Write},
-    path::Path,
-    string::String,
-    vec::Vec,
+use {
+    crate::secret_bytes::SecretString,
+    std::{
+        boxed::Box,
+        error,
+        fs::{self, File, OpenOptions},
+        io::{Read, Write},
+        path::Path,
+        vec::Vec,
+    },
+    zeroize::Zeroizing,
 };
 use {
     crate::{
@@ -18,10 +21,11 @@ use {
             PopVerified, PubkeyAffine, PubkeyProjective, VerifySignature,
             BLS_PUBLIC_KEY_AFFINE_SIZE,
         },
+        secret_bytes::SecretBytes,
         secret_key::{SecretKey, BLS_SECRET_KEY_SIZE},
         signature::{AsSignatureAffine, SignatureProjective},
     },
-    zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing},
+    zeroize::{Zeroize, ZeroizeOnDrop},
 };
 
 /// Size of BLS keypair in bytes
@@ -118,17 +122,17 @@ impl From<&Keypair> for [u8; BLS_KEYPAIR_SIZE] {
         // WARNING: `bytes` contains raw secret-key material. Callers should zeroize the returned
         // buffer as soon as they are done using it.
         let mut bytes = [0u8; BLS_KEYPAIR_SIZE];
-        let secret_bytes: Zeroizing<[u8; BLS_SECRET_KEY_SIZE]> = (&keypair.secret).into();
+        let secret_bytes: SecretBytes<BLS_SECRET_KEY_SIZE> = (&keypair.secret).into();
         bytes[..BLS_SECRET_KEY_SIZE].copy_from_slice(secret_bytes.as_slice());
         bytes[BLS_SECRET_KEY_SIZE..].copy_from_slice(&keypair.public.to_bytes_uncompressed());
         bytes
     }
 }
 
-impl From<&Keypair> for Zeroizing<[u8; BLS_KEYPAIR_SIZE]> {
+impl From<&Keypair> for SecretBytes<BLS_KEYPAIR_SIZE> {
     fn from(keypair: &Keypair) -> Self {
-        let mut bytes = Zeroizing::new([0u8; BLS_KEYPAIR_SIZE]);
-        let secret_bytes: Zeroizing<[u8; BLS_SECRET_KEY_SIZE]> = (&keypair.secret).into();
+        let mut bytes = SecretBytes::<BLS_KEYPAIR_SIZE>::zeroed();
+        let secret_bytes: SecretBytes<BLS_SECRET_KEY_SIZE> = (&keypair.secret).into();
         bytes[..BLS_SECRET_KEY_SIZE].copy_from_slice(secret_bytes.as_slice());
         bytes[BLS_SECRET_KEY_SIZE..].copy_from_slice(&keypair.public.to_bytes_uncompressed());
         bytes
@@ -152,9 +156,9 @@ impl Keypair {
     pub fn write_json<W: Write>(
         &self,
         writer: &mut W,
-    ) -> Result<Zeroizing<String>, Box<dyn error::Error>> {
-        let bytes: Zeroizing<[u8; BLS_KEYPAIR_SIZE]> = self.into();
-        let json = Zeroizing::new(serde_json::to_string(bytes.as_slice())?);
+    ) -> Result<SecretString, Box<dyn error::Error>> {
+        let bytes: SecretBytes<BLS_KEYPAIR_SIZE> = self.into();
+        let json = SecretString::new(serde_json::to_string(bytes.as_slice())?);
         writer.write_all(json.as_bytes())?;
         Ok(json)
     }
@@ -162,7 +166,7 @@ impl Keypair {
     pub fn write_json_file<F: AsRef<Path>>(
         &self,
         outfile: F,
-    ) -> Result<Zeroizing<String>, Box<dyn core::error::Error>> {
+    ) -> Result<SecretString, Box<dyn core::error::Error>> {
         let outfile = outfile.as_ref();
 
         if let Some(outdir) = outfile.parent() {

--- a/bls-signatures/src/lib.rs
+++ b/bls-signatures/src/lib.rs
@@ -17,6 +17,7 @@ pub use crate::{
     pubkey::{
         AsPubkeyProjective, PubkeyAffineUnchecked, PubkeyProjective, VerifyPop, VerifySignature,
     },
+    secret_bytes::{SecretBytes, SecretString},
     secret_key::{SecretKey, BLS_SECRET_KEY_SIZE},
     signature::{
         AsSignatureProjective, SignatureAffineUnchecked, SignatureProjective, VerifiableSignature,
@@ -44,6 +45,8 @@ pub(crate) mod macros;
 pub mod hash;
 pub mod proof_of_possession;
 pub mod pubkey;
+#[cfg(not(target_os = "solana"))]
+pub mod secret_bytes;
 #[cfg(not(target_os = "solana"))]
 pub mod secret_key;
 pub mod signature;

--- a/bls-signatures/src/lib.rs
+++ b/bls-signatures/src/lib.rs
@@ -17,6 +17,7 @@ pub use crate::{
     pubkey::{
         AsPubkeyProjective, PubkeyAffineUnchecked, PubkeyProjective, VerifyPop, VerifySignature,
     },
+    scalar::Scalar,
     secret_bytes::{SecretBytes, SecretString},
     secret_key::{SecretKey, BLS_SECRET_KEY_SIZE},
     signature::{
@@ -45,6 +46,8 @@ pub(crate) mod macros;
 pub mod hash;
 pub mod proof_of_possession;
 pub mod pubkey;
+#[cfg(not(target_os = "solana"))]
+pub mod scalar;
 #[cfg(not(target_os = "solana"))]
 pub mod secret_bytes;
 #[cfg(not(target_os = "solana"))]

--- a/bls-signatures/src/pubkey/aggregate.rs
+++ b/bls-signatures/src/pubkey/aggregate.rs
@@ -6,7 +6,7 @@ use {
         pubkey::points::{AddToPubkeyProjective, AggregatePubkey, PopVerified, PubkeyProjective},
         scalar::Scalar,
     },
-    blstrs::G1Projective,
+    blstrs::{G1Projective, Scalar as BlstrsScalar},
 };
 
 impl PubkeyProjective {
@@ -42,10 +42,33 @@ impl PubkeyProjective {
     }
 
     /// Aggregate a list of Proof-of-Possession verified public keys with scalars.
-    #[allow(clippy::arithmetic_side_effects)]
+    #[deprecated(
+        since = "3.5.0",
+        note = "Please use `PubkeyProjective::aggregate_with_weights` instead, which takes \
+                `solana_bls_signatures::Scalar` rather than `blstrs::Scalar`"
+    )]
     pub fn aggregate_with_scalars<'a, P: AddToPubkeyProjective + ?Sized + 'a>(
         pubkeys: impl ExactSizeIterator<Item = &'a PopVerified<P>>,
-        scalars: impl ExactSizeIterator<Item = &'a Scalar>,
+        scalars: impl ExactSizeIterator<Item = &'a BlstrsScalar>,
+    ) -> Result<AggregatePubkey<PubkeyProjective>, BlsError> {
+        Self::multi_exp(pubkeys, scalars.copied())
+    }
+
+    /// Aggregate a list of Proof-of-Possession verified public keys, each
+    /// weighted by a scalar.
+    pub fn aggregate_with_weights<'a, P: AddToPubkeyProjective + ?Sized + 'a>(
+        pubkeys: impl ExactSizeIterator<Item = &'a PopVerified<P>>,
+        weights: impl ExactSizeIterator<Item = &'a Scalar>,
+    ) -> Result<AggregatePubkey<PubkeyProjective>, BlsError> {
+        Self::multi_exp(pubkeys, weights.map(|weight| weight.0))
+    }
+
+    /// The multi-scalar multiplication shared by [`Self::aggregate_with_weights`]
+    /// and its deprecated `blstrs`-typed counterpart.
+    #[allow(clippy::arithmetic_side_effects)]
+    fn multi_exp<'a, P: AddToPubkeyProjective + ?Sized + 'a>(
+        pubkeys: impl ExactSizeIterator<Item = &'a PopVerified<P>>,
+        scalars: impl ExactSizeIterator<Item = BlstrsScalar>,
     ) -> Result<AggregatePubkey<PubkeyProjective>, BlsError> {
         if pubkeys.len() != scalars.len() {
             return Err(BlsError::InputLengthMismatch);
@@ -63,7 +86,7 @@ impl PubkeyProjective {
             pubkey.0.add_to_accumulator(&mut point)?;
 
             points.push(point.0);
-            scalar_values.push(scalar.0);
+            scalar_values.push(scalar);
         }
 
         Ok(AggregatePubkey(PubkeyProjective(G1Projective::multi_exp(
@@ -121,5 +144,29 @@ impl PubkeyProjective {
         }
 
         Ok(AggregatePubkey(aggregate))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{keypair::Keypair, pubkey::PubkeyProjective, scalar::Scalar};
+
+    #[test]
+    #[allow(deprecated)]
+    fn test_deprecated_aggregate_with_scalars_matches_weights() {
+        let pubkeys = [
+            Keypair::new().public,
+            Keypair::new().public,
+            Keypair::new().public,
+        ];
+        let weights = [Scalar::random(), Scalar::random(), Scalar::random()];
+        let blstrs_weights: alloc::vec::Vec<_> = weights.iter().map(|weight| weight.0).collect();
+
+        let from_weights =
+            PubkeyProjective::aggregate_with_weights(pubkeys.iter(), weights.iter()).unwrap();
+        let from_scalars =
+            PubkeyProjective::aggregate_with_scalars(pubkeys.iter(), blstrs_weights.iter())
+                .unwrap();
+        assert_eq!(from_weights, from_scalars);
     }
 }

--- a/bls-signatures/src/pubkey/aggregate.rs
+++ b/bls-signatures/src/pubkey/aggregate.rs
@@ -4,8 +4,9 @@ use {
     crate::{
         error::BlsError,
         pubkey::points::{AddToPubkeyProjective, AggregatePubkey, PopVerified, PubkeyProjective},
+        scalar::Scalar,
     },
-    blstrs::{G1Projective, Scalar},
+    blstrs::G1Projective,
 };
 
 impl PubkeyProjective {
@@ -62,7 +63,7 @@ impl PubkeyProjective {
             pubkey.0.add_to_accumulator(&mut point)?;
 
             points.push(point.0);
-            scalar_values.push(*scalar);
+            scalar_values.push(scalar.0);
         }
 
         Ok(AggregatePubkey(PubkeyProjective(G1Projective::multi_exp(

--- a/bls-signatures/src/scalar.rs
+++ b/bls-signatures/src/scalar.rs
@@ -1,0 +1,102 @@
+//! Scalar weights for linear combinations of public keys and signatures.
+
+use {blstrs::Scalar as BlstrsScalar, ff::Field, rand::rngs::OsRng};
+
+/// A scalar weight used to form linear combinations of public keys or
+/// signatures, as in [`PubkeyProjective::aggregate_with_scalars`] and
+/// [`SignatureProjective::aggregate_with_scalars`].
+///
+/// This wraps the underlying BLS12-381 scalar field element so that callers do
+/// not need a direct `blstrs` dependency (nor the `ff` and `rand` versions it
+/// happens to be pinned to) in order to build one.
+///
+/// [`PubkeyProjective::aggregate_with_scalars`]: crate::pubkey::PubkeyProjective::aggregate_with_scalars
+/// [`SignatureProjective::aggregate_with_scalars`]: crate::signature::SignatureProjective::aggregate_with_scalars
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Scalar(pub(crate) BlstrsScalar);
+
+impl Scalar {
+    /// The additive identity.
+    pub const ZERO: Self = Self(BlstrsScalar::ZERO);
+
+    /// The multiplicative identity, i.e. an unweighted term.
+    pub const ONE: Self = Self(BlstrsScalar::ONE);
+
+    /// Constructs a uniformly random scalar using `OsRng`.
+    pub fn random() -> Self {
+        let mut rng = OsRng;
+        Self(BlstrsScalar::random(&mut rng))
+    }
+
+    /// Parses a canonical little-endian scalar.
+    ///
+    /// Returns `None` if `bytes` is not a canonical encoding, i.e. if it is not
+    /// less than the field modulus.
+    pub fn from_bytes_le(bytes: &[u8; 32]) -> Option<Self> {
+        Option::<BlstrsScalar>::from(BlstrsScalar::from_bytes_le(bytes)).map(Self)
+    }
+
+    /// Returns the canonical little-endian encoding of this scalar.
+    pub fn to_bytes_le(&self) -> [u8; 32] {
+        self.0.to_bytes_le()
+    }
+}
+
+/// The additive identity, matching [`Scalar::ZERO`].
+impl Default for Scalar {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl From<u64> for Scalar {
+    fn from(value: u64) -> Self {
+        Self(BlstrsScalar::from(value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bytes_roundtrip() {
+        let scalar = Scalar::random();
+        let bytes = scalar.to_bytes_le();
+        assert_eq!(Scalar::from_bytes_le(&bytes), Some(scalar));
+    }
+
+    #[test]
+    fn test_from_bytes_le_rejects_non_canonical() {
+        // The BLS12-381 scalar field modulus, little-endian; the smallest
+        // non-canonical encoding.
+        // r = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001
+        let modulus = [
+            0x01, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xfe, 0x5b, 0xfe, 0xff, 0x02, 0xa4,
+            0xbd, 0x53, 0x05, 0xd8, 0xa1, 0x09, 0x08, 0xd8, 0x39, 0x33, 0x48, 0x7d, 0x9d, 0x29,
+            0x53, 0xa7, 0xed, 0x73,
+        ];
+        assert_eq!(Scalar::from_bytes_le(&modulus), None);
+        // One less than the modulus is canonical.
+        let mut max = modulus;
+        max[0] = 0x00;
+        assert!(Scalar::from_bytes_le(&max).is_some());
+    }
+
+    #[test]
+    fn test_constants_and_from_u64() {
+        assert_eq!(Scalar::from(0u64), Scalar::ZERO);
+        assert_eq!(Scalar::from(1u64), Scalar::ONE);
+        assert_ne!(Scalar::from(7u64), Scalar::ONE);
+    }
+
+    #[test]
+    fn test_default_is_zero() {
+        assert_eq!(Scalar::default(), Scalar::ZERO);
+    }
+
+    #[test]
+    fn test_random_is_random() {
+        assert_ne!(Scalar::random(), Scalar::random());
+    }
+}

--- a/bls-signatures/src/scalar.rs
+++ b/bls-signatures/src/scalar.rs
@@ -1,17 +1,32 @@
 //! Scalar weights for linear combinations of public keys and signatures.
 
-use {blstrs::Scalar as BlstrsScalar, ff::Field, rand::rngs::OsRng};
+// Field arithmetic is modular: it neither overflows nor panics, so the usual
+// concerns behind this lint do not apply to the operator impls below.
+#![allow(clippy::arithmetic_side_effects)]
+
+use {
+    blstrs::Scalar as BlstrsScalar,
+    core::{
+        iter::{Product, Sum},
+        ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
+    },
+    ff::Field,
+    rand::rngs::OsRng,
+};
 
 /// A scalar weight used to form linear combinations of public keys or
-/// signatures, as in [`PubkeyProjective::aggregate_with_scalars`] and
-/// [`SignatureProjective::aggregate_with_scalars`].
+/// signatures, as in [`PubkeyProjective::aggregate_with_weights`] and
+/// [`SignatureProjective::aggregate_with_weights`].
 ///
 /// This wraps the underlying BLS12-381 scalar field element so that callers do
 /// not need a direct `blstrs` dependency (nor the `ff` and `rand` versions it
-/// happens to be pinned to) in order to build one.
+/// happens to be pinned to) in order to build one. The full set of field
+/// operations is available through the standard [`Add`], [`Sub`], [`Mul`] and
+/// [`Neg`] traits (plus their assigning and by-reference forms), so weights can
+/// be derived arithmetically without reaching for `blstrs` either.
 ///
-/// [`PubkeyProjective::aggregate_with_scalars`]: crate::pubkey::PubkeyProjective::aggregate_with_scalars
-/// [`SignatureProjective::aggregate_with_scalars`]: crate::signature::SignatureProjective::aggregate_with_scalars
+/// [`PubkeyProjective::aggregate_with_weights`]: crate::pubkey::PubkeyProjective::aggregate_with_weights
+/// [`SignatureProjective::aggregate_with_weights`]: crate::signature::SignatureProjective::aggregate_with_weights
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Scalar(pub(crate) BlstrsScalar);
 
@@ -40,6 +55,22 @@ impl Scalar {
     pub fn to_bytes_le(&self) -> [u8; 32] {
         self.0.to_bytes_le()
     }
+
+    /// Returns `self + self`.
+    pub fn double(&self) -> Self {
+        Self(self.0.double())
+    }
+
+    /// Returns `self * self`.
+    pub fn square(&self) -> Self {
+        Self(self.0.square())
+    }
+
+    /// Returns the multiplicative inverse of this scalar, or `None` if it is
+    /// [`Scalar::ZERO`].
+    pub fn invert(&self) -> Option<Self> {
+        Option::<BlstrsScalar>::from(self.0.invert()).map(Self)
+    }
 }
 
 /// The additive identity, matching [`Scalar::ZERO`].
@@ -52,6 +83,100 @@ impl Default for Scalar {
 impl From<u64> for Scalar {
     fn from(value: u64) -> Self {
         Self(BlstrsScalar::from(value))
+    }
+}
+
+/// Forwards a binary operator and its assigning form to the wrapped field
+/// element, covering every owned/borrowed combination of operands.
+macro_rules! impl_binop {
+    ($op_trait:ident, $op:ident, $assign_trait:ident, $assign:ident) => {
+        impl $op_trait<Scalar> for Scalar {
+            type Output = Scalar;
+
+            fn $op(self, rhs: Scalar) -> Scalar {
+                Scalar(self.0.$op(rhs.0))
+            }
+        }
+
+        impl $op_trait<&Scalar> for Scalar {
+            type Output = Scalar;
+
+            fn $op(self, rhs: &Scalar) -> Scalar {
+                Scalar(self.0.$op(rhs.0))
+            }
+        }
+
+        impl $op_trait<Scalar> for &Scalar {
+            type Output = Scalar;
+
+            fn $op(self, rhs: Scalar) -> Scalar {
+                Scalar(self.0.$op(rhs.0))
+            }
+        }
+
+        impl $op_trait<&Scalar> for &Scalar {
+            type Output = Scalar;
+
+            fn $op(self, rhs: &Scalar) -> Scalar {
+                Scalar(self.0.$op(rhs.0))
+            }
+        }
+
+        impl $assign_trait<Scalar> for Scalar {
+            fn $assign(&mut self, rhs: Scalar) {
+                self.0.$assign(rhs.0);
+            }
+        }
+
+        impl $assign_trait<&Scalar> for Scalar {
+            fn $assign(&mut self, rhs: &Scalar) {
+                self.0.$assign(rhs.0);
+            }
+        }
+    };
+}
+
+impl_binop!(Add, add, AddAssign, add_assign);
+impl_binop!(Sub, sub, SubAssign, sub_assign);
+impl_binop!(Mul, mul, MulAssign, mul_assign);
+
+impl Neg for Scalar {
+    type Output = Scalar;
+
+    fn neg(self) -> Scalar {
+        Scalar(self.0.neg())
+    }
+}
+
+impl Neg for &Scalar {
+    type Output = Scalar;
+
+    fn neg(self) -> Scalar {
+        Scalar(self.0.neg())
+    }
+}
+
+impl Sum for Scalar {
+    fn sum<I: Iterator<Item = Scalar>>(iter: I) -> Self {
+        iter.fold(Self::ZERO, Add::add)
+    }
+}
+
+impl<'a> Sum<&'a Scalar> for Scalar {
+    fn sum<I: Iterator<Item = &'a Scalar>>(iter: I) -> Self {
+        iter.fold(Self::ZERO, Add::add)
+    }
+}
+
+impl Product for Scalar {
+    fn product<I: Iterator<Item = Scalar>>(iter: I) -> Self {
+        iter.fold(Self::ONE, Mul::mul)
+    }
+}
+
+impl<'a> Product<&'a Scalar> for Scalar {
+    fn product<I: Iterator<Item = &'a Scalar>>(iter: I) -> Self {
+        iter.fold(Self::ONE, Mul::mul)
     }
 }
 
@@ -98,5 +223,60 @@ mod tests {
     #[test]
     fn test_random_is_random() {
         assert_ne!(Scalar::random(), Scalar::random());
+    }
+
+    #[test]
+    fn test_arithmetic() {
+        let two = Scalar::from(2u64);
+        let three = Scalar::from(3u64);
+
+        assert_eq!(two + three, Scalar::from(5u64));
+        assert_eq!(three - two, Scalar::ONE);
+        assert_eq!(two * three, Scalar::from(6u64));
+        assert_eq!(two + (-two), Scalar::ZERO);
+        assert_eq!(two.double(), Scalar::from(4u64));
+        assert_eq!(three.square(), Scalar::from(9u64));
+        assert_eq!(two * two.invert().unwrap(), Scalar::ONE);
+        assert_eq!(Scalar::ZERO.invert(), None);
+    }
+
+    #[test]
+    // The point of this test is to exercise the by-reference operator impls.
+    #[allow(clippy::op_ref)]
+    fn test_arithmetic_by_reference() {
+        let two = Scalar::from(2u64);
+        let three = Scalar::from(3u64);
+        let five = Scalar::from(5u64);
+
+        // Every owned/borrowed combination agrees.
+        assert_eq!(&two + &three, five);
+        assert_eq!(&two + three, five);
+        assert_eq!(two + &three, five);
+        assert_eq!(-&two, -two);
+
+        let mut accumulator = two;
+        accumulator += &three;
+        accumulator -= two;
+        accumulator *= &two;
+        assert_eq!(accumulator, Scalar::from(6u64));
+    }
+
+    #[test]
+    fn test_sum_and_product() {
+        let scalars = [Scalar::from(2u64), Scalar::from(3u64), Scalar::from(4u64)];
+
+        assert_eq!(
+            scalars.iter().sum::<Scalar>(),
+            Scalar::from(9u64) // 2 + 3 + 4
+        );
+        assert_eq!(
+            scalars.into_iter().product::<Scalar>(),
+            Scalar::from(24u64) // 2 * 3 * 4
+        );
+        assert_eq!(core::iter::empty::<Scalar>().sum::<Scalar>(), Scalar::ZERO);
+        assert_eq!(
+            core::iter::empty::<Scalar>().product::<Scalar>(),
+            Scalar::ONE
+        );
     }
 }

--- a/bls-signatures/src/secret_bytes.rs
+++ b/bls-signatures/src/secret_bytes.rs
@@ -1,0 +1,159 @@
+//! Owned containers for secret-key material that clear themselves on drop.
+//!
+//! These stand in for `zeroize::Zeroizing` in this crate's public API. Naming
+//! `Zeroizing` in a return type or trait impl would force every caller to take
+//! a direct dependency on `zeroize` and keep its major version in lockstep with
+//! ours; these crate-owned types keep that dependency an implementation detail
+//! while preserving the clear-on-drop behavior.
+
+use {
+    alloc::string::String,
+    core::{
+        fmt,
+        ops::{Deref, DerefMut},
+    },
+    zeroize::Zeroize,
+};
+
+/// A fixed-size buffer of secret-key material, zeroized on drop.
+///
+/// Dereferences to `[u8; N]`, so it can be passed anywhere the raw buffer is
+/// expected. `Debug` deliberately does not print the contents.
+#[derive(Clone, Eq, PartialEq)]
+pub struct SecretBytes<const N: usize>([u8; N]);
+
+impl<const N: usize> SecretBytes<N> {
+    /// Takes ownership of `bytes`, clearing it when the returned value drops.
+    ///
+    /// `bytes` is moved rather than cleared in place, so only pass a buffer
+    /// that is not retained elsewhere.
+    pub const fn new(bytes: [u8; N]) -> Self {
+        Self(bytes)
+    }
+
+    /// A zeroed buffer, to be filled in place via [`Self::as_mut_slice`].
+    pub const fn zeroed() -> Self {
+        Self([0u8; N])
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        &mut self.0
+    }
+}
+
+impl<const N: usize> Deref for SecretBytes<N> {
+    type Target = [u8; N];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const N: usize> DerefMut for SecretBytes<N> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<const N: usize> AsRef<[u8]> for SecretBytes<N> {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl<const N: usize> fmt::Debug for SecretBytes<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SecretBytes<{N}>(<hidden>)")
+    }
+}
+
+impl<const N: usize> Drop for SecretBytes<N> {
+    fn drop(&mut self) {
+        // `Zeroize for [u8; N]` is a volatile write followed by a compiler
+        // fence, matching the guarantees of `SecretKey::zeroize`.
+        self.0.zeroize();
+    }
+}
+
+/// A `String` holding secret material, zeroized on drop.
+///
+/// Dereferences to `str`. `Debug` deliberately does not print the contents.
+#[derive(Clone, Eq, PartialEq)]
+pub struct SecretString(String);
+
+impl SecretString {
+    /// Takes ownership of `string`, clearing it when the returned value drops.
+    ///
+    /// `string` is moved rather than cleared in place, so only pass a value
+    /// that is not retained elsewhere.
+    pub const fn new(string: String) -> Self {
+        Self(string)
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+impl Deref for SecretString {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<str> for SecretString {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for SecretString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SecretString(<hidden>)")
+    }
+}
+
+impl Drop for SecretString {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, alloc::string::ToString};
+
+    #[test]
+    fn test_secret_bytes_debug_hides_contents() {
+        let bytes = SecretBytes::new([0xabu8; 4]);
+        assert_eq!(alloc::format!("{bytes:?}"), "SecretBytes<4>(<hidden>)");
+    }
+
+    #[test]
+    fn test_secret_bytes_fill_in_place() {
+        let mut bytes = SecretBytes::<4>::zeroed();
+        assert_eq!(bytes.as_slice(), &[0, 0, 0, 0]);
+        bytes.as_mut_slice().copy_from_slice(&[1, 2, 3, 4]);
+        assert_eq!(bytes.as_slice(), &[1, 2, 3, 4]);
+        // Deref reaches the underlying array
+        assert_eq!(*bytes, [1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_secret_string_debug_hides_contents() {
+        let string = SecretString::new("hunter2".to_string());
+        assert_eq!(alloc::format!("{string:?}"), "SecretString(<hidden>)");
+        assert_eq!(string.as_str(), "hunter2");
+        assert_eq!(string.as_bytes(), b"hunter2");
+    }
+}

--- a/bls-signatures/src/secret_bytes.rs
+++ b/bls-signatures/src/secret_bytes.rs
@@ -3,8 +3,8 @@
 //! These stand in for `zeroize::Zeroizing` in this crate's public API. Naming
 //! `Zeroizing` in a return type or trait impl would force every caller to take
 //! a direct dependency on `zeroize` and keep its major version in lockstep with
-//! ours; these crate-owned types keep that dependency an implementation detail
-//! while preserving the clear-on-drop behavior.
+//! ours; these crate-owned types wrap it privately, so the clear-on-drop
+//! behavior is preserved while the dependency stays an implementation detail.
 
 use {
     alloc::string::String,
@@ -12,7 +12,7 @@ use {
         fmt,
         ops::{Deref, DerefMut},
     },
-    zeroize::Zeroize,
+    zeroize::Zeroizing,
 };
 
 /// A fixed-size buffer of secret-key material, zeroized on drop.
@@ -20,28 +20,28 @@ use {
 /// Dereferences to `[u8; N]`, so it can be passed anywhere the raw buffer is
 /// expected. `Debug` deliberately does not print the contents.
 #[derive(Clone, Eq, PartialEq)]
-pub struct SecretBytes<const N: usize>([u8; N]);
+pub struct SecretBytes<const N: usize>(Zeroizing<[u8; N]>);
 
 impl<const N: usize> SecretBytes<N> {
     /// Takes ownership of `bytes`, clearing it when the returned value drops.
     ///
     /// `bytes` is moved rather than cleared in place, so only pass a buffer
     /// that is not retained elsewhere.
-    pub const fn new(bytes: [u8; N]) -> Self {
-        Self(bytes)
+    pub fn new(bytes: [u8; N]) -> Self {
+        Self(Zeroizing::new(bytes))
     }
 
     /// A zeroed buffer, to be filled in place via [`Self::as_mut_slice`].
-    pub const fn zeroed() -> Self {
-        Self([0u8; N])
+    pub fn zeroed() -> Self {
+        Self::new([0u8; N])
     }
 
     pub fn as_slice(&self) -> &[u8] {
-        &self.0
+        &self.0[..]
     }
 
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
-        &mut self.0
+        &mut self.0[..]
     }
 }
 
@@ -61,7 +61,7 @@ impl<const N: usize> DerefMut for SecretBytes<N> {
 
 impl<const N: usize> AsRef<[u8]> for SecretBytes<N> {
     fn as_ref(&self) -> &[u8] {
-        &self.0
+        self.as_slice()
     }
 }
 
@@ -71,27 +71,19 @@ impl<const N: usize> fmt::Debug for SecretBytes<N> {
     }
 }
 
-impl<const N: usize> Drop for SecretBytes<N> {
-    fn drop(&mut self) {
-        // `Zeroize for [u8; N]` is a volatile write followed by a compiler
-        // fence, matching the guarantees of `SecretKey::zeroize`.
-        self.0.zeroize();
-    }
-}
-
 /// A `String` holding secret material, zeroized on drop.
 ///
 /// Dereferences to `str`. `Debug` deliberately does not print the contents.
 #[derive(Clone, Eq, PartialEq)]
-pub struct SecretString(String);
+pub struct SecretString(Zeroizing<String>);
 
 impl SecretString {
     /// Takes ownership of `string`, clearing it when the returned value drops.
     ///
     /// `string` is moved rather than cleared in place, so only pass a value
     /// that is not retained elsewhere.
-    pub const fn new(string: String) -> Self {
-        Self(string)
+    pub fn new(string: String) -> Self {
+        Self(Zeroizing::new(string))
     }
 
     pub fn as_str(&self) -> &str {
@@ -120,12 +112,6 @@ impl AsRef<str> for SecretString {
 impl fmt::Debug for SecretString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SecretString(<hidden>)")
-    }
-}
-
-impl Drop for SecretString {
-    fn drop(&mut self) {
-        self.0.zeroize();
     }
 }
 

--- a/bls-signatures/src/secret_key.rs
+++ b/bls-signatures/src/secret_key.rs
@@ -4,6 +4,7 @@ use {
         hash::{hash_bound_pop_to_projective, hash_message_to_projective},
         proof_of_possession::ProofOfPossessionProjective,
         pubkey::PubkeyProjective,
+        secret_bytes::SecretBytes,
         signature::SignatureProjective,
     },
     blst::{blst_keygen, blst_scalar},
@@ -52,7 +53,7 @@ impl ZeroizeOnDrop for SecretKey {}
 
 impl SecretKey {
     /// Parses a canonical, non-zero secret scalar from little-endian bytes.
-    fn parse_scalar(bytes: &Zeroizing<[u8; BLS_SECRET_KEY_SIZE]>) -> Result<Scalar, BlsError> {
+    fn parse_scalar(bytes: &SecretBytes<BLS_SECRET_KEY_SIZE>) -> Result<Scalar, BlsError> {
         let scalar: Option<Scalar> = Scalar::from_bytes_le(bytes).into();
         let scalar = scalar.ok_or(BlsError::FieldDecode)?;
         if bool::from(scalar.is_zero()) {
@@ -83,7 +84,7 @@ impl SecretKey {
                 0,
             );
         }
-        let bytes = Zeroizing::new(scalar.b);
+        let bytes = SecretBytes::new(scalar.b);
         Self::parse_scalar(&bytes).map(Self)
     }
 
@@ -131,28 +132,31 @@ impl TryFrom<&[u8]> for SecretKey {
         if src.len() != BLS_SECRET_KEY_SIZE {
             return Err(BlsError::ParseFromBytes);
         }
-        let mut bytes = Zeroizing::new([0u8; BLS_SECRET_KEY_SIZE]);
-        bytes.copy_from_slice(src);
+        let mut bytes = SecretBytes::<BLS_SECRET_KEY_SIZE>::zeroed();
+        bytes.as_mut_slice().copy_from_slice(src);
         Self::parse_scalar(&bytes).map(Self)
     }
 }
 
-/// Converts a secret key into a zeroizing little-endian byte buffer.
+/// Converts a secret key into a little-endian byte buffer that is zeroized on
+/// drop.
 ///
 /// If a caller explicitly needs a plain `[u8; BLS_SECRET_KEY_SIZE]`, they can
-/// copy it out of the zeroizing wrapper:
+/// copy it out of the wrapper:
 ///
 /// ```
-/// use zeroize::Zeroizing;
-/// use solana_bls_signatures::secret_key::{SecretKey, BLS_SECRET_KEY_SIZE};
+/// use solana_bls_signatures::{
+///     secret_bytes::SecretBytes,
+///     secret_key::{SecretKey, BLS_SECRET_KEY_SIZE},
+/// };
 ///
 /// let secret_key = SecretKey::new();
-/// let zeroizing_bytes: Zeroizing<[u8; BLS_SECRET_KEY_SIZE]> = (&secret_key).into();
+/// let secret_bytes: SecretBytes<BLS_SECRET_KEY_SIZE> = (&secret_key).into();
 /// let mut raw_bytes = [0u8; BLS_SECRET_KEY_SIZE];
-/// raw_bytes.copy_from_slice(zeroizing_bytes.as_slice());
+/// raw_bytes.copy_from_slice(secret_bytes.as_slice());
 /// ```
-impl From<&SecretKey> for Zeroizing<[u8; BLS_SECRET_KEY_SIZE]> {
+impl From<&SecretKey> for SecretBytes<BLS_SECRET_KEY_SIZE> {
     fn from(secret_key: &SecretKey) -> Self {
-        Zeroizing::new(secret_key.0.to_bytes_le())
+        SecretBytes::new(secret_key.0.to_bytes_le())
     }
 }

--- a/bls-signatures/src/secret_key.rs
+++ b/bls-signatures/src/secret_key.rs
@@ -160,3 +160,13 @@ impl From<&SecretKey> for SecretBytes<BLS_SECRET_KEY_SIZE> {
         SecretBytes::new(secret_key.0.to_bytes_le())
     }
 }
+
+/// Converts a secret key into a zeroizing little-endian byte buffer.
+///
+/// Prefer the [`SecretBytes`] conversion above, which does not require a direct
+/// dependency on `zeroize`. This impl is retained for backward compatibility.
+impl From<&SecretKey> for Zeroizing<[u8; BLS_SECRET_KEY_SIZE]> {
+    fn from(secret_key: &SecretKey) -> Self {
+        Zeroizing::new(secret_key.0.to_bytes_le())
+    }
+}

--- a/bls-signatures/src/signature/aggregate.rs
+++ b/bls-signatures/src/signature/aggregate.rs
@@ -6,7 +6,7 @@ use {
         scalar::Scalar,
         signature::points::{AddToSignatureProjective, SignatureProjective},
     },
-    blstrs::G2Projective,
+    blstrs::{G2Projective, Scalar as BlstrsScalar},
 };
 
 impl SignatureProjective {
@@ -40,10 +40,32 @@ impl SignatureProjective {
     }
 
     // Aggregate a list of signatures and scalar elements using MSM on these signatures
-    #[allow(clippy::arithmetic_side_effects)]
+    #[deprecated(
+        since = "3.5.0",
+        note = "Please use `SignatureProjective::aggregate_with_weights` instead, which takes \
+                `solana_bls_signatures::Scalar` rather than `blstrs::Scalar`"
+    )]
     pub fn aggregate_with_scalars<'a, S: AddToSignatureProjective + ?Sized + 'a>(
         signatures: impl ExactSizeIterator<Item = &'a S>,
-        scalars: impl ExactSizeIterator<Item = &'a Scalar>,
+        scalars: impl ExactSizeIterator<Item = &'a BlstrsScalar>,
+    ) -> Result<SignatureProjective, BlsError> {
+        Self::multi_exp(signatures, scalars.copied())
+    }
+
+    /// Aggregate a list of signatures, each weighted by a scalar, using MSM.
+    pub fn aggregate_with_weights<'a, S: AddToSignatureProjective + ?Sized + 'a>(
+        signatures: impl ExactSizeIterator<Item = &'a S>,
+        weights: impl ExactSizeIterator<Item = &'a Scalar>,
+    ) -> Result<SignatureProjective, BlsError> {
+        Self::multi_exp(signatures, weights.map(|weight| weight.0))
+    }
+
+    /// The multi-scalar multiplication shared by [`Self::aggregate_with_weights`]
+    /// and its deprecated `blstrs`-typed counterpart.
+    #[allow(clippy::arithmetic_side_effects)]
+    fn multi_exp<'a, S: AddToSignatureProjective + ?Sized + 'a>(
+        signatures: impl ExactSizeIterator<Item = &'a S>,
+        scalars: impl ExactSizeIterator<Item = BlstrsScalar>,
     ) -> Result<SignatureProjective, BlsError> {
         if signatures.len() != scalars.len() {
             return Err(BlsError::InputLengthMismatch);
@@ -61,7 +83,7 @@ impl SignatureProjective {
             signature.add_to_accumulator(&mut point)?;
 
             points.push(point.0);
-            scalar_values.push(scalar.0);
+            scalar_values.push(scalar);
         }
 
         Ok(SignatureProjective(G2Projective::multi_exp(
@@ -118,5 +140,30 @@ impl SignatureProjective {
         }
 
         Ok(aggregate)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{keypair::Keypair, scalar::Scalar, signature::SignatureProjective};
+
+    #[test]
+    #[allow(deprecated)]
+    fn test_deprecated_aggregate_with_scalars_matches_weights() {
+        let message = b"test message";
+        let signatures = [
+            Keypair::new().sign(message),
+            Keypair::new().sign(message),
+            Keypair::new().sign(message),
+        ];
+        let weights = [Scalar::random(), Scalar::random(), Scalar::random()];
+        let blstrs_weights: alloc::vec::Vec<_> = weights.iter().map(|weight| weight.0).collect();
+
+        let from_weights =
+            SignatureProjective::aggregate_with_weights(signatures.iter(), weights.iter()).unwrap();
+        let from_scalars =
+            SignatureProjective::aggregate_with_scalars(signatures.iter(), blstrs_weights.iter())
+                .unwrap();
+        assert_eq!(from_weights, from_scalars);
     }
 }

--- a/bls-signatures/src/signature/aggregate.rs
+++ b/bls-signatures/src/signature/aggregate.rs
@@ -3,9 +3,10 @@ use rayon::prelude::*;
 use {
     crate::{
         error::BlsError,
+        scalar::Scalar,
         signature::points::{AddToSignatureProjective, SignatureProjective},
     },
-    blstrs::{G2Projective, Scalar},
+    blstrs::G2Projective,
 };
 
 impl SignatureProjective {
@@ -60,7 +61,7 @@ impl SignatureProjective {
             signature.add_to_accumulator(&mut point)?;
 
             points.push(point.0);
-            scalar_values.push(*scalar);
+            scalar_values.push(scalar.0);
         }
 
         Ok(SignatureProjective(G2Projective::multi_exp(


### PR DESCRIPTION
this PR removes the foreign types that were use in bls-signature crate
- e9fd489d24d6272e06b77ad82eff546c5bec87a2 wraps the `zeroized` types
- 4dacca187f73f18b67fb6933cdc2f82b080b494a wraps `blstrs::Scalar`