### PR TITLE
[bls-signatures] Reduce allocations in BLS proof-of-possession hashing and verification

### DIFF
--- a/bls-signatures/benches/verification_paths.rs
+++ b/bls-signatures/benches/verification_paths.rs
@@ -6,15 +6,18 @@ use {
     criterion::{criterion_group, criterion_main, Criterion},
     solana_bls_signatures::{
         error::BlsError,
-        hash::{HashedMessage, PreparedHashedMessage},
+        hash::{HashedMessage, HashedPoPPayload, PreparedHashedMessage},
         keypair::Keypair,
-        pubkey::VerifySignature,
+        proof_of_possession::ProofOfPossessionAffine,
+        pubkey::{VerifyPop, VerifySignature},
         signature::{SignatureAffine, SignatureCompressed, SignatureProjective},
     },
     std::{hint::black_box, time::Duration},
 };
 
 fn verification_paths(c: &mut Criterion) {
+    proof_of_possession_paths(c);
+
     #[cfg(feature = "parallel")]
     parallel_aggregate_paths(c);
 
@@ -305,6 +308,67 @@ fn parallel_aggregate_paths(c: &mut Criterion) {
                 })
             });
         });
+    }
+
+    group.finish();
+}
+
+fn proof_of_possession_paths(c: &mut Criterion) {
+    // Match the allocation regression fixtures and keep setup outside timing.
+    let keypair = Keypair::derive(&[42u8; 32]).expect("derive PoP fixture key");
+    let other_keypair = Keypair::derive(&[43u8; 32]).expect("derive other PoP key");
+    let pubkey = *keypair.public;
+    let pubkey_bytes = pubkey.to_bytes_compressed();
+    let custom_payload: &[u8] = b"solana-pop-alloc";
+    let mut group = c.benchmark_group("bls_pop");
+
+    for (mode, payload) in [("standard", None), ("custom", Some(custom_payload))] {
+        let payload_bytes = payload.unwrap_or(&[]);
+        let hashed = HashedPoPPayload::new(payload_bytes, &pubkey_bytes);
+        let valid: ProofOfPossessionAffine = keypair.proof_of_possession(payload).into();
+        let wrong: ProofOfPossessionAffine = other_keypair.proof_of_possession(payload).into();
+
+        group.bench_function(format!("hash/{mode}"), |b| {
+            b.iter(|| {
+                black_box(HashedPoPPayload::new(
+                    black_box(payload_bytes),
+                    black_box(&pubkey_bytes),
+                ))
+            });
+        });
+
+        for (status, proof, expected) in [
+            ("valid", &valid, Ok(())),
+            ("wrong_key", &wrong, Err(BlsError::VerificationFailed)),
+        ] {
+            assert_eq!(
+                pubkey.verify_proof_of_possession(proof, payload),
+                expected,
+                "pop/raw/{mode}/{status}",
+            );
+            assert_eq!(
+                pubkey.verify_proof_of_possession_pre_hashed(proof, &hashed),
+                expected,
+                "pop/pre_hashed/{mode}/{status}",
+            );
+
+            group.bench_function(format!("raw/{mode}/{status}"), |b| {
+                b.iter(|| {
+                    black_box(
+                        black_box(&pubkey)
+                            .verify_proof_of_possession(black_box(proof), black_box(payload)),
+                    )
+                });
+            });
+            group.bench_function(format!("pre_hashed/{mode}/{status}"), |b| {
+                b.iter(|| {
+                    black_box(black_box(&pubkey).verify_proof_of_possession_pre_hashed(
+                        black_box(proof),
+                        black_box(&hashed),
+                    ))
+                });
+            });
+        }
     }
 
     group.finish();

--- a/bls-signatures/src/hash.rs
+++ b/bls-signatures/src/hash.rs
@@ -1,6 +1,5 @@
 use {
     crate::{prepared_g2::PreparedG2, proof_of_possession::POP_DST},
-    alloc::vec::Vec,
     blstrs::{G2Affine, G2Projective},
 };
 
@@ -74,14 +73,47 @@ pub(crate) fn hash_message_to_projective(message: &[u8]) -> G2Projective {
     G2Projective::hash_to_curve(message, HASH_TO_POINT_DST, &[])
 }
 
+#[cfg(test)]
 pub(crate) fn hash_pop_to_projective(payload: &[u8]) -> G2Projective {
     G2Projective::hash_to_curve(payload, POP_DST, &[])
 }
 
 pub(crate) fn hash_bound_pop_to_projective(payload: &[u8], pubkey_bytes: &[u8]) -> G2Projective {
-    let capacity = payload.len().saturating_add(pubkey_bytes.len());
-    let mut bound_payload = Vec::with_capacity(capacity);
-    bound_payload.extend_from_slice(payload);
-    bound_payload.extend_from_slice(pubkey_bytes);
-    hash_pop_to_projective(&bound_payload)
+    // blst hashes augmentation before the message, preserving
+    // H(payload || pubkey_bytes) under POP_DST without a temporary buffer.
+    G2Projective::hash_to_curve(pubkey_bytes, POP_DST, payload)
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, alloc::vec::Vec};
+
+    #[test]
+    fn test_pop_hash_matches_concatenated_input() {
+        for payload_len in [0, 1, 15, 16, 17, 63, 64, 65, 127, 128, 129, 1024] {
+            let payload: Vec<u8> = [0x00, 0x7f, 0x80, 0xff]
+                .into_iter()
+                .cycle()
+                .take(payload_len)
+                .collect();
+            for pubkey_len in [0, 1, 48, 96] {
+                let pubkey_bytes: Vec<u8> = [0xa5, 0x00, 0xff, 0x19]
+                    .into_iter()
+                    .cycle()
+                    .take(pubkey_len)
+                    .collect();
+
+                // Reproduce the old input construction independently.
+                let mut joined = payload.clone();
+                joined.extend_from_slice(&pubkey_bytes);
+                let expected = G2Projective::hash_to_curve(&joined, POP_DST, &[]);
+                let actual = HashedPoPPayload::new(&payload, &pubkey_bytes);
+                assert_eq!(
+                    actual.0,
+                    G2Affine::from(expected),
+                    "payload_len={payload_len}, pubkey_len={pubkey_len}"
+                );
+            }
+        }
+    }
 }

--- a/bls-signatures/src/pubkey/verify.rs
+++ b/bls-signatures/src/pubkey/verify.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "std")]
-use {blstrs::G1Projective, group::Group, std::sync::LazyLock};
 use {
     crate::{
         error::BlsError,
@@ -12,6 +10,8 @@ use {
     blstrs::G1Affine,
     group::prime::PrimeCurveAffine,
 };
+#[cfg(feature = "std")]
+use {blstrs::G1Projective, group::Group, std::sync::LazyLock};
 
 #[cfg(feature = "std")]
 pub(crate) static NEG_G1_GENERATOR_AFFINE: LazyLock<G1Affine> =
@@ -163,8 +163,7 @@ impl PubkeyAffine {
         let generator = G1Affine::generator();
         let payload_pairing =
             blst::blst_fp12::miller_loop(hashed_payload.0.as_ref(), self.0.as_ref());
-        let proof_pairing =
-            blst::blst_fp12::miller_loop(proof.0.as_ref(), generator.as_ref());
+        let proof_pairing = blst::blst_fp12::miller_loop(proof.0.as_ref(), generator.as_ref());
 
         // Compare the pairings using one final exponentiation.
         blst::blst_fp12::finalverify(&payload_pairing, &proof_pairing)

--- a/bls-signatures/src/pubkey/verify.rs
+++ b/bls-signatures/src/pubkey/verify.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "std")]
-use std::sync::LazyLock;
+use {blstrs::G1Projective, group::Group, std::sync::LazyLock};
 use {
     crate::{
         error::BlsError,
@@ -9,9 +9,8 @@ use {
         pubkey::points::{AsPubkeyAffine, PopVerified, PubkeyAffine},
         signature::{AsSignatureAffine, SignatureAffine},
     },
-    blstrs::{Bls12, G1Affine, G1Projective, G2Prepared, Gt},
-    group::{prime::PrimeCurveAffine, Group},
-    pairing::{MillerLoopResult, MultiMillerLoop},
+    blstrs::G1Affine,
+    group::prime::PrimeCurveAffine,
 };
 
 #[cfg(feature = "std")]
@@ -159,27 +158,15 @@ impl PubkeyAffine {
             return false;
         }
 
-        // The verification equation is e(pubkey, H(pubkey)) == e(g1, proof).
-        // This is rewritten to e(pubkey, H(pubkey)) * e(-g1, proof) = 1 for batching.
-        let hashed_pubkey = hashed_payload.0;
-        let hashed_pubkey_prepared = G2Prepared::from(hashed_pubkey);
-        let proof_prepared = G2Prepared::from(proof.0);
+        // Check e(pubkey, H(payload || pubkey_bytes)) = e(g1, proof)
+        // without preparing either G2 point.
+        let generator = G1Affine::generator();
+        let payload_pairing =
+            blst::blst_fp12::miller_loop(hashed_payload.0.as_ref(), self.0.as_ref());
+        let proof_pairing =
+            blst::blst_fp12::miller_loop(proof.0.as_ref(), generator.as_ref());
 
-        // Use the static value if std is available, otherwise compute it
-        #[cfg(feature = "std")]
-        let neg_g1_generator = &*NEG_G1_GENERATOR_AFFINE;
-        #[cfg(not(feature = "std"))]
-        #[allow(clippy::arithmetic_side_effects)]
-        let neg_g1_generator_val: G1Affine = (-G1Projective::generator()).into();
-        #[cfg(not(feature = "std"))]
-        let neg_g1_generator = &neg_g1_generator_val;
-
-        let miller_loop_result = Bls12::multi_miller_loop(&[
-            (&self.0, &hashed_pubkey_prepared),
-            // Reuse the same pre-computed static value here for efficiency
-            (neg_g1_generator, &proof_prepared),
-        ]);
-
-        miller_loop_result.final_exponentiation() == Gt::identity()
+        // Compare the pairings using one final exponentiation.
+        blst::blst_fp12::finalverify(&payload_pairing, &proof_pairing)
     }
 }

--- a/bls-signatures/tests/allocation_regression.rs
+++ b/bls-signatures/tests/allocation_regression.rs
@@ -8,9 +8,10 @@
 use {
     solana_bls_signatures::{
         error::BlsError,
-        hash::{HashedMessage, PreparedHashedMessage},
+        hash::{HashedMessage, HashedPoPPayload, PreparedHashedMessage},
         keypair::Keypair,
-        pubkey::VerifySignature,
+        proof_of_possession::ProofOfPossessionAffine,
+        pubkey::{VerifyPop, VerifySignature},
         signature::{SignatureAffine, SignatureCompressed, SignatureProjective},
     },
     std::{
@@ -109,6 +110,12 @@ fn check_budget(
             (0, 0)
         }
         name if name.starts_with("par_aggregate/prepared/") => (0, 0),
+        // PoP hashing streams the payload and public key without a temporary buffer.
+        "hash_pop/standard" => (0, 0),
+        "hash_pop/custom" => (0, 0),
+        name if name.starts_with("pop/raw/standard/") => (0, 0),
+        name if name.starts_with("pop/raw/custom/") => (0, 0),
+        name if name.starts_with("pop/pre_hashed/") => (0, 0),
         _ => panic!("missing allocation budget for {label}"),
     };
 
@@ -268,6 +275,8 @@ fn run_allocation_regression() {
             true
         });
 
+        measure_pop_paths(&keypair, &other_keypair);
+
         for (status, encoded, expected) in [
             ("valid", &valid, Ok(())),
             ("wrong_message", &wrong, Err(BlsError::VerificationFailed)),
@@ -354,4 +363,42 @@ fn run_allocation_regression() {
     }
 
     println!("\nAllocation budgets and verification outcomes passed.");
+}
+
+fn measure_pop_paths(keypair: &Keypair, other_keypair: &Keypair) {
+    let pubkey = *keypair.public;
+    let pubkey_bytes = pubkey.to_bytes_compressed();
+    let custom_payload: &[u8] = b"solana-pop-alloc";
+
+    for (mode, payload) in [("standard", None), ("custom", Some(custom_payload))] {
+        // Fixture construction happens with allocation counting disabled.
+        let payload_bytes = payload.unwrap_or(&[]);
+        let hashed = HashedPoPPayload::new(payload_bytes, &pubkey_bytes);
+        let valid: ProofOfPossessionAffine = keypair.proof_of_possession(payload).into();
+        let wrong: ProofOfPossessionAffine = other_keypair.proof_of_possession(payload).into();
+
+        measure(&format!("hash_pop/{mode}"), || {
+            black_box(HashedPoPPayload::new(
+                black_box(payload_bytes),
+                black_box(&pubkey_bytes),
+            ));
+            true
+        });
+
+        // The wrong proof is a valid group point belonging to another key.
+        for (status, proof, expected) in [
+            ("valid", &valid, Ok(())),
+            ("wrong_key", &wrong, Err(BlsError::VerificationFailed)),
+        ] {
+            measure(&format!("pop/raw/{mode}/{status}"), || {
+                black_box(&pubkey).verify_proof_of_possession(black_box(proof), black_box(payload))
+                    == expected
+            });
+            measure(&format!("pop/pre_hashed/{mode}/{status}"), || {
+                black_box(&pubkey)
+                    .verify_proof_of_possession_pre_hashed(black_box(proof), black_box(&hashed))
+                    == expected
+            });
+        }
+    }
 }


### PR DESCRIPTION
#### Summary of Changes

PoP hashing and verification allocate temporary payload buffers and pairing preparation tables. I removed these allocations by hashing `payload || pubkey_bytes` through `blst` augmentation and computing verification pairings directly. Hash outputs, domain separation, and rejection behavior should be preserved.

In the process of testing, I added hash-equivalence tests, allocation regression coverage, and timing benchmarks for standard and custom payloads.

Operation | Allocations before → after | Allocated bytes before → after
-- | -- | --
Hashing | 1 → 0 | 48 → 0
Verification, including hashing | 3 → 0 | 39,216 → 0
Verification with a reused hash | 2 → 0 | 39,168 → 0
