### PR TITLE
(Backport v4) clock: Semver-trick to newest clock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3140,7 +3140,7 @@ dependencies = [
  "serde_derive",
  "solana-account",
  "solana-account-info",
- "solana-clock",
+ "solana-clock 3.2.0",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-instruction-error",
@@ -3215,7 +3215,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-address-lookup-table-interface",
- "solana-clock",
+ "solana-clock 3.2.0",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-hash",
@@ -3372,14 +3372,22 @@ dependencies = [
 name = "solana-clock"
 version = "3.2.0"
 dependencies = [
+ "solana-clock 4.0.0",
+ "static_assertions",
+]
+
+[[package]]
+name = "solana-clock"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "178fc0c31655aa16190cc112919dcdf279437e14b2f2f9790fe1ec29157ff20c"
+dependencies = [
  "serde",
  "serde_derive",
- "solana-clock",
  "solana-get-sysvar",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
- "static_assertions",
  "wincode",
 ]
 
@@ -3527,7 +3535,7 @@ version = "3.3.0"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-clock",
+ "solana-clock 3.2.0",
  "solana-epoch-schedule",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
@@ -3590,7 +3598,7 @@ dependencies = [
  "log",
  "serde",
  "serde_derive",
- "solana-clock",
+ "solana-clock 3.2.0",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "static_assertions",
@@ -3662,7 +3670,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-account",
- "solana-clock",
+ "solana-clock 3.2.0",
  "solana-cluster-type",
  "solana-epoch-schedule",
  "solana-fee-calculator",
@@ -4041,7 +4049,7 @@ version = "3.1.0"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-clock",
+ "solana-clock 3.2.0",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "static_assertions",
@@ -4082,7 +4090,7 @@ dependencies = [
  "solana-big-mod-exp",
  "solana-blake3-hasher",
  "solana-borsh",
- "solana-clock",
+ "solana-clock 3.2.0",
  "solana-cpi",
  "solana-define-syscall",
  "solana-epoch-rewards",
@@ -4196,7 +4204,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_derive",
- "solana-clock",
+ "solana-clock 3.2.0",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-get-sysvar",
@@ -4552,7 +4560,7 @@ dependencies = [
  "bincode",
  "serde",
  "serde_derive",
- "solana-clock",
+ "solana-clock 3.2.0",
  "solana-example-mocks",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
@@ -4645,7 +4653,7 @@ dependencies = [
  "serde_derive",
  "serial_test",
  "solana-account-info",
- "solana-clock",
+ "solana-clock 3.2.0",
  "solana-define-syscall",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
@@ -4756,7 +4764,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_with",
- "solana-clock",
+ "solana-clock 3.2.0",
  "solana-epoch-schedule",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -369,5 +369,11 @@ opt-level = 1
 opt-level = 1
 
 [patch.crates-io]
+solana-address = { path = "address" }
 solana-define-syscall = { path = "define-syscall" }
+solana-get-sysvar = { path = "get-sysvar" }
+solana-program-error = { path = "program-error" }
 solana-pubkey = { path = "pubkey" }
+solana-sdk-ids = { path = "sdk-ids" }
+solana-sdk-macro = { path = "sdk-macro" }
+solana-sysvar-id = { path = "sysvar-id" }

--- a/clock/Cargo.toml
+++ b/clock/Cargo.toml
@@ -9,25 +9,29 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.cargo-semver-checks.lints]
+# cargo-semver-checks performs checks on the exported symbol graph, so re-exports
+# are considered different elements and they will be flagged as breaking changes
+# even if the public API is equivalent.
+declarative_macro_missing = "allow"
+enum_missing = "allow"
+function_missing = "allow"
+module_missing = "allow"
+pub_module_level_const_missing = "allow"
+struct_missing = "allow"
+
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
 [features]
-serde = ["dep:serde", "dep:serde_derive"]
-sysvar = ["dep:solana-get-sysvar", "dep:solana-sdk-ids", "dep:solana-sysvar-id"]
-wincode = ["dep:wincode"]
+serde = ["solana-clock-v4/serde"]
+sysvar = ["solana-clock-v4/sysvar"]
+wincode = ["solana-clock-v4/wincode"]
 
 [dependencies]
-serde = { workspace = true, optional = true }
-serde_derive = { workspace = true, optional = true }
-solana-get-sysvar = { workspace = true, optional = true }
-solana-sdk-ids = { workspace = true, optional = true }
-solana-sdk-macro = { workspace = true }
-solana-sysvar-id = { workspace = true, optional = true }
-wincode = { workspace = true, optional = true }
+solana-clock-v4 = { package = "solana-clock", version = "4.0.0" }
 
 [dev-dependencies]
-solana-clock = { path = ".", features = ["sysvar", "wincode"] }
 static_assertions = { workspace = true }

--- a/clock/src/lib.rs
+++ b/clock/src/lib.rs
@@ -25,10 +25,6 @@
 #[cfg(feature = "sysvar")]
 pub mod sysvar;
 
-#[cfg(feature = "serde")]
-use serde_derive::{Deserialize, Serialize};
-use solana_sdk_macro::CloneZeroed;
-
 /// The default tick rate that the cluster attempts to achieve (160 per second).
 ///
 /// Note that the actual tick rate at any given time should be expected to drift.
@@ -111,92 +107,8 @@ pub const MAX_TRANSACTION_FORWARDING_DELAY: usize = 6;
 pub const FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET: u64 = 2;
 pub const HOLD_TRANSACTIONS_SLOT_OFFSET: u64 = 20;
 
-/// The unit of time given to a leader for encoding a block.
-///
-/// It is some number of _ticks_ long.
-pub type Slot = u64;
-
-/// Uniquely distinguishes every version of a slot.
-///
-/// The `BankId` is unique even if the slot number of two different slots is the
-/// same. This can happen in the case of e.g. duplicate slots.
-pub type BankId = u64;
-
-/// The unit of time a given leader schedule is honored.
-///
-/// It lasts for some number of [`Slot`]s.
-pub type Epoch = u64;
-
 pub const GENESIS_EPOCH: Epoch = 0;
 // must be sync with Account::rent_epoch::default()
 pub const INITIAL_RENT_EPOCH: Epoch = 0;
 
-/// An index to the slots of a epoch.
-pub type SlotIndex = u64;
-
-/// The number of slots in a epoch.
-pub type SlotCount = u64;
-
-/// An approximate measure of real-world time.
-///
-/// Expressed as Unix time (i.e. seconds since the Unix epoch).
-pub type UnixTimestamp = i64;
-
-/// A representation of network time.
-///
-/// All members of `Clock` start from 0 upon network boot.
-#[repr(C)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "wincode", derive(wincode::SchemaWrite, wincode::SchemaRead))]
-#[derive(Debug, CloneZeroed, Default, PartialEq, Eq)]
-pub struct Clock {
-    /// The current `Slot`.
-    pub slot: Slot,
-    /// The timestamp of the first `Slot` in this `Epoch`.
-    pub epoch_start_timestamp: UnixTimestamp,
-    /// The current `Epoch`.
-    pub epoch: Epoch,
-    /// The future `Epoch` for which the leader schedule has
-    /// most recently been calculated.
-    pub leader_schedule_epoch: Epoch,
-    /// The approximate real world time of the current slot.
-    ///
-    /// This value was originally computed from genesis creation time and
-    /// network time in slots, incurring a lot of drift. Following activation of
-    /// the [`timestamp_correction` and `timestamp_bounding`][tsc] features it
-    /// is calculated using a [validator timestamp oracle][oracle].
-    ///
-    /// [tsc]: https://docs.solanalabs.com/implemented-proposals/bank-timestamp-correction
-    /// [oracle]: https://docs.solanalabs.com/implemented-proposals/validator-timestamp-oracle
-    pub unix_timestamp: UnixTimestamp,
-}
-
-/// Serialized size of the `Clock` sysvar account.
-pub const SIZE: usize = size_of::<Clock>();
-const _: () = assert!(SIZE == 40);
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_size_of() {
-        assert_eq!(
-            wincode::serialized_size(&Clock::default()).unwrap() as usize,
-            SIZE,
-        );
-    }
-
-    #[test]
-    fn test_clone() {
-        let clock = Clock {
-            slot: 1,
-            epoch_start_timestamp: 2,
-            epoch: 3,
-            leader_schedule_epoch: 4,
-            unix_timestamp: 5,
-        };
-        let cloned_clock = clock.clone();
-        assert_eq!(cloned_clock, clock);
-    }
-}
+pub use solana_clock_v4::{BankId, Clock, Epoch, Slot, SlotCount, SlotIndex, UnixTimestamp, SIZE};

--- a/clock/src/sysvar.rs
+++ b/clock/src/sysvar.rs
@@ -1,12 +1,1 @@
-pub use solana_sdk_ids::sysvar::clock::{check_id, id, ID};
-use {
-    crate::Clock,
-    solana_get_sysvar::{impl_get_sysvar, GetSysvar},
-    solana_sysvar_id::impl_sysvar_id,
-};
-
-impl_sysvar_id!(Clock);
-
-impl GetSysvar for Clock {
-    impl_get_sysvar!(ID);
-}
+pub use solana_clock_v4::sysvar::*;


### PR DESCRIPTION
#### Problem

There was a breaking release to the clock crate, but it was just constants.

#### Summary of changes

Use the semver trick to re-export the newest version of the struct, but keep all of the previous constants

~~NOTE: builds on https://github.com/anza-xyz/solana-sdk/pull/942~~ All ready now!