### PR TITLE
scripts: Allow for self-dependency in order script

### DIFF
--- a/scripts/order-crates-for-publishing.py
+++ b/scripts/order-crates-for-publishing.py
@@ -80,6 +80,21 @@ def is_self_dev_dep_with_dev_context_only_utils(package, dependency, wrong_self_
     return is_special_cased
 
 
+# When using the semver trick to make version X compatible with version X + 1,
+# we add a self-dependency on a different major version.
+# This is totally fine from a publishing perspective.
+def is_self_dep_with_different_major(package, dependency):
+    no_explicit_version = '*'
+
+    is_special_cased = False
+    if (dependency['name'] == package['name'] and
+        dependency['req'] != no_explicit_version and
+        dependency['req'].lstrip('^~>=<')[0] != package['version'][0]):
+        is_special_cased = True
+
+    return is_special_cased
+
+
 # `cargo publish` is fine with circular dev-dependencies if
 # they are path deps.
 # However, cargo still fails if deps are path deps with versions
@@ -102,10 +117,12 @@ def should_add(package, dependency, wrong_self_dev_dependencies):
     self_dev_dep_with_dev_context_only_utils = is_self_dev_dep_with_dev_context_only_utils(
         package, dependency, wrong_self_dev_dependencies
     )
+    self_dep_with_different_major = is_self_dep_with_different_major(package, dependency)
     return (
         related_to_solana
         and not self_dev_dep_with_dev_context_only_utils
         and not is_path_dev_dep(dependency)
+        and not self_dep_with_different_major
     )
 
 def get_packages():


### PR DESCRIPTION
#### Problem

When we did the backports in the previous branch, there was an issue in the ordering script, but we never added it to master.

#### Summary of changes

Add the changes from #418 to master too.