### PR TITLE
ci: use hash-pinned versions for github actions deps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -362,7 +362,7 @@ jobs:
           echo "SOLANA_VERSION=$solana_version" >> $GITHUB_ENV
 
       - name: Install Solana CLI
-        uses: solana-program/actions/install-solana@v1
+        uses: solana-program/actions/install-solana@35ada2e9a5e7d83c1321903810b2f73c2787abb2  # v1
         with:
           version: ${{ env.SOLANA_VERSION }}
           cache: true

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: 0 # full history to check for whitespace / conflict markers
 
       - name: Summarise workflow inputs
-        uses: solana-program/actions/workflow-inputs@v1
+        uses: solana-program/actions/workflow-inputs@35ada2e9a5e7d83c1321903810b2f73c2787abb2  # v1
 
       - name: Setup Environment
         uses: ./.github/actions/setup


### PR DESCRIPTION
#### Summary of Changes

let's use hash-pinned versions for github actions deps 🫡