### PR TITLE
ci(tombi): use toml version 1.0.0

### DIFF
--- a/tombi.toml
+++ b/tombi.toml
@@ -1,5 +1,3 @@
-toml-version = "v1.1.0"
-
 [format.rules]
 comment-style = "preserve"
 date-time-delimiter = "preserve"
@@ -9,6 +7,7 @@ line-width = 200
 string-quote-style = "preserve"
 
 [[schemas]]
+toml-version = "v1.0.0"
 path = "tombi://www.schemastore.org/cargo.json"
 include = ["Cargo.toml", "**/Cargo.toml"]
 


### PR DESCRIPTION
toml version 1.1.0 is only supported since cargo 1.94.0 which is higher than the current MSRV.

Tombi could cause formatting of toml files that would be unparseable for current msrv.