### PR TITLE
[bls-signatures] Reduce allocations in prepared distinct-message screening

### DIFF
--- a/bls-signatures/benches/verification_paths.rs
+++ b/bls-signatures/benches/verification_paths.rs
@@ -17,6 +17,7 @@ use {
 
 fn verification_paths(c: &mut Criterion) {
     proof_of_possession_paths(c);
+    distinct_prepared_paths(c);
 
     #[cfg(feature = "parallel")]
     parallel_aggregate_paths(c);
@@ -371,6 +372,80 @@ fn proof_of_possession_paths(c: &mut Criterion) {
         }
     }
 
+    group.finish();
+}
+
+fn distinct_prepared_paths(c: &mut Criterion) {
+    let keypair = Keypair::derive(&[42u8; 32]).expect("derive fixture key");
+    let other_keypair = Keypair::derive(&[43u8; 32]).expect("derive second fixture key");
+    let public_keys = [keypair.public, other_keypair.public];
+    let message_a: &[u8] = b"distinct allocation A";
+    let message_b: &[u8] = b"distinct allocation B";
+
+    #[cfg(feature = "parallel")]
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(2)
+        .build()
+        .expect("build distinct benchmark pool");
+    #[cfg(feature = "parallel")]
+    {
+        drop(pool.broadcast(|_| ()));
+        std::thread::sleep(Duration::from_millis(100));
+        println!("distinct prepared timing: inside a private two-worker Rayon pool");
+    }
+    println!("distinct prepared timing includes aggregation; message preparations are reused");
+
+    let mut group = c.benchmark_group("bls_distinct_prepared");
+    for (shape, messages) in [
+        ("unique", [message_a, message_b]),
+        ("shared", [message_a, message_a]),
+    ] {
+        let preparations = messages.map(PreparedHashedMessage::new);
+        let valid: [SignatureAffine; 2] = [
+            keypair.sign(messages[0]).into(),
+            other_keypair.sign(messages[1]).into(),
+        ];
+        let wrong = [keypair.sign(b"wrong distinct message").into(), valid[1]];
+
+        for (status, signatures, expected) in [
+            ("valid", &valid, Ok(())),
+            ("wrong_message", &wrong, Err(BlsError::VerificationFailed)),
+        ] {
+            let seq = || {
+                SignatureProjective::verify_distinct_prepared(
+                    black_box(&public_keys).iter(),
+                    black_box(signatures).iter(),
+                    black_box(&preparations).iter(),
+                )
+            };
+            #[cfg(feature = "parallel")]
+            assert_eq!(pool.install(seq), expected, "seq/{shape}/{status}");
+            #[cfg(not(feature = "parallel"))]
+            assert_eq!(seq(), expected, "seq/{shape}/{status}");
+
+            group.bench_function(format!("seq/{shape}/{status}"), |b| {
+                #[cfg(feature = "parallel")]
+                b.iter_custom(|iterations| time_on_worker(&pool, iterations, seq));
+                #[cfg(not(feature = "parallel"))]
+                b.iter(|| black_box(seq()));
+            });
+
+            #[cfg(feature = "parallel")]
+            {
+                let par = || {
+                    SignatureProjective::par_verify_distinct_prepared(
+                        black_box(&public_keys),
+                        black_box(signatures),
+                        black_box(&preparations),
+                    )
+                };
+                assert_eq!(pool.install(par), expected, "par/{shape}/{status}");
+                group.bench_function(format!("par/{shape}/{status}"), |b| {
+                    b.iter_custom(|iterations| time_on_worker(&pool, iterations, par));
+                });
+            }
+        }
+    }
     group.finish();
 }
 

--- a/bls-signatures/src/prepared_g2.rs
+++ b/bls-signatures/src/prepared_g2.rs
@@ -54,9 +54,11 @@ impl PreparedG2 {
 }
 
 #[allow(clippy::arithmetic_side_effects)]
-pub(crate) fn multi_miller_loop(terms: &[(&G1Affine, &PreparedG2)]) -> blst_fp12 {
+pub(crate) fn multi_miller_loop<'a, 'b>(
+    terms: impl IntoIterator<Item = (&'a G1Affine, &'b PreparedG2)>,
+) -> blst_fp12 {
     let mut result = blst_fp12::default();
-    for (index, (point, prepared)) in terms.iter().enumerate() {
+    for (index, (point, prepared)) in terms.into_iter().enumerate() {
         let term = prepared.miller_loop(point);
         if index == 0 {
             result = term;

--- a/bls-signatures/src/signature/verify_distinct.rs
+++ b/bls-signatures/src/signature/verify_distinct.rs
@@ -74,12 +74,13 @@ impl SignatureProjective {
 
     /// Group pairing terms by message hash in `O(n log n)` time by sorting keys,
     /// keeping prepared G2 terms to avoid recomputation.
-    fn group_prepared_terms<'b>(
-        pairs: impl Iterator<Item = (G1Affine, &'b PreparedHashedMessage)>,
+    fn try_group_prepared_terms<'b>(
+        pairs: impl Iterator<Item = Result<(G1Affine, &'b PreparedHashedMessage), BlsError>>,
         capacity: usize,
-    ) -> (alloc::vec::Vec<G1Affine>, alloc::vec::Vec<&'b PreparedG2>) {
+    ) -> Result<alloc::vec::Vec<(G1Affine, &'b PreparedG2)>, BlsError> {
         let mut entries = alloc::vec::Vec::with_capacity(capacity);
-        for (pubkey_affine, prepared) in pairs {
+        for pair in pairs {
+            let (pubkey_affine, prepared) = pair?;
             entries.push((
                 prepared.hashed_message.0.to_uncompressed(),
                 pubkey_affine,
@@ -92,8 +93,7 @@ impl SignatureProjective {
         #[cfg(not(feature = "parallel"))]
         entries.sort_unstable_by(|a, b| a.0.cmp(&b.0));
 
-        let mut grouped_pubkeys = alloc::vec::Vec::with_capacity(entries.len());
-        let mut grouped_prepared = alloc::vec::Vec::with_capacity(entries.len());
+        let mut grouped_terms = alloc::vec::Vec::with_capacity(entries.len());
 
         for chunk in entries.chunk_by(|a, b| a.0 == b.0) {
             let mut aggregate_pubkey = G1Projective::from(chunk[0].1);
@@ -103,12 +103,10 @@ impl SignatureProjective {
                     aggregate_pubkey += &item.1;
                 }
             }
-            grouped_pubkeys.push(aggregate_pubkey);
-            grouped_prepared.push(chunk[0].2);
+            grouped_terms.push((G1Affine::from(aggregate_pubkey), chunk[0].2));
         }
 
-        let grouped_pubkeys_affine = grouped_pubkeys.into_iter().map(Into::into).collect();
-        (grouped_pubkeys_affine, grouped_prepared)
+        Ok(grouped_terms)
     }
 
     /// Performs aggregate screening of signatures over distinct messages.
@@ -352,48 +350,38 @@ impl SignatureProjective {
             return Err(BlsError::EmptyAggregation);
         }
         let public_keys_len = public_keys.len();
-        let mut pubkeys_affine = alloc::vec::Vec::with_capacity(public_keys_len);
-        let mut prepared_refs = alloc::vec::Vec::with_capacity(public_keys_len);
+        let mut pairs = alloc::vec::Vec::with_capacity(public_keys_len);
         for (pubkey, prepared) in public_keys.zip(prepared_hashed_messages) {
             let g1_affine = pubkey.try_as_affine()?;
             if bool::from(g1_affine.0.is_identity()) {
                 return Err(BlsError::VerificationFailed);
             }
-            pubkeys_affine.push(g1_affine.0);
-            prepared_refs.push(prepared);
+            pairs.push((g1_affine.0, prepared));
         }
 
         let aggregate_signature_affine = aggregate_signature.try_as_affine()?;
-        let signature_prepared = PreparedG2::from(aggregate_signature_affine.0);
 
-        #[cfg(feature = "std")]
-        let neg_g1_generator = &*NEG_G1_GENERATOR_AFFINE;
-        #[cfg(not(feature = "std"))]
-        #[allow(clippy::arithmetic_side_effects)]
-        let neg_g1_generator_val: G1Affine = (-G1Projective::generator()).into();
-        #[cfg(not(feature = "std"))]
-        let neg_g1_generator = &neg_g1_generator_val;
+        let grouped_terms =
+            Self::try_group_prepared_terms(pairs.into_iter().map(Ok), public_keys_len)?;
 
-        let (grouped_pubkeys_affine, grouped_prepared_hashes) = Self::group_prepared_terms(
-            pubkeys_affine.into_iter().zip(prepared_refs),
-            public_keys_len,
-        );
-
-        let mut terms =
-            alloc::vec::Vec::with_capacity(grouped_pubkeys_affine.len().saturating_add(1));
-        for (pubkey, prepared_hash) in grouped_pubkeys_affine
-            .iter()
-            .zip(grouped_prepared_hashes.iter())
-        {
+        for (pubkey, _) in &grouped_terms {
             if bool::from(pubkey.is_identity()) {
                 return Err(BlsError::VerificationFailed);
             }
-            terms.push((pubkey, *prepared_hash));
         }
-        terms.push((neg_g1_generator, &signature_prepared));
 
-        let miller_loop_result = multi_miller_loop(&terms);
-        (miller_loop_result.final_exp() == blst::blst_fp12::default())
+        // Reuse the cached message tables and compute the signature term directly.
+        let message_pairing = multi_miller_loop(
+            grouped_terms
+                .iter()
+                .map(|(pubkey, prepared)| (pubkey, *prepared)),
+        );
+        let generator = G1Affine::generator();
+        let signature_pairing =
+            blst::blst_fp12::miller_loop(aggregate_signature_affine.0.as_ref(), generator.as_ref());
+
+        // Compare the pairings using one final exponentiation.
+        blst::blst_fp12::finalverify(&message_pairing, &signature_pairing)
             .then_some(())
             .ok_or(BlsError::VerificationFailed)
     }
@@ -496,14 +484,10 @@ impl SignatureProjective {
             return Err(BlsError::EmptyAggregation);
         }
         let aggregate_signature = SignatureProjective::par_aggregate(signatures.into_par_iter())?;
-        let hashed_messages: Vec<_> = prepared_hashed_messages
-            .iter()
-            .map(|prepared| prepared.hashed_message)
-            .collect();
-        Self::par_verify_distinct_aggregated_pre_hashed(
+        Self::par_verify_distinct_aggregated_prepared(
             public_keys,
             &aggregate_signature,
-            &hashed_messages,
+            prepared_hashed_messages,
         )
     }
 
@@ -653,14 +637,46 @@ impl SignatureProjective {
             return Err(BlsError::EmptyAggregation);
         }
 
-        let hashed_messages: Vec<_> = prepared_hashed_messages
-            .iter()
-            .map(|prepared| prepared.hashed_message)
-            .collect();
-        Self::par_verify_distinct_aggregated_pre_hashed(
-            public_keys,
-            aggregate_signature,
-            &hashed_messages,
-        )
+        // Preallocate the input count to avoid growing a small vector.
+        let mut pubkeys_affine = Vec::with_capacity(public_keys.len());
+        public_keys
+            .par_iter()
+            .map(|pk| {
+                let affine = pk.try_as_affine()?;
+                if bool::from(affine.0.is_identity()) {
+                    return Err(BlsError::VerificationFailed);
+                }
+                Ok::<G1Affine, BlsError>(affine.0)
+            })
+            .collect_into_vec(&mut pubkeys_affine);
+
+        let grouped_terms = Self::try_group_prepared_terms(
+            pubkeys_affine
+                .into_iter()
+                .zip(prepared_hashed_messages)
+                .map(|(pubkey, prepared)| pubkey.map(|pubkey| (pubkey, prepared))),
+            public_keys.len(),
+        )?;
+        let aggregate_signature_affine = aggregate_signature.try_as_affine()?;
+
+        for (pubkey, _) in &grouped_terms {
+            if bool::from(pubkey.is_identity()) {
+                return Err(BlsError::VerificationFailed);
+            }
+        }
+
+        // Borrow cached message tables instead of rebuilding their preparations.
+        let message_pairing = multi_miller_loop(
+            grouped_terms
+                .iter()
+                .map(|(pubkey, prepared)| (pubkey, *prepared)),
+        );
+        let generator = G1Affine::generator();
+        let signature_pairing =
+            blst::blst_fp12::miller_loop(aggregate_signature_affine.0.as_ref(), generator.as_ref());
+
+        blst::blst_fp12::finalverify(&message_pairing, &signature_pairing)
+            .then_some(())
+            .ok_or(BlsError::VerificationFailed)
     }
 }

--- a/bls-signatures/tests/allocation_regression.rs
+++ b/bls-signatures/tests/allocation_regression.rs
@@ -116,6 +116,11 @@ fn check_budget(
         name if name.starts_with("pop/raw/standard/") => (0, 0),
         name if name.starts_with("pop/raw/custom/") => (0, 0),
         name if name.starts_with("pop/pre_hashed/") => (0, 0),
+        // Prepared distinct-message screening with two affine inputs.
+        name if name.starts_with("distinct/prepared/seq/unique/") => (3, 1_008),
+        name if name.starts_with("distinct/prepared/seq/shared/") => (3, 1_008),
+        name if name.starts_with("distinct/prepared/par/unique/") => (3, 1_008),
+        name if name.starts_with("distinct/prepared/par/shared/") => (3, 1_008),
         _ => panic!("missing allocation budget for {label}"),
     };
 
@@ -240,6 +245,7 @@ fn run_allocation_regression() {
     println!("raw_compressed also decodes the compressed signature each time.");
     println!("Counts include destruction of temporaries within each operation.");
     println!("aggregate rows include aggregation of two affine keys and signatures.");
+    println!("distinct/prepared rows use two affine keys/signatures and reused preparations.");
     #[cfg(feature = "parallel")]
     println!("par_aggregate rows call the parallel helpers with the same two inputs.");
 
@@ -276,6 +282,7 @@ fn run_allocation_regression() {
         });
 
         measure_pop_paths(&keypair, &other_keypair);
+        measure_distinct_prepared_paths(&keypair, &other_keypair);
 
         for (status, encoded, expected) in [
             ("valid", &valid, Ok(())),
@@ -398,6 +405,47 @@ fn measure_pop_paths(keypair: &Keypair, other_keypair: &Keypair) {
                 black_box(&pubkey)
                     .verify_proof_of_possession_pre_hashed(black_box(proof), black_box(&hashed))
                     == expected
+            });
+        }
+    }
+}
+
+fn measure_distinct_prepared_paths(keypair: &Keypair, other_keypair: &Keypair) {
+    let public_keys = [keypair.public, other_keypair.public];
+    let message_a: &[u8] = b"distinct allocation A";
+    let message_b: &[u8] = b"distinct allocation B";
+
+    for (shape, messages) in [
+        ("unique", [message_a, message_b]),
+        ("shared", [message_a, message_a]),
+    ] {
+        // Build and retain fixtures with counting disabled.
+        let preparations = messages.map(PreparedHashedMessage::new);
+        let valid: [SignatureAffine; 2] = [
+            keypair.sign(messages[0]).into(),
+            other_keypair.sign(messages[1]).into(),
+        ];
+        let wrong = [keypair.sign(b"wrong distinct message").into(), valid[1]];
+
+        for (status, signatures, expected) in [
+            ("valid", &valid, Ok(())),
+            ("wrong_message", &wrong, Err(BlsError::VerificationFailed)),
+        ] {
+            measure(&format!("distinct/prepared/seq/{shape}/{status}"), || {
+                SignatureProjective::verify_distinct_prepared(
+                    black_box(&public_keys).iter(),
+                    black_box(signatures).iter(),
+                    black_box(&preparations).iter(),
+                ) == expected
+            });
+
+            #[cfg(feature = "parallel")]
+            measure(&format!("distinct/prepared/par/{shape}/{status}"), || {
+                SignatureProjective::par_verify_distinct_prepared(
+                    black_box(&public_keys),
+                    black_box(signatures),
+                    black_box(&preparations),
+                ) == expected
             });
         }
     }

--- a/bls-signatures/tests/prepared_verification.rs
+++ b/bls-signatures/tests/prepared_verification.rs
@@ -103,6 +103,34 @@ fn prepared_verification_preserves_signature_errors() {
             expected,
             "{label}: prepared verification",
         );
+        assert_eq!(
+            SignatureProjective::verify_distinct_aggregated_pre_hashed(
+                core::iter::once(&keypair.public),
+                &signature,
+                core::iter::once(&hashed),
+            ),
+            expected,
+            "{label}: pre-hashed aggregate screening",
+        );
+        assert_eq!(
+            SignatureProjective::verify_distinct_aggregated_prepared(
+                core::iter::once(&keypair.public),
+                &signature,
+                core::iter::once(&prepared),
+            ),
+            expected,
+            "{label}: prepared aggregate screening",
+        );
+        #[cfg(feature = "parallel")]
+        assert_eq!(
+            SignatureProjective::par_verify_distinct_aggregated_prepared(
+                core::slice::from_ref(&keypair.public),
+                &signature,
+                core::slice::from_ref(&prepared),
+            ),
+            expected,
+            "{label}: parallel prepared aggregate screening",
+        );
     }
 }
 
@@ -152,6 +180,93 @@ fn prepared_screening_preserves_duplicate_message_grouping() {
             ),
             expected,
             "prepared aggregate screening",
+        );
+        #[cfg(feature = "parallel")]
+        {
+            assert_eq!(
+                SignatureProjective::par_verify_distinct_aggregated_prepared(
+                    &public_keys,
+                    &aggregate_signature,
+                    &preparations,
+                ),
+                expected,
+                "parallel prepared aggregate screening",
+            );
+            assert_eq!(
+                SignatureProjective::par_verify_distinct_prepared(
+                    &public_keys,
+                    &signatures,
+                    &preparations,
+                ),
+                expected,
+                "parallel prepared screening with signature aggregation",
+            );
+        }
+    }
+}
+
+#[cfg(feature = "parallel")]
+#[test]
+fn parallel_distinct_screening_preserves_public_key_errors() {
+    use solana_bls_signatures::pubkey::{
+        AsPubkeyAffine, PopVerified, PubkeyAffine, PubkeyCompressed, PubkeyProjective,
+    };
+
+    let keypair = Keypair::derive(&[48u8; 32]).unwrap();
+    let messages: [&[u8]; 3] = [b"first", b"second", b"third"];
+    let hashes = messages.map(HashedMessage::new);
+    let preparations: Vec<_> = hashes
+        .iter()
+        .map(PreparedHashedMessage::from_hashed_message)
+        .collect();
+    let signatures = messages.map(|message| keypair.sign(message));
+    let aggregate_signature = SignatureProjective::aggregate(signatures.iter()).unwrap();
+
+    let malformed = PubkeyCompressed([0u8; 48]);
+    let decode_error = malformed
+        .try_as_affine()
+        .expect_err("all-zero bytes must not decode as a public key");
+    let compressed = PubkeyCompressed::from(*keypair.public);
+    // The keypair already supplies a PoP-verified key.
+    let valid_keys = [unsafe { PopVerified::new_unchecked(compressed) }; 3];
+    assert_eq!(
+        SignatureProjective::par_verify_distinct_aggregated_prepared(
+            &valid_keys,
+            &aggregate_signature,
+            &preparations,
+        ),
+        Ok(()),
+    );
+
+    for bad_index in 0..valid_keys.len() {
+        let mut public_keys = valid_keys;
+        // Deliberately bypass PoP validation to exercise malformed-key rejection.
+        public_keys[bad_index] = unsafe { PopVerified::new_unchecked(malformed) };
+        assert_eq!(
+            SignatureProjective::par_verify_distinct_aggregated_prepared(
+                &public_keys,
+                &aggregate_signature,
+                &preparations,
+            ),
+            Err(decode_error.clone()),
+            "prepared screening: malformed key at {bad_index}",
+        );
+    }
+
+    let identity = PubkeyAffine::from(PubkeyProjective::identity());
+    let malformed_signature = SignatureCompressed([0u8; 96]);
+    for bad_index in 0..valid_keys.len() {
+        let mut public_keys = [keypair.public; 3];
+        // An invalid key must be rejected before decoding the aggregate signature.
+        public_keys[bad_index] = unsafe { PopVerified::new_unchecked(identity) };
+        assert_eq!(
+            SignatureProjective::par_verify_distinct_aggregated_prepared(
+                &public_keys,
+                &malformed_signature,
+                &preparations,
+            ),
+            Err(BlsError::VerificationFailed),
+            "prepared screening: identity key at {bad_index} precedes signature decoding",
         );
     }
 }


### PR DESCRIPTION
#### Summary of Changes

Currently, the prepared distinct-message screening allocates temporary pairing preparation tables and input buffers, even when message preparations are already available. I reduced these allocations by reusing the prepared message tables, computing the signature pairing directly, and combining temporary buffers. Duplicate-message grouping and existing verification and rejection behavior should be preserved.

In the process of testing, I added allocation regression coverage, tests for signature and public-key errors, and timing benchmarks for sequential and parallel prepared screening.

 Operation | Allocations before → after | Allocated bytes before → after
-- | -- | --
Sequential, unique messages | 7 → 3 | 20,736 → 1,008
Sequential, shared messages | 7 → 3 | 20,720 → 1,008
Parallel, unique messages | 14 -> 3 | 62,176 → 1,008
Parallel, shared messages | 13 -> 3 | 42,576 -> 1,008

The table above contains Rust heap allocations per screening operation with two public keys and two signatures, using either distinct or shared messages. Each operation includes signature aggregation and reuses existing message preparations.